### PR TITLE
Fix wrong condition to validate permission on post handler

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -105,11 +105,11 @@ def delete_all_in_index(index):
 
 class BaseHandler(webapp2.RequestHandler):
     """Base Handler."""
-    pass
-    # def handle_exception(self, exception, debug):
-    #     """Exception."""
-    #     logging.error(str(exception))
-    #     self.response.write("oops! %s\n" % str(exception))
+
+    def handle_exception(self, exception, debug):
+        """Exception."""
+        logging.error(str(exception))
+        self.response.write("oops! %s\n" % str(exception))
 
 
 class ResetHandler(BaseHandler):
@@ -328,7 +328,7 @@ class ResetHandler(BaseHandler):
             splab.add_member(user)
             user.add_institution(splab.key)
             user.follow(splab.key)
-        print andre.permissions
+
         for user in [jorge.key, andre.key, maiana.key, luiz.key,
                      raoni.key, ruan.key, tiago.key, admin.key]:
             splab.follow(user)
@@ -355,7 +355,6 @@ class ResetHandler(BaseHandler):
             user.add_institution(eciis.key)
             user.follow(eciis.key)
 
-        print andre.permissions
         for user in [mayza.key, andre.key, jorge.key, dalton.key,
                      maiana.key, luiz.key, raoni.key,
                      ruan.key, tiago.key, admin.key]:

--- a/admin.py
+++ b/admin.py
@@ -105,11 +105,11 @@ def delete_all_in_index(index):
 
 class BaseHandler(webapp2.RequestHandler):
     """Base Handler."""
-
-    def handle_exception(self, exception, debug):
-        """Exception."""
-        logging.error(str(exception))
-        self.response.write("oops! %s\n" % str(exception))
+    pass
+    # def handle_exception(self, exception, debug):
+    #     """Exception."""
+    #     logging.error(str(exception))
+    #     self.response.write("oops! %s\n" % str(exception))
 
 
 class ResetHandler(BaseHandler):
@@ -297,9 +297,12 @@ class ResetHandler(BaseHandler):
             'phone_number': '83 33224455',
             'state': 'active'
         }
+
         certbio = createInstitution(data, admin)
         for user in [mayza, dalton, admin]:
             certbio.add_member(user)
+            user.add_institution(certbio.key)
+            user.follow(certbio.key)
         for user in [jorge.key, mayza.key, maiana.key, luiz.key,
                      raoni.key, ruan.key, tiago.key, admin.key]:
             certbio.follow(user)
@@ -319,16 +322,20 @@ class ResetHandler(BaseHandler):
             'phone_number': '83 33227865',
             'state': 'active'
         }
+
         splab = createInstitution(data, admin)
         for user in [jorge, andre, admin]:
             splab.add_member(user)
+            user.add_institution(splab.key)
+            user.follow(splab.key)
+        print andre.permissions
         for user in [jorge.key, andre.key, maiana.key, luiz.key,
                      raoni.key, ruan.key, tiago.key, admin.key]:
             splab.follow(user)
 
         # new Institution eciis
         data = {
-            'name': 'Complexo Industrial da Saúde',
+            'name': 'Complexo Industrial da Saude',
             'acronym': 'e-ciis',
             'cnpj': '18.104.068/0001-30',
             'legal_nature': 'public',
@@ -340,11 +347,15 @@ class ResetHandler(BaseHandler):
             'phone_number': '83 33227865',
             'state': 'active'
         }
+
         eciis = createInstitution(data, admin)
         for user in [dalton, andre, jorge, maiana,
                      luiz, raoni, ruan, tiago, mayza, admin]:
             eciis.add_member(user)
+            user.add_institution(eciis.key)
+            user.follow(eciis.key)
 
+        print andre.permissions
         for user in [mayza.key, andre.key, jorge.key, dalton.key,
                      maiana.key, luiz.key, raoni.key,
                      ruan.key, tiago.key, admin.key]:
@@ -358,35 +369,6 @@ class ResetHandler(BaseHandler):
 
         jsonList.append(
             {"msg": "database initialized with a few institutions"})
-
-        # Updating Institutions
-        mayza.institutions = [certbio.key, eciis.key]
-        mayza.follows = [splab.key, eciis.key, certbio.key]
-        mayza.put()
-        andre.institutions = [splab.key, eciis.key]
-        andre.follows = [splab.key, eciis.key]
-        andre.put()
-        jorge.institutions = [splab.key, eciis.key]
-        jorge.follows = [certbio.key, splab.key, eciis.key]
-        jorge.put()
-        dalton.institutions = [eciis.key, certbio.key]
-        dalton.follows = [splab.key, eciis.key]
-        dalton.put()
-        maiana.institutions = [eciis.key]
-        maiana.follows = [splab.key, eciis.key, certbio.key]
-        maiana.put()
-        luiz.institutions = [eciis.key]
-        luiz.follows = [splab.key, eciis.key, certbio.key]
-        luiz.put()
-        raoni.institutions = [eciis.key]
-        raoni.follows = [splab.key, eciis.key, certbio.key]
-        raoni.put()
-        ruan.institutions = [eciis.key]
-        ruan.follows = [splab.key, eciis.key, certbio.key]
-        ruan.put()
-        tiago.institutions = [eciis.key]
-        tiago.follows = [splab.key, eciis.key, certbio.key]
-        tiago.put()
 
         admin.institutions_admin = [certbio.key, eciis.key, splab.key]
         admin.put()

--- a/handlers/post_collection_handler.py
+++ b/handlers/post_collection_handler.py
@@ -32,7 +32,7 @@ class PostCollectionHandler(BaseHandler):
         data = json.loads(self.request.body)
         institution_key = data['institution']
 
-        Utils._assert(user.has_permission("publish_post", institution_key),
+        Utils._assert(not user.has_permission("publish_post", institution_key),
                 "You don't have permission to publish post.", NotAuthorizedException)
 
         institution = ndb.Key(urlsafe=institution_key).get()

--- a/models/user.py
+++ b/models/user.py
@@ -86,7 +86,7 @@ class User(ndb.Model):
         """Add a institution to user."""
         if institution_key not in self.institutions:
             self.institutions.append(institution_key)
-            self.add_permission("publish_post", self.key.urlsafe())
+            self.add_permission("publish_post", institution_key.urlsafe())
             self.put()
 
     def add_image(self, url_image):
@@ -106,7 +106,10 @@ class User(ndb.Model):
         permission_type -- permission name that will be used to verify authorization
         entity_key -- ndb urlsafe of the object binded to the permission
         """
-        self.permissions[permission_type] = {entity_key: True}
+        if self.permissions.get(permission_type, None):
+            self.permissions[permission_type][entity_key] = True
+        else:
+            self.permissions[permission_type] = {entity_key: True}
         self.put()
 
     def remove_permission(self, permission_type, entity_key):

--- a/test/institution_timeline_handler_test.py
+++ b/test/institution_timeline_handler_test.py
@@ -128,6 +128,7 @@ def initModels(cls):
         'text': "At vero eos et accusamus et iusto",
         'institution': cls.certbio.key.urlsafe()
     }
-    cls.mayza.institutions = [cls.certbio.key]
     cls.mayza.follows = [cls.certbio.key]
     cls.mayza.put()
+
+    cls.mayza.add_institution(cls.certbio.key)

--- a/test/post_collection_handler_test.py
+++ b/test/post_collection_handler_test.py
@@ -104,3 +104,5 @@ def initModels(cls):
     cls.certbio.posts = []
     cls.certbio.admin = cls.mayza.key
     cls.certbio.put()
+
+    cls.mayza.add_institution(cls.certbio.key)

--- a/test/user_timeline_handler_test.py
+++ b/test/user_timeline_handler_test.py
@@ -127,6 +127,7 @@ def initModels(cls):
         'text': "At vero eos et accusamus et iusto",
         'institution': cls.certbio.key.urlsafe()
     }
-    cls.mayza.institutions = [cls.certbio.key]
     cls.mayza.follows = [cls.certbio.key]
     cls.mayza.put()
+
+    cls.mayza.add_institution(cls.certbio.key)


### PR DESCRIPTION
The condition to validate user permission was to have publish_post, using Utils._assert, but the that function works with the opposite condition to thrown an error. So, the correct validation is not to have publish_post.