### PR TITLE
Fix bug on long lines in posts

### DIFF
--- a/app/post/post_details.html
+++ b/app/post/post_details.html
@@ -19,7 +19,7 @@
   <md-card-title ng-if="!postDetailsCtrl.isDeleted()">
     <md-card-title-text>
       <a href class="md-title hyperlink" ng-click="postDetailsCtrl.goToPost()">
-        <span class="md-headline">{{postDetailsCtrl.post.title}}</span>
+        <span class="md-headline break">{{postDetailsCtrl.post.title}}</span>
       </a>
     </md-card-title-text>
   </md-card-title>
@@ -32,7 +32,7 @@
       </p>
     </div>
     <div ng-if="!postDetailsCtrl.isDeleted()">
-        <p ng-bind-html="postDetailsCtrl.recognizeUrl(postDetailsCtrl.post).text">
+        <p ng-bind-html="postDetailsCtrl.recognizeUrl(postDetailsCtrl.post).text" class="break">
         {{postDetailsCtrl.recognizeUrl(postDetailsCtrl.post).text}}
         </p>
         <div layout="row" layout-align="end-center">

--- a/app/styles/custom.css
+++ b/app/styles/custom.css
@@ -261,3 +261,7 @@ a:active {
     opacity:1;
     color: black;
 }
+
+.break {
+    word-break: break-all;
+}


### PR DESCRIPTION
**Bug**: It occurs when a post has a text line too long on title or on the post's message.
**Effect**: The text overflows the post card.
**Solution**: It was created a CSS class with the word-break property and this class was used on the 
affected elements.