### PR TITLE
Bug on showing Institution name and image on edit post dialog

### DIFF
--- a/app/post/postDirective.js
+++ b/app/post/postDirective.js
@@ -268,19 +268,34 @@
             postCtrl.pdfFiles.splice(index, 1);
         };
 
-        (function main() {
-            if($scope.isEditing) {
-                postCtrl.createEditedPost($scope.originalPost);
-                observer = jsonpatch.observe(postCtrl.post);
-
-            }
-        })();
-
         postCtrl.hideImage = function() {
            postCtrl.photoUrl = "";
            postCtrl.photoBase64Data = null;
            postCtrl.deletePreviousImage = true;
         };
+
+        postCtrl.getInstPhotoUrl = function getInstPhotoUrl() {
+            var photoUrl = postCtrl.user.current_institution.photo_url;
+            if($scope.isEditing) {
+                photoUrl = postCtrl.post.institution_image;
+            }
+            return photoUrl;
+        };
+
+        postCtrl.getInstName = function getInstName() {            
+            var instName = postCtrl.user.current_institution.name;
+            if($scope.isEditing) {
+                instName = postCtrl.post.institution_name;
+            }
+            return instName;
+        };
+
+        (function main() {
+            if($scope.isEditing) {
+                postCtrl.createEditedPost($scope.originalPost);
+                observer = jsonpatch.observe(postCtrl.post);
+            }
+        })();
     });
 
     app.directive("savePost", function() {

--- a/app/post/save_post.html
+++ b/app/post/save_post.html
@@ -1,10 +1,10 @@
 <md-card flex="100">
   <md-card-header>
     <md-card-avatar>
-      <img ng-src="{{ postCtrl.user.current_institution.photo_url }}" class="md-user-avatar"/>
+      <img ng-src="{{ postCtrl.getInstPhotoUrl()}}" class="md-user-avatar"/>
     </md-card-avatar>
     <md-card-header-text>
-      <span class="md-title">{{ postCtrl.user.current_institution.name }}</span>
+      <span class="md-title">{{ postCtrl.getInstName() }}</span>
       <span class="md-subhead">por {{ postCtrl.user.name }}</span>
     </md-card-header-text>
     <md-button class="md-icon-button" ng-click="postCtrl.cancelDialog()" ng-if="postCtrl.post.title">


### PR DESCRIPTION
**Cause**: It occurs when the user is logged in with a different institution from that on the post that is being edited.

**Effect**: The institution image and name shown are from the user current institution when it should be from the post institution.

**Solution**: It was created functions to get the correct institution name and photo_url depending on whether the post is being edited or not.