### PR TITLE
Fix user permission to comment on a deleted post

### DIFF
--- a/custom_exceptions/entityException.py
+++ b/custom_exceptions/entityException.py
@@ -1,0 +1,10 @@
+"""Entity Exception."""
+
+
+class EntityException(Exception):
+    """Not Authorized Exception."""
+
+    def __init__(self, message=None):
+        """Init method."""
+        super(EntityException, self).__init__(
+            message or 'The user can not do this procedure in this entity.')

--- a/custom_exceptions/entityException.py
+++ b/custom_exceptions/entityException.py
@@ -2,7 +2,7 @@
 
 
 class EntityException(Exception):
-    """Not Authorized Exception."""
+    """Entity Exception."""
 
     def __init__(self, message=None):
         """Init method."""

--- a/handlers/post_comment_handler.py
+++ b/handlers/post_comment_handler.py
@@ -16,8 +16,6 @@ from models.post import Comment
 
 from firebase import send_notification
 
-STATE_DELETED = "deleted"
-
 
 def check_permission(user, post, comment_id):
     """Check the user permission to delete comment."""
@@ -52,7 +50,7 @@ class PostCommentHandler(BaseHandler):
         """Handle Post Comments requests."""
         data = json.loads(self.request.body)
         post = ndb.Key(urlsafe=url_string).get()
-        Utils._assert(post.state == STATE_DELETED,
+        Utils._assert(post.state == 'deleted',
                       "This post has been deleted", EntityException)
         comment = Comment.create(data, user.key, post.key)
         post.add_comment(comment)

--- a/handlers/post_comment_handler.py
+++ b/handlers/post_comment_handler.py
@@ -16,6 +16,8 @@ from models.post import Comment
 
 from firebase import send_notification
 
+STATE_DELETED = "deleted"
+
 
 def check_permission(user, post, comment_id):
     """Check the user permission to delete comment."""
@@ -50,7 +52,7 @@ class PostCommentHandler(BaseHandler):
         """Handle Post Comments requests."""
         data = json.loads(self.request.body)
         post = ndb.Key(urlsafe=url_string).get()
-        Utils._assert(post.state == 'deleted',
+        Utils._assert(post.state == STATE_DELETED,
                       "This post has been deleted", EntityException)
         comment = Comment.create(data, user.key, post.key)
         post.add_comment(comment)

--- a/handlers/post_comment_handler.py
+++ b/handlers/post_comment_handler.py
@@ -9,6 +9,7 @@ from utils import login_required
 from utils import json_response
 from utils import Utils
 from custom_exceptions.notAuthorizedException import NotAuthorizedException
+from custom_exceptions.entityException import EntityException
 
 from handlers.base_handler import BaseHandler
 from models.post import Comment
@@ -49,6 +50,8 @@ class PostCommentHandler(BaseHandler):
         """Handle Post Comments requests."""
         data = json.loads(self.request.body)
         post = ndb.Key(urlsafe=url_string).get()
+        Utils._assert(post.state == "deleted",
+                      "This post has been deleted", EntityException)
         comment = Comment.create(data, user.key, post.key)
         post.add_comment(comment)
 

--- a/handlers/post_comment_handler.py
+++ b/handlers/post_comment_handler.py
@@ -50,7 +50,7 @@ class PostCommentHandler(BaseHandler):
         """Handle Post Comments requests."""
         data = json.loads(self.request.body)
         post = ndb.Key(urlsafe=url_string).get()
-        Utils._assert(post.state == "deleted",
+        Utils._assert(post.state == 'deleted',
                       "This post has been deleted", EntityException)
         comment = Comment.create(data, user.key, post.key)
         post.add_comment(comment)

--- a/test/post_comment_handler_test.py
+++ b/test/post_comment_handler_test.py
@@ -22,7 +22,6 @@ class PostCommentHandlerTest(TestBaseHandler):
 
     URL_POST_COMMENT = "/api/posts/%s/comments"
     URL_DELETE_COMMENT = "/api/posts/%s/comments/%s"
-    URL_DELETE_POST = "/api/posts/%s"
 
 
     @classmethod

--- a/test/post_comment_handler_test.py
+++ b/test/post_comment_handler_test.py
@@ -3,7 +3,6 @@
 
 from test_base_handler import TestBaseHandler
 from custom_exceptions.notAuthorizedException import NotAuthorizedException
-from custom_exceptions.entityException import EntityException
 from handlers.post_comment_handler import PostCommentHandler
 from handlers.post_comment_handler import check_permission
 from models.user import User


### PR DESCRIPTION
If the user try to comment a deleted post an exception is raised and the procedure is interrupted.