### PR TITLE
Fix token expiration error

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -188,6 +188,18 @@
                     $state.go("signin");
                 }
                 return config || $q.when(config);
+            },
+            responseError: function(rejection) {
+                var AuthService = $injector.get('AuthService');
+                if (rejection.status === 401) {
+                    if (AuthService.isLoggedIn()) {
+                        AuthService.logout();
+                        rejection.data.msg = "Sua sessão expirou!";
+                    } else {
+                        $state.go("signin");
+                    } 
+                }
+                return $q.reject(rejection);
             }
         };
     });

--- a/app/auth/authService.js
+++ b/app/auth/authService.js
@@ -37,8 +37,10 @@
         service.login = function login() {
             var deferred = $q.defer();
             authObj.$signInWithPopup("google").then(function(result) {
-                service.setupUser(result.credential.idToken).then(function success(userInfo) {
-                    deferred.resolve(userInfo);
+                result.user.getIdToken(true).then(function(idToken) {
+                    service.setupUser(idToken).then(function success(userInfo) {
+                        deferred.resolve(userInfo);
+                    });
                 });
             }).catch(function(error) {
                 MessageService.showToast(error);
@@ -49,10 +51,11 @@
 
         service.loginWithEmailAndPassword = function loginWithEmailAndPassword(email, password) {
             var deferred = $q.defer();
-            authObj.$signInWithEmailAndPassword(email, password).then(function(result) {
-                var idToken = result.toJSON().stsTokenManager.accessToken;
-                service.setupUser(idToken).then(function success(userInfo) {
-                    deferred.resolve(userInfo);
+            authObj.$signInWithEmailAndPassword(email, password).then(function(user) {
+                user.getIdToken(true).then(function(idToken) {
+                    service.setupUser(idToken).then(function success(userInfo) {
+                        deferred.resolve(userInfo);
+                    });
                 });
             }).catch(function(error) {
                 MessageService.showToast(error);

--- a/utils.py
+++ b/utils.py
@@ -146,6 +146,9 @@ class Utils():
         return str(hash_num)
 
 
+_LOCAL_OAUTH2_CERTS_URL = "https://storage.googleapis.com/eciis-splab.appspot.com/certs.json"
+
+
 def verify_token(request):
     """Verify Firebase auth."""
     token = request.headers['Authorization']
@@ -153,10 +156,9 @@ def verify_token(request):
         token = token.split(' ').pop()
         try:
             return google.oauth2.id_token.verify_token(
-                token, HTTP_REQUEST)
+                token, HTTP_REQUEST, certs_url=_LOCAL_OAUTH2_CERTS_URL)
         except:
-            return google.oauth2.id_token.verify_firebase_token(
-                token, HTTP_REQUEST)
+            return None
 
 
 def login_required(method):


### PR DESCRIPTION
When the user session expired, a key error was returned by the server, the solution was to export the certs.json (file that stores the oauth2 certificates to verify user token) to a single file in the cloud storage, and handles properly the error 401 in the client side. 