### PR TITLE
Remove delete of comments in deleted posts

### DIFF
--- a/app/post/comment.html
+++ b/app/post/comment.html
@@ -26,7 +26,7 @@
               {{ commentCtrl.numberOfLikes() }}
             </md-button>
             <md-button class="md-icon-button" aria-label="Reply" ng-click="showReply = !showReply"
-                title="Comentar" ng-disabled="commentCtrl.disableButton()">
+                title="Comentar" ng-disabled="commentCtrl.showReplies()">
               <md-icon>reply</md-icon>
             </md-button>
             <md-button class="post-count md-icon-button md-primary md-hue-1">
@@ -67,7 +67,7 @@
         </div>
       </md-list-item>
       <!-- Reply input -->
-      <md-list-item class="md-3-line" ng-if="showReply" style="margin-left: 50px;">
+      <md-list-item class="md-3-line" ng-if="showReply && !commentCtrl.canReply()" style="margin-left: 50px;">
         <img ng-src="{{commentCtrl.user.photo_url}}" class="md-avatar" alt="{{commentCtrl.user.name}}" />
         <div class="md-list-item-text" layout="row" layout-align="center center">
           <md-input-container flex>

--- a/app/post/postDetailsDirective.js
+++ b/app/post/postDetailsDirective.js
@@ -534,29 +534,44 @@
         };
 
         commentCtrl.confirmCommentDeletion = function confirmCommentDeletion(event, reply) {
-            MessageService.showConfirmationDialog(event, 'Excluir Comentário',
-                'Este comentário será excluído e desaparecerá do referente post.'
-            ).then(function() {
-                if (reply) {
-                    commentCtrl.deleteReply(reply);
-                } else {
-                    commentCtrl.deleteComment();
-                }
-            }, function() {
-                MessageService.showToast('Cancelado');
-            });
+            if(commentCtrl.post.state !== 'deleted') {
+                MessageService.showConfirmationDialog(event, 'Excluir Comentário',
+                    'Este comentário será excluído e desaparecerá do referente post.'
+                ).then(function() {
+                    if (reply) {
+                        commentCtrl.deleteReply(reply);
+                    } else {
+                        commentCtrl.deleteComment();
+                    }
+                }, function() {
+                    MessageService.showToast('Cancelado');
+                });
+            }
         };
 
         commentCtrl.canDeleteComment = function canDeleteComment(reply) {
+            var deletedPost = commentCtrl.post.state === 'deleted';
             if (reply) {
                 var replyHasActivity = commentCtrl.numberOfLikes(reply) > 0;
                 return !replyHasActivity &&
-                    reply.author_key == commentCtrl.user.key;
+                    reply.author_key == commentCtrl.user.key && !deletedPost;
             }
             var commentHasActivity = commentCtrl.numberOfReplies() > 0 ||
                 commentCtrl.numberOfLikes() > 0;
             return !commentHasActivity &&
-                commentCtrl.comment.author_key == commentCtrl.user.key;
+                commentCtrl.comment.author_key == commentCtrl.user.key && !deletedPost;
+        };
+
+        commentCtrl.canReply = function canReply() {
+            return commentCtrl.post.state === 'deleted';
+        };
+
+        commentCtrl.showReplies = function showReplies() {
+            if(commentCtrl.post.state === 'deleted') {
+                var noReplies = commentCtrl.numberOfReplies() === 0;
+                return commentCtrl.saving || noReplies;
+            }
+            return commentCtrl.saving;
         };
 
         commentCtrl.disableButton = function disableButton() {

--- a/app/test/specs/commentControllerSpec.js
+++ b/app/test/specs/commentControllerSpec.js
@@ -66,12 +66,14 @@
 
     describe('canDeleteComment()', function() {
         it('Should return true', function() {
+            commentCtrl.post = posts[0];
             var comment = {author_key: commentCtrl.user.key, text: "testando"};
             var result = commentCtrl.canDeleteComment(comment);
             expect(result).toBeTruthy();
         });
 
         it('Should return false', function() {
+            commentCtrl.post = posts[0];
             var comment = {author_key: "1234", text: "testando"};
             var result = commentCtrl.canDeleteComment(comment);
             expect(result).toBeFalsy();
@@ -87,6 +89,10 @@
     });
 
     describe('confirmCommentDeletion()', function(){
+        beforeEach(function() {
+            posts[0].state = 'published';
+        });
+
         it('Should delete the comment', function() {
             commentCtrl.post = posts[0];
             spyOn(mdDialog, 'confirm').and.callThrough();

--- a/app/test/specs/commentControllerSpec.js
+++ b/app/test/specs/commentControllerSpec.js
@@ -25,7 +25,8 @@
     posts = [{
                 title: 'post principal', author_key: user.key,
                 key: "123456", comments: "/api/posts/123456/comments",
-                likes: "/api/posts/123456/likes", number_of_likes: 0, number_of_comments: 0
+                likes: "/api/posts/123456/likes", number_of_likes: 0, number_of_comments: 0,
+                state: 'published'
         }];
 
     beforeEach(inject(function($controller, $httpBackend, $http, $mdDialog,
@@ -71,6 +72,14 @@
         });
 
         it('Should return false', function() {
+            var comment = {author_key: "1234", text: "testando"};
+            var result = commentCtrl.canDeleteComment(comment);
+            expect(result).toBeFalsy();
+        });
+
+        it('Should not delete the comment in deleted post', function() {
+            commentCtrl.post = posts[0];
+            commentCtrl.post.state = 'deleted';
             var comment = {author_key: "1234", text: "testando"};
             var result = commentCtrl.canDeleteComment(comment);
             expect(result).toBeFalsy();

--- a/handlers/post_comment_handler.py
+++ b/handlers/post_comment_handler.py
@@ -71,6 +71,8 @@ class PostCommentHandler(BaseHandler):
         institution = post.institution.get()
         Utils._assert(institution.state == 'inactive',
                       "The institution has been deleted", NotAuthorizedException)
+        Utils._assert(post.state == 'deleted',
+                      "Can not delete comment in deleted post", NotAuthorizedException)
         comment = post.get_comment(comment_id)
 
         hasActivity = len(comment.get('replies')) > 0 or len(comment.get('likes')) > 0


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> User can delete comments and replies in deleted posts.</p>

<p><b>Solution:</b> In back-end: added exception in delete comment when post state is deleted.
 In front-end: added some verifications to not allow delete comments in posts with deleted state.</p>

<p><b>TODO/FIXME:</b> n/a</p>
