### PR TITLE
Circular loading when loading posts and profile

### DIFF
--- a/app/home/home.html
+++ b/app/home/home.html
@@ -43,7 +43,12 @@
       </md-card>
     </div>
 
-    <post-timeline flex-gt-md="60" flex-md="75" layout="column" md-colors="{background: 'grey-200'}" posts="homeCtrl.posts" institution="false" user="homeCtrl.user"></post-timeline>
+    <post-timeline ng-if="!homeCtrl.isLoadingPosts" flex-gt-md="60" flex-md="75" layout="column" md-colors="{background: 'grey-200'}" posts="homeCtrl.posts" institution="false" user="homeCtrl.user"></post-timeline>
+    <div flex>
+      <md-card layout-align="center center" layout="row">
+        <md-progress-circular ng-show="homeCtrl.isLoadingPosts" md-mode="indeterminate" style="width: 13%"></md-progress-circular>
+      </md-card>
+    </div>
 
     <!-- RIGHT SIDE PANEL -->
     <div flex-gt-md="20" layout="row" hide show-gt-md>

--- a/app/home/home.html
+++ b/app/home/home.html
@@ -44,10 +44,10 @@
     </div>
 
     <post-timeline ng-if="!homeCtrl.isLoadingPosts" flex-gt-md="60" flex-md="75" layout="column" md-colors="{background: 'grey-200'}" posts="homeCtrl.posts" institution="false" user="homeCtrl.user"></post-timeline>
-    <div flex>
-      <md-card layout-align="center center" layout="row">
-        <md-progress-circular ng-show="homeCtrl.isLoadingPosts" md-mode="indeterminate" style="width: 13%"></md-progress-circular>
-      </md-card>
+
+    <!-- LOADING CIRCLE -->
+    <div flex layout-align="center center" layout="row">
+      <md-progress-circular ng-show="homeCtrl.isLoadingPosts" md-mode="indeterminate"></md-progress-circular>
     </div>
 
     <!-- RIGHT SIDE PANEL -->

--- a/app/home/homeController.js
+++ b/app/home/homeController.js
@@ -14,6 +14,7 @@
         homeCtrl.events = [];
         homeCtrl.followingInstitutions = [];
         homeCtrl.instMenuExpanded = false;
+        homeCtrl.isLoadingPosts = true;
 
         homeCtrl.user = AuthService.getCurrentUser();
 
@@ -66,6 +67,7 @@
         var loadPosts = function loadPosts() {
             PostService.get().then(function success(response) {
                 homeCtrl.posts = response.data;
+                homeCtrl.isLoadingPosts = false;
             }, function error(response) {
                 MessageService.showToast(response.data.msg);
             });

--- a/app/institution/institutionController.js
+++ b/app/institution/institutionController.js
@@ -15,6 +15,7 @@
         institutionCtrl.isMember = false;
         institutionCtrl.portfolioUrl = null;
         institutionCtrl.showFullDescription = false;
+        institutionCtrl.isLoadingPosts = true;
 
         institutionCtrl.legal_natures = {
             "public": "Pública",
@@ -38,6 +39,7 @@
         function loadPosts() {
             InstitutionService.getTimeline(currentInstitutionKey).then(function success(response) {
                 institutionCtrl.posts = response.data;
+                institutionCtrl.isLoadingPosts = false;
             }, function error(response) {
                 MessageService.showToast(response.data.msg);
             });

--- a/app/institution/institution_page.html
+++ b/app/institution/institution_page.html
@@ -137,11 +137,11 @@
                     </md-card>
                 </div>
 
-                <div flex>
-                    <post-timeline ng-if="!institutionCtrl.isLoadingPosts" layout="column" md-colors="{background: 'grey-200'}" posts="institutionCtrl.posts"
-                        institution="true" user="institutionCtrl.user">
-                    </post-timeline>
-                    <md-progress-circular class="inst-timeline-center" ng-show="institutionCtrl.isLoadingPosts" md-mode="indeterminate" style="width: 13%"></md-progress-circular>
+                <post-timeline flex ng-if="!institutionCtrl.isLoadingPosts" layout="column" md-colors="{background: 'grey-200'}" posts="institutionCtrl.posts"
+                    institution="true" user="institutionCtrl.user">
+                </post-timeline>
+                <div flex ng-if="institutionCtrl.isLoadingPosts" layout="row" layout-align="center center">
+                    <md-progress-circular md-mode="indeterminate"></md-progress-circular>
                 </div>
 
             </div>

--- a/app/institution/institution_page.html
+++ b/app/institution/institution_page.html
@@ -137,9 +137,13 @@
                     </md-card>
                 </div>
 
-                <post-timeline flex layout="column" md-colors="{background: 'grey-200'}" posts="institutionCtrl.posts"
-                    institution="true" user="institutionCtrl.user">
-                </post-timeline>
+                <div flex>
+                    <post-timeline ng-if="!institutionCtrl.isLoadingPosts" layout="column" md-colors="{background: 'grey-200'}" posts="institutionCtrl.posts"
+                        institution="true" user="institutionCtrl.user">
+                    </post-timeline>
+                    <md-progress-circular class="inst-timeline-center" ng-show="institutionCtrl.isLoadingPosts" md-mode="indeterminate" style="width: 13%"></md-progress-circular>
+                </div>
+
             </div>
         </div>
     </div>

--- a/app/styles/custom.css
+++ b/app/styles/custom.css
@@ -350,3 +350,7 @@ a:active {
    border-radius:50%;
    border: 2px solid #EFEBE9;
 }
+
+.inst-timeline-center {
+    margin-left: 46%;
+}

--- a/app/user/profile.html
+++ b/app/user/profile.html
@@ -24,5 +24,5 @@
             <h2>O usuário não possui instituições.</h2>
         </md-dialog-content>
     </div>
-    <md-progress-circular ng-show="profileCtrl.loading" md-mode="indeterminate" style="width: 20%"></md-progress-circular>
+    <md-progress-circular ng-show="profileCtrl.loading" md-mode="indeterminate"></md-progress-circular>
 </md-dialog>

--- a/app/user/profile.html
+++ b/app/user/profile.html
@@ -20,8 +20,9 @@
                 </md-list-item>
             </md-list>
         </md-dialog-content>
-        <md-dialog-content ng-if="!profileCtrl.isToShow()">
+        <md-dialog-content ng-if="!profileCtrl.loading && !profileCtrl.isToShow()">
             <h2>O usuário não possui instituições.</h2>
         </md-dialog-content>
     </div>
+    <md-progress-circular ng-show="profileCtrl.loading" md-mode="indeterminate" style="width: 20%"></md-progress-circular>
 </md-dialog>

--- a/app/user/profileService.js
+++ b/app/user/profileService.js
@@ -35,8 +35,11 @@
         function ProfileController(user, UserService) {
             var profileCtrl = this;
 
+            profileCtrl.loading = true;
+
             UserService.getUser(user).then(function success(response) {
                     profileCtrl.user = response;
+                    profileCtrl.loading = false;
             });
 
             profileCtrl.isToShow = function() {


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> When timeline in home page or institution page is loading posts the following messages is displayed: "O usuário não tem perfil" e "A instituição ainda não possui publicações.", respectively.</p>

<p><b>Solution:</b> Added boolean variable in profileCtrl, homeCtrl and institutionCtrl to know when the information is loaded. When is not loaded, the html show progress circular animation.</p>

<p><b>TODO/FIXME:</b> n/a</p>
