### PR TITLE
add inviter name and institution inviter name in invites

### DIFF
--- a/app/invites/invite.js
+++ b/app/invites/invite.js
@@ -1,12 +1,12 @@
 "use strict";
 
-function Invite(data, type_of_invite, institution_key, inviter_email) {
+function Invite(data, type_of_invite, institution_key, inviter_key) {
     data = data || {};
     _.extend(this, data);
 
     this.type_of_invite = type_of_invite;
     this.institution_key = institution_key;
-    this.inviter = inviter_email;
+    this.inviter = inviter_key;
 }
 
 Invite.prototype.isValid = function isValid() {

--- a/app/invites/invite.js
+++ b/app/invites/invite.js
@@ -6,7 +6,7 @@ function Invite(data, type_of_invite, institution_key, inviter_key) {
 
     this.type_of_invite = type_of_invite;
     this.institution_key = institution_key;
-    this.inviter = inviter_key;
+    this.inviter_key = inviter_key;
 }
 
 Invite.prototype.isValid = function isValid() {

--- a/app/invites/inviteInstHierarchieController.js
+++ b/app/invites/inviteInstHierarchieController.js
@@ -32,7 +32,7 @@
         inviteInstCtrl.checkInstInvite = function checkInstInvite(ev) {
             var promise;
             invite = new Invite(inviteInstCtrl.invite, inviteInstCtrl.invite.type_of_invite,
-                institutionKey, inviteInstCtrl.user.email);
+                institutionKey, inviteInstCtrl.user.key);
             if (!invite.isValid()) {
                 MessageService.showToast('Convite inválido!');
             } else if(inviteInstCtrl.hasParent && invite.type_of_invite === INSTITUTION_PARENT) {

--- a/app/invites/inviteInstitutionController.js
+++ b/app/invites/inviteInstitutionController.js
@@ -23,7 +23,7 @@
             var promise;
             var currentInstitutionKey = inviteController.user.current_institution.key;
             invite = new Invite(inviteController.invite, 'INSTITUTION',
-                currentInstitutionKey, inviteController.user.email);
+                currentInstitutionKey, inviteController.user.key);
             if (!invite.isValid()) {
                 MessageService.showToast('Convite inválido!');
             } else {

--- a/app/invites/inviteUserController.js
+++ b/app/invites/inviteUserController.js
@@ -15,7 +15,7 @@
         inviteController.user = AuthService.getCurrentUser();
 
         inviteController.sendUserInvite = function sendInvite() {
-            invite = new Invite(inviteController.invite, 'USER', currentInstitutionKey, inviteController.user.email);
+            invite = new Invite(inviteController.invite, 'USER', currentInstitutionKey, inviteController.user.key);
             if (inviteController.isUserInviteValid(invite)) {
                 var promise = InviteService.sendInvite(invite);
                 promise.then(function success(response) {

--- a/app/invites/newInviteController.js
+++ b/app/invites/newInviteController.js
@@ -10,6 +10,7 @@
         newInviteCtrl.institution = null;
 
         newInviteCtrl.inviteKey = $state.params.inviteKey;
+    
 
         var institutionKey = $state.params.institutionKey;
 
@@ -101,6 +102,7 @@
         function loadInstitution() {
             InstitutionService.getInstitution(institutionKey).then(function success(response) {
                 newInviteCtrl.institution = response.data;
+                loadInvite();
             }, function error(response) {
                 MessageService.showToast(response.data.msg);
             });
@@ -117,6 +119,15 @@
                  .ok('Ok')
                  .targetEvent(event)
              );
+        }
+
+        function loadInvite(){
+            newInviteCtrl.invite = _.find(newInviteCtrl.user.invites, function(invite){
+                return invite.key === newInviteCtrl.inviteKey;
+            });
+            console.log(newInviteCtrl.user.invites);
+            console.log(newInviteCtrl.invite.institution_inviter);
+            console.log(newInviteCtrl.invite);
         }
 
         loadInstitution();

--- a/app/invites/newInviteController.js
+++ b/app/invites/newInviteController.js
@@ -46,6 +46,7 @@
                     MessageService.showToast('Cadastro de instituição realizado com sucesso');
                     newInviteCtrl.user.removeInviteInst(newInviteCtrl.institution.key);
                     newInviteCtrl.user.institutions.push(institutionSaved);
+                    newInviteCtrl.user.institutions_admin.push(institutionSaved.key);
                     newInviteCtrl.user.current_institution = institutionSaved;
                     newInviteCtrl.user.state = 'active';
                     AuthService.save();

--- a/app/invites/newInviteController.js
+++ b/app/invites/newInviteController.js
@@ -47,6 +47,7 @@
                     newInviteCtrl.user.removeInviteInst(newInviteCtrl.institution.key);
                     newInviteCtrl.user.institutions.push(institutionSaved);
                     newInviteCtrl.user.institutions_admin.push(institutionSaved.key);
+                    newInviteCtrl.user.follow(institutionSaved);
                     newInviteCtrl.user.current_institution = institutionSaved;
                     newInviteCtrl.user.state = 'active';
                     AuthService.save();

--- a/app/invites/newInviteController.js
+++ b/app/invites/newInviteController.js
@@ -11,7 +11,6 @@
 
         newInviteCtrl.inviteKey = $state.params.inviteKey;
     
-
         var institutionKey = $state.params.institutionKey;
 
         var typeOfInvite = $state.params.typeInvite;
@@ -125,9 +124,6 @@
             newInviteCtrl.invite = _.find(newInviteCtrl.user.invites, function(invite){
                 return invite.key === newInviteCtrl.inviteKey;
             });
-            console.log(newInviteCtrl.user.invites);
-            console.log(newInviteCtrl.invite.institution_inviter);
-            console.log(newInviteCtrl.invite);
         }
 
         loadInstitution();

--- a/app/invites/new_invite_page.html
+++ b/app/invites/new_invite_page.html
@@ -8,7 +8,7 @@
         <div>
           <div>
             <md-list flex ng-if="newInviteCtrl.isInviteUser()">
-              <md-subheader class="md-no-sticky">Você tem um novo convite para ser membro de:</md-subheader>
+              <md-subheader class="md-no-sticky">{{newInviteCtrl.invite.inviter}} te enviou um convite para ser membro de:</md-subheader>
               <md-list-item class="md-3-line">
                 <img ng-src="{{ newInviteCtrl.institution.photo_url }}" class="md-avatar" alt="{{newInviteCtrl.institution.name}}" />
                 <div class="md-list-item-text" layout="column">
@@ -20,11 +20,12 @@
             </md-list>
 
             <md-list flex ng-if="!newInviteCtrl.isInviteUser()">
-              <md-subheader class="md-no-sticky">Você tem um convite para ser administrador da nova instituição:</md-subheader>
+              <md-subheader class="md-no-sticky">{{newInviteCtrl.invite.inviter}} da Instituição {{newInviteCtrl.invite.institution_inviter.name}}  te enviou um convite convite para ser administrador da nova instituição:</md-subheader>
               <md-list-item class="md-3-line">
                 <div class="md-list-item-text" layout="column">
                   <h3><b>{{ newInviteCtrl.institution.name }}</b></h3>
                 </div>
+                <p></p>
               </md-list-item>
             </md-list>
           </div>

--- a/app/invites/new_invite_page.html
+++ b/app/invites/new_invite_page.html
@@ -8,7 +8,7 @@
         <div>
           <div>
             <md-list flex ng-if="newInviteCtrl.isInviteUser()">
-              <md-subheader class="md-no-sticky">{{newInviteCtrl.invite.inviter}} te enviou um convite para ser membro de:</md-subheader>
+              <md-subheader class="md-no-sticky">{{newInviteCtrl.invite.inviter_name}} te enviou um convite para ser membro de:</md-subheader>
               <md-list-item class="md-3-line">
                 <img ng-src="{{ newInviteCtrl.institution.photo_url }}" class="md-avatar" alt="{{newInviteCtrl.institution.name}}" />
                 <div class="md-list-item-text" layout="column">
@@ -20,7 +20,7 @@
             </md-list>
 
             <md-list flex ng-if="!newInviteCtrl.isInviteUser()">
-              <md-subheader class="md-no-sticky">{{newInviteCtrl.invite.inviter}} da Instituição {{newInviteCtrl.invite.institution_inviter.name}}  te enviou um convite convite para ser administrador da nova instituição:</md-subheader>
+              <md-subheader class="md-no-sticky">{{newInviteCtrl.invite.inviter_name}} da Instituição {{newInviteCtrl.invite.institution_inviter.name}}  te enviou um convite convite para ser administrador da nova instituição:</md-subheader>
               <md-list-item class="md-3-line">
                 <div class="md-list-item-text" layout="column">
                   <h3><b>{{ newInviteCtrl.institution.name }}</b></h3>

--- a/app/test/specs/inviteInsHierarchieSpec.js
+++ b/app/test/specs/inviteInsHierarchieSpec.js
@@ -25,6 +25,7 @@
     var maiana = {
         name: 'Maiana',
         email: 'maiana.brito@gmail.com',
+        key: '12345',
         institutions: [splab.key],
         follows: [splab.key],
         invites:[]
@@ -36,11 +37,11 @@
 
     var invite = new Invite({invitee: "parent@gmail.com",
                         suggestion_institution_name : "Institution Parent"},
-                            'INSTITUTION_PARENT', splab.key, maiana.email);
+                            'INSTITUTION_PARENT', splab.key, maiana.key);
 
     var inviteChildren = new Invite({invitee: "children@gmail.com",
                         suggestion_institution_name : "Children Institution"},
-                            'INSTITUTION_CHILDREN', splab.key, maiana.email);
+                            'INSTITUTION_CHILDREN', splab.key, maiana.key);
 
     var childrenStub = new Institution({name: "Children Institution", state : "pending"});
 

--- a/app/test/specs/inviteUserControllerSpec.js
+++ b/app/test/specs/inviteUserControllerSpec.js
@@ -5,9 +5,9 @@
 
     var inviteUserCtrl, httpBackend, scope, inviteService, createCtrl, state, authService;
 
-    var invite = new Invite({invitee: "mayzabeel@gmail.com"}, 'USER', '987654321', 'tiago@gmail.com');
+    var invite = new Invite({invitee: "mayzabeel@gmail.com"}, 'USER', '987654321', '12345');
 
-    var otherInvite = new Invite({invitee: "pedro@gmail.com"}, 'USER', '987654321', 'maiana.brito@ccc.ufcg.edu.br');
+    var otherInvite = new Invite({invitee: "pedro@gmail.com"}, 'USER', '987654321', '12345');
 
     var splab = {
             name: 'SPLAB',
@@ -19,6 +19,7 @@
     var tiago = {
         name: 'Tiago',
         cpf: '121.445.044-07',
+        key: '12345',
         email: 'tiago@gmail.com',
         institutions: [splab.key]
     };
@@ -26,9 +27,12 @@
     var user = {
          name: 'Maiana',
          cpf: '121.445.044-07',
+         key: '12345',
          email: 'maiana.brito@ccc.ufcg.edu.br',
          institutions: [splab.key]
      };
+
+    
 
     beforeEach(module('app'));
 
@@ -108,17 +112,17 @@
         describe('isUserInviteValid()', function() {
 
             it('should be true with new invite', function() {
-                var newInvite = new Invite({invitee: "pedro@gmail.com"}, 'USER', '987654321', 'tiago@gmail.com');
+                var newInvite = new Invite({invitee: "pedro@gmail.com"}, 'USER', '987654321', '12345');
                 expect(inviteUserCtrl.isUserInviteValid(newInvite)).toBe(true);
             });
 
             it('should be false when the invitee was already invited', function() {
-                var inviteInvited = new Invite({invitee: "mayzabeel@gmail.com"}, 'USER', '987654321', 'tiago@gmail.com');
+                var inviteInvited = new Invite({invitee: "mayzabeel@gmail.com"}, 'USER', '987654321', '12345');
                 expect(inviteUserCtrl.isUserInviteValid(inviteInvited)).toBe(false);
             });
 
             it('should be false when the invitee was already member', function() {
-                var inviteMember = new Invite({invitee: "tiago@gmail.com"}, 'USER', '987654321', 'tiago@gmail.com');
+                var inviteMember = new Invite({invitee: "tiago@gmail.com"}, 'USER', '987654321', '12345');
                 expect(inviteUserCtrl.isUserInviteValid(inviteMember)).toBe(false);
             });
         });

--- a/app/test/specs/inviteUserControllerSpec.js
+++ b/app/test/specs/inviteUserControllerSpec.js
@@ -32,8 +32,6 @@
          institutions: [splab.key]
      };
 
-    
-
     beforeEach(module('app'));
 
     beforeEach(inject(function($controller, $httpBackend, $rootScope, $state, InviteService, AuthService, InstitutionService) {

--- a/app/test/specs/newInviteControllerSpec.js
+++ b/app/test/specs/newInviteControllerSpec.js
@@ -12,6 +12,7 @@
     var splab = {
             name: 'SPLAB',
             key: '987654321',
+            institutions_admin: [],
             sent_invitations: []
     };
 
@@ -24,6 +25,7 @@
     var tiago = {
         name: 'Tiago',
         institutions: [splab],
+        institutions_admin: [],
         follows: [splab.key],
         invites: [invite],
         accessToken: '00000'

--- a/models/invite.py
+++ b/models/invite.py
@@ -47,7 +47,7 @@ class Invite(PolyModel):
         """Create personalized json of invite."""
         return {
             'invitee': self.invitee,
-            'inviter_key': self.inviter_key.get().name,
+            'inviter_name': self.inviter_key.get().name,
             'key': self.key.urlsafe(),
             'status': self.status,
             'institution_inviter': self.institution_key.get().make(['name'])

--- a/models/invite.py
+++ b/models/invite.py
@@ -12,7 +12,7 @@ class Invite(PolyModel):
     invitee = ndb.StringProperty(required=True)
 
     # Inviter email
-    inviter = ndb.StringProperty(required=True)
+    inviter = ndb.KeyProperty(kind="User", required=True)
 
     # Status of Invite.
     status = ndb.StringProperty(choices=set([
@@ -34,7 +34,7 @@ class Invite(PolyModel):
     def create(data, invite):
         """Create a post and check required fields."""
         invite.invitee = data.get('invitee')
-        invite.inviter = data.get('inviter')
+        invite.inviter = ndb.Key(urlsafe=data.get('inviter'))
         invite.institution_key = ndb.Key(urlsafe=data.get('institution_key'))
 
         return invite
@@ -47,9 +47,10 @@ class Invite(PolyModel):
         """Create personalized json of invite."""
         return {
             'invitee': self.invitee,
-            'inviter': self.inviter,
+            'inviter': self.inviter.get().name,
             'key': self.key.urlsafe(),
-            'status': self.status
+            'status': self.status,
+            'institution_inviter': self.institution_key.get().make(['name'])
         }
 
     def change_status(self, status):

--- a/models/invite.py
+++ b/models/invite.py
@@ -11,8 +11,8 @@ class Invite(PolyModel):
     # Email of the invitee.
     invitee = ndb.StringProperty(required=True)
 
-    # Inviter email
-    inviter = ndb.KeyProperty(kind="User", required=True)
+    # Key of user inviter
+    inviter_key = ndb.KeyProperty(kind="User", required=True)
 
     # Status of Invite.
     status = ndb.StringProperty(choices=set([
@@ -34,7 +34,7 @@ class Invite(PolyModel):
     def create(data, invite):
         """Create a post and check required fields."""
         invite.invitee = data.get('invitee')
-        invite.inviter = ndb.Key(urlsafe=data.get('inviter'))
+        invite.inviter_key = ndb.Key(urlsafe=data.get('inviter_key'))
         invite.institution_key = ndb.Key(urlsafe=data.get('institution_key'))
 
         return invite
@@ -47,7 +47,7 @@ class Invite(PolyModel):
         """Create personalized json of invite."""
         return {
             'invitee': self.invitee,
-            'inviter': self.inviter.get().name,
+            'inviter_key': self.inviter_key.get().name,
             'key': self.key.urlsafe(),
             'status': self.status,
             'institution_inviter': self.institution_key.get().make(['name'])

--- a/test/institution_handler_test.py
+++ b/test/institution_handler_test.py
@@ -208,7 +208,7 @@ def initModels(cls):
     # Invite for Raoni create new inst
     cls.invite = Invite()
     cls.invite.invitee = 'raoni.smaneoto@ccc.ufcg.edu.br'
-    cls.invite.inviter = cls.mayza.key
+    cls.invite.inviter_key = cls.mayza.key
     cls.invite.type_of_invite = 'institution'
     cls.invite.suggestion_institution_name = "Nova Inst"
     cls.invite.put()

--- a/test/institution_handler_test.py
+++ b/test/institution_handler_test.py
@@ -208,7 +208,7 @@ def initModels(cls):
     # Invite for Raoni create new inst
     cls.invite = Invite()
     cls.invite.invitee = 'raoni.smaneoto@ccc.ufcg.edu.br'
-    cls.invite.inviter = 'mayzabeel@gmail.com'
+    cls.invite.inviter = cls.mayza.key
     cls.invite.type_of_invite = 'institution'
     cls.invite.suggestion_institution_name = "Nova Inst"
     cls.invite.put()

--- a/test/invite_collection_handler_test.py
+++ b/test/invite_collection_handler_test.py
@@ -31,7 +31,7 @@ class InviteCollectionHandlerTest(TestBaseHandler):
     def test_post_invite_institution(self, verify_token):
         invite = self.testapp.post_json("/api/invites", {
             'invitee': 'ana@gmail.com',
-            'inviter': 'mayzabeel@gmail.com',
+            'inviter': self.mayza.key.urlsafe(),
             'type_of_invite': 'INSTITUTION',
             'suggestion_institution_name': 'New Institution',
             'institution_key': self.certbio.key.urlsafe()})
@@ -44,8 +44,8 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         # Check data of invite
         self.assertEqual(invite_obj.invitee, 'ana@gmail.com',
                          "The email expected was ana@gmail.com")
-        self.assertEqual(invite_obj.inviter, 'mayzabeel@gmail.com',
-                         "The inviter expected was mayzabeel@gmail.com")
+        self.assertEqual(invite_obj.inviter, self.mayza.key,
+                         "The inviter expected was Mayza")
         self.assertEqual(invite_obj.suggestion_institution_name,
                          'New Institution',
                          "The suggestion institution name of \
@@ -59,14 +59,14 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         with self.assertRaises(Exception):
             self.testapp.post_json("/api/invites", {
                 'invitee': 'ana@gmail.com',
-                'inviter': 'mayzabeel@gmail.com',
+                'inviter': self.mayza.key.urlsafe(),
                 'type_of_invite': 'INSTITUTION'})
 
     @patch('utils.verify_token', return_value={'email': 'mayzabeel@gmail.com'})
     def test_post_invite_user(self, verify_token):
         invite = self.testapp.post_json("/api/invites", {
             'invitee': 'ana@gmail.com',
-            'inviter': 'mayzabeel@gmail.com',
+            'inviter': self.mayza.key.urlsafe(),
             'type_of_invite': 'USER',
             'institution_key': self.certbio.key.urlsafe()})
         # Retrieve the entities
@@ -77,8 +77,8 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         # Check data of invite
         self.assertEqual(invite_obj.invitee, 'ana@gmail.com',
                          "The email expected was ana@gmail.com")
-        self.assertEqual(invite_obj.inviter, 'mayzabeel@gmail.com',
-                         "The inviter expected was mayzabeel@gmail.com")
+        self.assertEqual(invite_obj.inviter, self.mayza.key,
+                         "The inviter expected was Mayza")
         self.assertEqual(invite_obj.institution_key, self.certbio.key,
                          "The institution key expected was key of certbio")
 
@@ -86,7 +86,7 @@ class InviteCollectionHandlerTest(TestBaseHandler):
     def test_post_invite_user_member_of_other_institution(self, verify_token):
         invite = self.testapp.post_json("/api/invites", {
             'invitee': 'adriana@ccc.ufcg.edu.br',
-            'inviter': 'tiago.pereira@ccc.ufcg.edu.br',
+            'inviter': self.tiago.key.urlsafe(),
             'type_of_invite': 'USER',
             'institution_key': self.splab.key.urlsafe()})
         # Retrieve the entities
@@ -97,8 +97,8 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         # Check data of invite
         self.assertEqual(invite_obj.invitee, 'adriana@ccc.ufcg.edu.br',
                          "The email expected was adriana@ccc.ufcg.edu.br")
-        self.assertEqual(invite_obj.inviter, 'tiago.pereira@ccc.ufcg.edu.br',
-                         "The inviter expected was tiago.pereira@ccc.ufcg.edu.br")
+        self.assertEqual(invite_obj.inviter, self.tiago.key,
+                         "The inviter expected was Tiago")
         self.assertEqual(invite_obj.institution_key, self.splab.key,
                          "The institution key expected was key of splab")
 
@@ -109,7 +109,7 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         with self.assertRaises(Exception):
             self.testapp.post_json("/api/invites", {
                 'invitee': 'tiago.pereira@ccc.ufcg.edu.br',
-                'inviter': 'mayzabeel@gmail.com',
+                'inviter': self.mayza.key.urlsafe(),
                 'type_of_invite': 'USER',
                 'institution_key': self.certbio.key.urlsafe()})
 
@@ -120,7 +120,7 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         with self.assertRaises(Exception):
             self.testapp.post_json("/api/invites", {
                 'invitee': 'ana@gmail.com',
-                'inviter': 'mayzabeel@gmail.com',
+                'inviter': self.mayza.key.urlsafe(),
                 'type_of_invite': 'USER'})
 
     @patch('utils.verify_token', return_value={'email': 'tiago.pereira@ccc.ufcg.edu.br'})
@@ -129,7 +129,7 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         with self.assertRaises(Exception):
             self.testapp.post_json("/api/invites", {
                 'invitee': 'ana@gmail.com',
-                'inviter': 'mayzabeel@gmail.com',
+                'inviter': self.mayza.key.urlsafe(),
                 'type_of_invite': 'USER',
                 'institution_key': self.certbio.key.urlsafe()})
 
@@ -139,7 +139,7 @@ class InviteCollectionHandlerTest(TestBaseHandler):
 
         invite = self.testapp.post_json("/api/invites", {
             'invitee': 'mayzabeel@gmail.com',
-            'inviter': 'mayzabeel@gmail.com',
+            'inviter': self.mayza.key.urlsafe(),
             'type_of_invite': 'INSTITUTION_PARENT',
             'suggestion_institution_name': 'Institution Parent',
             'institution_key': self.certbio.key.urlsafe()})

--- a/test/invite_collection_handler_test.py
+++ b/test/invite_collection_handler_test.py
@@ -31,7 +31,7 @@ class InviteCollectionHandlerTest(TestBaseHandler):
     def test_post_invite_institution(self, verify_token):
         invite = self.testapp.post_json("/api/invites", {
             'invitee': 'ana@gmail.com',
-            'inviter': self.mayza.key.urlsafe(),
+            'inviter_key': self.mayza.key.urlsafe(),
             'type_of_invite': 'INSTITUTION',
             'suggestion_institution_name': 'New Institution',
             'institution_key': self.certbio.key.urlsafe()})
@@ -44,8 +44,8 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         # Check data of invite
         self.assertEqual(invite_obj.invitee, 'ana@gmail.com',
                          "The email expected was ana@gmail.com")
-        self.assertEqual(invite_obj.inviter, self.mayza.key,
-                         "The inviter expected was Mayza")
+        self.assertEqual(invite_obj.inviter_key, self.mayza.key,
+                         "The inviter_key expected was Mayza")
         self.assertEqual(invite_obj.suggestion_institution_name,
                          'New Institution',
                          "The suggestion institution name of \
@@ -59,14 +59,14 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         with self.assertRaises(Exception):
             self.testapp.post_json("/api/invites", {
                 'invitee': 'ana@gmail.com',
-                'inviter': self.mayza.key.urlsafe(),
+                'inviter_key': self.mayza.key.urlsafe(),
                 'type_of_invite': 'INSTITUTION'})
 
     @patch('utils.verify_token', return_value={'email': 'mayzabeel@gmail.com'})
     def test_post_invite_user(self, verify_token):
         invite = self.testapp.post_json("/api/invites", {
             'invitee': 'ana@gmail.com',
-            'inviter': self.mayza.key.urlsafe(),
+            'inviter_key': self.mayza.key.urlsafe(),
             'type_of_invite': 'USER',
             'institution_key': self.certbio.key.urlsafe()})
         # Retrieve the entities
@@ -77,8 +77,8 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         # Check data of invite
         self.assertEqual(invite_obj.invitee, 'ana@gmail.com',
                          "The email expected was ana@gmail.com")
-        self.assertEqual(invite_obj.inviter, self.mayza.key,
-                         "The inviter expected was Mayza")
+        self.assertEqual(invite_obj.inviter_key, self.mayza.key,
+                         "The inviter_key expected was Mayza")
         self.assertEqual(invite_obj.institution_key, self.certbio.key,
                          "The institution key expected was key of certbio")
 
@@ -86,7 +86,7 @@ class InviteCollectionHandlerTest(TestBaseHandler):
     def test_post_invite_user_member_of_other_institution(self, verify_token):
         invite = self.testapp.post_json("/api/invites", {
             'invitee': 'adriana@ccc.ufcg.edu.br',
-            'inviter': self.tiago.key.urlsafe(),
+            'inviter_key': self.tiago.key.urlsafe(),
             'type_of_invite': 'USER',
             'institution_key': self.splab.key.urlsafe()})
         # Retrieve the entities
@@ -97,8 +97,8 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         # Check data of invite
         self.assertEqual(invite_obj.invitee, 'adriana@ccc.ufcg.edu.br',
                          "The email expected was adriana@ccc.ufcg.edu.br")
-        self.assertEqual(invite_obj.inviter, self.tiago.key,
-                         "The inviter expected was Tiago")
+        self.assertEqual(invite_obj.inviter_key, self.tiago.key,
+                         "The inviter_key expected was Tiago")
         self.assertEqual(invite_obj.institution_key, self.splab.key,
                          "The institution key expected was key of splab")
 
@@ -109,7 +109,7 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         with self.assertRaises(Exception):
             self.testapp.post_json("/api/invites", {
                 'invitee': 'tiago.pereira@ccc.ufcg.edu.br',
-                'inviter': self.mayza.key.urlsafe(),
+                'inviter_key': self.mayza.key.urlsafe(),
                 'type_of_invite': 'USER',
                 'institution_key': self.certbio.key.urlsafe()})
 
@@ -120,16 +120,16 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         with self.assertRaises(Exception):
             self.testapp.post_json("/api/invites", {
                 'invitee': 'ana@gmail.com',
-                'inviter': self.mayza.key.urlsafe(),
+                'inviter_key': self.mayza.key.urlsafe(),
                 'type_of_invite': 'USER'})
 
     @patch('utils.verify_token', return_value={'email': 'tiago.pereira@ccc.ufcg.edu.br'})
     def test_post_invite_without_admin(self, verify_token):
-        """ Check if raise exception when the inviter is not admistrator."""
+        """ Check if raise exception when the inviter_key is not admistrator."""
         with self.assertRaises(Exception):
             self.testapp.post_json("/api/invites", {
                 'invitee': 'ana@gmail.com',
-                'inviter': self.mayza.key.urlsafe(),
+                'inviter_key': self.mayza.key.urlsafe(),
                 'type_of_invite': 'USER',
                 'institution_key': self.certbio.key.urlsafe()})
 
@@ -139,7 +139,7 @@ class InviteCollectionHandlerTest(TestBaseHandler):
 
         invite = self.testapp.post_json("/api/invites", {
             'invitee': 'mayzabeel@gmail.com',
-            'inviter': self.mayza.key.urlsafe(),
+            'inviter_key': self.mayza.key.urlsafe(),
             'type_of_invite': 'INSTITUTION_PARENT',
             'suggestion_institution_name': 'Institution Parent',
             'institution_key': self.certbio.key.urlsafe()})


### PR DESCRIPTION
The invite saves the inviter_key instead of email inviter, to show in invite page who is the inviter.