### PR TITLE
Fix add institution to user when creating stub

### DIFF
--- a/models/institution.py
+++ b/models/institution.py
@@ -150,7 +150,8 @@ class Institution(ndb.Model):
             institution.photo_url = "/images/institution.jpg"
         institution.put()
 
-        user.institutions.append(institution.key)
+        user.add_institution(institution.key)
+
         user.institutions_admin.append(institution.key)
         user.state = "active"
         user.follows.append(institution.key)


### PR DESCRIPTION
When the institution stub is created the function was appending the institution key directly to the user instead of use the user function, this modification wasn't giving the right permissions to the user.