### PR TITLE
Bug on showing institution photo and name in user profile

### DIFF
--- a/handlers/request_handler.py
+++ b/handlers/request_handler.py
@@ -52,13 +52,12 @@ class RequestHandler(BaseHandler):
         request.change_status('accepted')
 
         institution_key = request.institution_key
+        institution = institution_key.get()
         user = request.sender_key.get()
 
         user.add_institution(institution_key)
         user.follow(institution_key)
         user.change_state('active')
-
-        institution = institution_key.get()
 
         institution.add_member(user)
         institution.follow(user.key)

--- a/handlers/user_request_collection_handler.py
+++ b/handlers/user_request_collection_handler.py
@@ -10,7 +10,6 @@ from models.request_user import RequestUser
 from custom_exceptions.entityException import EntityException
 from handlers.base_handler import BaseHandler
 from models.factory_invites import InviteFactory
-from models.user import InstitutionProfile
 
 
 class UserRequestCollectionHandler(BaseHandler):
@@ -48,15 +47,17 @@ class UserRequestCollectionHandler(BaseHandler):
         request = InviteFactory.create(data, type_of_invite)
         request.put()
 
+        institution = ndb.Key(urlsafe=institution_key).get()
         user.name = data.get('sender_name')
-        user_profile = InstitutionProfile()
-        user_profile.email = data.get('institutional_email')
-        user_profile.institution_key = data.get('institution_key')
-        user_profile.office = data.get('office')
-        user_profile.name = data.get('sender_name')
-        user.institution_profiles.append(user_profile)
 
-        user.put()
+        data_profile = {
+            'office': request.office,
+            'email': request.institutional_email,
+            'institution_key': institution_key,
+            'institution_name': institution.name,
+            'institution_photo_url': institution.photo_url
+        }
+        user.create_and_add_profile(data_profile)
 
         if(request.stub_institution_key):
             request.stub_institution_key.get().addInvite(request)

--- a/models/user.py
+++ b/models/user.py
@@ -1,6 +1,8 @@
 """User Model."""
 from google.appengine.ext import ndb
 
+from custom_exceptions.fieldException import FieldException
+
 
 class InstitutionProfile(ndb.Model):
     """Model of InstitutionProfile."""
@@ -18,7 +20,10 @@ class InstitutionProfile(ndb.Model):
         profile['office'] = self.office
         profile['email'] = self.email
         profile['phone'] = self.phone
-        profile['institution'] = {'name': self.institution_name, 'photo_url': self.institution_photo_url}
+        profile['institution'] = {
+            'name': self.institution_name,
+            'photo_url': self.institution_photo_url
+        }
         return profile
 
     @staticmethod
@@ -32,6 +37,13 @@ class InstitutionProfile(ndb.Model):
     @staticmethod
     def create(data):
         """Create an institution profile model instance."""
+        for prop in ['office', 'institution_name',
+                     'institution_key', 'institution_photo_url']:
+            if(not data.get(prop)):
+                raise FieldException(
+                    "The %s property is missing in data profile" % prop
+                )
+
         profile = InstitutionProfile()
         profile.office = data.get('office')
         profile.email = data.get('email')

--- a/test/model_test/institution_profile_test.py
+++ b/test/model_test/institution_profile_test.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+
+from ..test_base import TestBase
+
+from models.user import InstitutionProfile
+
+
+class InstitutionProfileTest(TestBase):
+    """Test the institution profile model."""
+
+    @classmethod
+    def setUp(cls):
+        """Provide the base for the tests."""
+        cls.test = cls.testbed.Testbed()
+        cls.test.activate()
+        cls.policy = cls.datastore.PseudoRandomHRConsistencyPolicy(
+            probability=1)
+        cls.test.init_datastore_v3_stub(consistency_policy=cls.policy)
+        cls.test.init_memcache_stub()
+        initModels(cls)
+
+    def test_make(self):
+        """Test the make method."""
+        profile = InstitutionProfile.create(self.data_profile)
+        maked_profile = {
+            'office': 'member',
+            'email': 'institutional_email',
+            'phone': '88 8888-88888',
+            'institution': {
+                'name': 'institution_name',
+                'photo_url': 'photo_url.com'
+            }
+        }
+
+        self.assertEquals(
+            profile.make(), maked_profile,
+            "It should be equal to the maked profile"
+        )
+
+    def test_is_valid(self):
+        """Test the is_valid method."""
+        profile = InstitutionProfile.create(self.data_profile)
+        data = self.data_profile.copy()
+        data['office'] = "manager"
+        other_profile = InstitutionProfile.create(data)
+        profiles = [profile, other_profile]
+
+        self.assertEquals(
+            InstitutionProfile.is_valid(profiles),
+            True, "It should be True"
+        )
+
+        wrong_profile = InstitutionProfile()
+        wrong_profile.office = None
+        profiles.append(wrong_profile)
+
+        self.assertEquals(
+            InstitutionProfile.is_valid(profiles),
+            False, "It should be False"
+        )
+
+    def test_create(self):
+        """Test the create method."""
+        profile = InstitutionProfile.create(self.data_profile)
+
+        for prop in self.data_profile.keys():
+            self.assertEquals(
+                getattr(profile, prop),
+                self.data_profile.get(prop),
+                "The profile property %s should be %s"
+                % (prop, self.data_profile.get(prop))
+            )
+
+        with self.assertRaises(Exception):
+            data = self.data_profile.copy()
+            data['office'] = None
+            InstitutionProfile.create(data)
+
+        with self.assertRaises(Exception):
+            data = self.data_profile.copy()
+            data['institution_key'] = None
+            InstitutionProfile.create(data)
+
+        with self.assertRaises(Exception):
+            data = self.data_profile.copy()
+            data['institution_name'] = None
+            InstitutionProfile.create(data)
+
+        with self.assertRaises(Exception):
+            data = self.data_profile.copy()
+            data['institution_photo_url'] = None
+            InstitutionProfile.create(data)
+
+
+def initModels(cls):
+    """Init the models."""
+    cls.data_profile = {
+        'office': 'member',
+        'email': 'institutional_email',
+        'phone': '88 8888-88888',
+        'institution_key': 'institution_key',
+        'institution_name': 'institution_name',
+        'institution_photo_url': 'photo_url.com'
+    }

--- a/test/model_test/user_test.py
+++ b/test/model_test/user_test.py
@@ -21,58 +21,72 @@ class UserTest(TestBase):
 
     def test_add_permission(self):
         self.assertEquals(len(self.user.permissions), 0,
-                        "Permission list size should be zero.")
+                          "Permission list size should be zero.")
         permission_type = "publish_post"
         entity_key = "key_of_post"
         self.user.add_permission(permission_type, entity_key)
         self.assertEquals(len(self.user.permissions), 1,
-                        "Permission list size should be zero.")
+                          "Permission list size should be zero.")
 
-        self.assertTrue(self.user.permissions[permission_type][entity_key],
-                        "Permission publish_post should be granted to the user.")
+        self.assertTrue(
+            self.user.permissions[permission_type][entity_key],
+            "Permission publish_post should be granted to the user."
+        )
 
     def test_remove_permission(self):
-        self.assertEquals(len(self.user.permissions), 0,
-                        "Permission list size should be zero.")
+        self.assertEquals(
+            len(self.user.permissions),
+            0, "Permission list size should be zero.")
         permission_type = "publish_post"
         entity_key = "key_of_post"
         self.user.add_permission(permission_type, entity_key)
-        self.assertEquals(len(self.user.permissions), 1,
-                        "Permission list size should be zero.")
-        self.assertTrue(self.user.permissions[permission_type][entity_key],
-                        "Permission publish_post should be granted to the user.")
+        self.assertEquals(
+            len(self.user.permissions), 1,
+            "Permission list size should be zero.")
+        self.assertTrue(
+            self.user.permissions[permission_type][entity_key],
+            "Permission publish_post should be granted to the user.")
         self.user.remove_permission(permission_type, entity_key)
 
-        self.assertEquals(len(self.user.permissions[permission_type]), 0,
-                        "Permission list size should be zero.")
+        self.assertEquals(
+            len(self.user.permissions[permission_type]),
+            0, "Permission list size should be zero.")
 
     def test_has_permission(self):
-        self.assertEquals(len(self.user.permissions), 0,
-                        "Permission list size should be zero.")
+        self.assertEquals(
+            len(self.user.permissions),
+            0, "Permission list size should be zero.")
         permission_type = "publish_post"
         entity_key = "key_of_post"
         self.user.add_permission(permission_type, entity_key)
-        self.assertEquals(len(self.user.permissions), 1,
-                        "Permission list size should be zero.")
+        self.assertEquals(
+            len(self.user.permissions),
+            1, "Permission list size should be zero.")
 
-        self.assertTrue(self.user.permissions[permission_type][entity_key],
-                        "Permission publish_post should be granted to the user.")
+        self.assertTrue(
+            self.user.permissions[permission_type][entity_key],
+            "Permission publish_post should be granted to the user.")
 
         has_permission = self.user.has_permission(permission_type, entity_key)
 
-        self.assertTrue(has_permission,
-                "User should be granted with publish_post permission on post %s" % entity_key)
+        self.assertTrue(
+            has_permission,
+            "User should be granted with publish_post permission on post %s"
+            % entity_key)
 
     def test_dont_have_permission(self):
-        self.assertEquals(len(self.user.permissions), 0,
-                        "Permission list size should be zero.")
+        self.assertEquals(
+            len(self.user.permissions),
+            0, "Permission list size should be zero.")
         permission_type = "publish_post"
         entity_key = "key_of_post"
 
         has_permission = self.user.has_permission(permission_type, entity_key)
 
-        self.assertFalse(has_permission,
-                "User should not be granted with publish_post permission on post %s" % entity_key)
+        self.assertFalse(
+            has_permission,
+            "User should not be granted with publish_post permission on post %s"
+            % entity_key)
 
 
 def initModels(cls):

--- a/test/user_request_collection_handler_test.py
+++ b/test/user_request_collection_handler_test.py
@@ -80,7 +80,9 @@ class UserRequestCollectionHandlerTest(TestBaseHandler):
             'type_of_invite': 'INVITE',
             'sender_name': self.other_user.name,
             'office': 'CEO',
-            'institutional_email': 'other@ceo.com'
+            'institutional_email': 'other@ceo.com',
+            'institution_name': self.inst_test.name,
+            'institution_photo_url': self.inst_test.photo_url
         }
 
         with self.assertRaises(Exception) as ex:
@@ -113,6 +115,7 @@ def initModels(cls):
     # new Institution inst test
     cls.inst_test = Institution()
     cls.inst_test.name = 'inst test'
+    cls.inst_test.photo_url = 'www.photo.com'
     cls.inst_test.address = cls.address
     cls.inst_test.members = [cls.user_admin.key]
     cls.inst_test.followers = [cls.user_admin.key]


### PR DESCRIPTION
<p><b>Bug description:</b> The institution photo and name was not being shown on a recent created user profile</p>

<p><b>Solution:</b> When a new user requests to become member of an institution, it is created a profile.
 Previously, the institution name and photo_url were not being set on profile creation, now they are.</p>