### PR TITLE
Fix exclusion of user profile when institution rejects his membership

### DIFF
--- a/app/invites/inviteUserController.js
+++ b/app/invites/inviteUserController.js
@@ -50,7 +50,6 @@
 
         inviteController.rejectRequest = function rejectInvite(request, event){
                 var promise = RequestInvitationService.showRejectDialog(event);
-
                 promise.then(function() {
                     deleteRequest(request);
                 }, function() {

--- a/handlers/request_handler.py
+++ b/handlers/request_handler.py
@@ -72,4 +72,10 @@ class RequestHandler(BaseHandler):
         """Change request status from 'sent' to 'rejected'."""
         request = ndb.Key(urlsafe=request_key).get()
         request.change_status('rejected')
+
+        institution_key = request.institution_requested_key.urlsafe()
+        sender_user = request.sender_key.get()
+        sender_user.remove_profile(institution_key)
+
+        sender_user.put()
         request.put()

--- a/models/user.py
+++ b/models/user.py
@@ -123,10 +123,10 @@ class User(ndb.Model):
                 self.change_state('inactive')
             self.put()
 
-    def remove_profile(self, institution):
+    def remove_profile(self, institution_key):
         """Remove a profile."""
         for profile in self.institution_profiles:
-            if profile.institution_key == institution:
+            if profile.institution_key == institution_key:
                 self.institution_profiles.remove(profile)
                 break
 


### PR DESCRIPTION
<p><b>Bug description:</b> When an user request to become member of an institution was rejected the corresponding user profile was not being removed.</p>

<p><b>Solution:</b> Now it is called the user method remove_profile in the request_handler delete method to remove the profile related to that request.</p> 

