### PR TITLE
Fix match url pattern on post text

### DIFF
--- a/app/post/postDetailsDirective.js
+++ b/app/post/postDetailsDirective.js
@@ -275,7 +275,6 @@
             var post = new Post(receivedPost, receivedPost.institutionKey);
             var urlsInText = post.text.match(URL_PATTERN);
             post.text = addHttpsToUrl(post.text, urlsInText);
-            post.text = post.text.replace(URL_PATTERN,REPLACE_URL);
             post.text = adjustText(post.text);
             return post;
         };

--- a/app/post/postDetailsDirective.js
+++ b/app/post/postDetailsDirective.js
@@ -258,7 +258,7 @@
             return _.includes(_.map(postDetailsCtrl.user.institutions_admin, getKeyFromUrl), postDetailsCtrl.post.institution_key);
         }
 
-        var URL_PATTERN = /((https?:\/\/)?[\w-]+(\.[\w-]+)+\.?(:\d+)?(\/\S*)?)/gi;
+        var URL_PATTERN = /(((www.)|(http(s)?:\/\/))[\w-]+(\.[\w-]+)+\.?(:\d+)?(\/\S*)?)/gi;
         var REPLACE_URL = "<a href=\'$1\' target='_blank'>$1</a>";
 
         /**
@@ -271,11 +271,8 @@
         */
         postDetailsCtrl.recognizeUrl =  function recognizeUrl(receivedPost) {
             var post = new Post(receivedPost, receivedPost.institutionKey);
-            var urlsInTitle = post.title.match(URL_PATTERN);
             var urlsInText = post.text.match(URL_PATTERN);
-            post.title = addHttpsToUrl(post.title, urlsInTitle);
             post.text = addHttpsToUrl(post.text, urlsInText);
-            post.title = post.title.replace(URL_PATTERN, REPLACE_URL);
             post.text = post.text.replace(URL_PATTERN,REPLACE_URL);
             return post;
         };
@@ -289,10 +286,10 @@
 
         function addHttpsToUrl(text, urls) {
             if(urls) {
-                var https = "https://";
+                var http = "http://";
                 for (var i = 0; i < urls.length; i++) {
-                    if(urls[i].slice(0, 4) != "http") {
-                        text = text.replace(urls[i], https + urls[i]);
+                    if(urls[i].slice(0, 4) !== "http") {
+                        text = text.replace(urls[i], http + urls[i]);
                     }
                 }
             }

--- a/app/test/specs/postDetailsControllerSpec.js
+++ b/app/test/specs/postDetailsControllerSpec.js
@@ -252,7 +252,7 @@
 
         it('Should returns a post with https url in title', function() {
             var newPost = postDetailsCtrl.recognizeUrl(post);
-            expect(newPost.title).toEqual("Post de Tiago em <a href='https://www.twitter.com' target='_blank'>https://www.twitter.com</a>");
+            expect(newPost.title).toEqual("Post de Tiago em <a href='http://www.twitter.com' target='_blank'>http://www.twitter.com</a>");
         });
 
         it('Should not change the original post title', function() {
@@ -262,7 +262,7 @@
 
         it('Should returns a post with https url in text', function() {
             var newPost = postDetailsCtrl.recognizeUrl(post);
-            expect(newPost.text).toEqual("Acessem: <a href='https://www.google.com' target='_blank'>https://www.google.com</a>");
+            expect(newPost.text).toEqual("Acessem: <a href='http://www.google.com' target='_blank'>http://www.google.com</a>");
         });
 
         it('Should not change the original post text', function() {

--- a/app/test/specs/postDetailsControllerSpec.js
+++ b/app/test/specs/postDetailsControllerSpec.js
@@ -250,11 +250,6 @@
             };
         });
 
-        it('Should returns a post with https url in title', function() {
-            var newPost = postDetailsCtrl.recognizeUrl(post);
-            expect(newPost.title).toEqual("Post de Tiago em <a href='http://www.twitter.com' target='_blank'>http://www.twitter.com</a>");
-        });
-
         it('Should not change the original post title', function() {
             var newPost = postDetailsCtrl.recognizeUrl(post);
             expect(post.title).toEqual("Post de Tiago em www.twitter.com");


### PR DESCRIPTION
The pattern to recognize URL on text post was matching with any string with a dot "." between two words, like name.name. The solution was rethink the pattern to accomplish the correct match.