### PR TITLE
Fix institutions rejected invites

### DIFF
--- a/app/invites/existing_institutions.html
+++ b/app/invites/existing_institutions.html
@@ -14,7 +14,7 @@
                             </md-button>
                         </div>
                     </md-list-item>
-                    <md-list-item ng-if="!suggestInstCtrl.isActive(institution.state)" ng-click="null" class="md-2-line">
+                    <md-list-item ng-if="suggestInstCtrl.isPending(institution.state)" ng-click="null" class="md-2-line">
                         <div class="md-list-item-text">
                             <h3 style="color: #616161">{{institution.name}}</h3>
                             <p style="color: #9E9E9E">Convite enviado para: {{institution.admin}}<p>

--- a/app/invites/inviteInstitutionController.js
+++ b/app/invites/inviteInstitutionController.js
@@ -72,11 +72,11 @@
 
         inviteController.sendInstInvite = function sendInstInvite(invite) {
             var promise = InviteService.sendInvite(invite);
-            promise.then(function success(response) {
+            promise.then(function success() {
                     inviteController.invite = {};
                     inviteController.showButton = true;
                     invite.status = 'sent';
-                    invite.inviter_name = inviteController.user.name;
+                    invite.sender_name = inviteController.user.name;
                     inviteController.sent_invitations.push(invite);
                     MessageService.showToast('Convite enviado com sucesso!');
                 }, function error(response) {

--- a/app/invites/inviteInstitutionController.js
+++ b/app/invites/inviteInstitutionController.js
@@ -27,6 +27,7 @@
 
             inviteController.invite.institution_key = currentInstitutionKey;
             inviteController.invite.admin_key = inviteController.user.key;
+            inviteController.invite.sender_key = inviteController.user.key;
             inviteController.invite.type_of_invite = 'INSTITUTION';
             invite = new Invite(inviteController.invite);
 

--- a/app/invites/invite_institution.html
+++ b/app/invites/invite_institution.html
@@ -42,7 +42,7 @@
                 <div class="md-list-item-text" layout="column">
                   <h3>{{ invite.suggestion_institution_name }}</h3>
                   <h4>{{ invite.invitee }}</h4>
-                  <h4>Convidada por: {{ invite.inviter_name }}</h4>
+                  <h4>Convidada por: {{ invite.sender_name }}</h4>
                 </div>
               </md-list-item>
             </md-list>

--- a/app/invites/new_invite_page.html
+++ b/app/invites/new_invite_page.html
@@ -20,12 +20,7 @@
             </md-list>
 
             <md-list flex ng-if="!newInviteCtrl.isInviteUser()">
-              <md-subheader class="md-no-sticky">{{newInviteCtrl.invite.admin_name}} da Instituição {{newInviteCtrl.invite.institution.name}}  te enviou um convite para ser administrador da nova instituição:</md-subheader>
-              <md-list-item class="md-3-line">
-                <div class="md-list-item-text" layout="column" style="text-align: center;">
-                  <h3><b>{{ newInviteCtrl.invite.suggestion_institution_name}}</b></h3>
-                </div>
-              </md-list-item>
+              <p>{{newInviteCtrl.invite.admin_name}} da Instituição {{newInviteCtrl.invite.institution.name}} te enviou um convite para ser administrador da instituição <b>{{ newInviteCtrl.invite.suggestion_institution_name | uppercase}}</b></p>
             </md-list>
             <div layout="column" layout-align="center" ng-if="newInviteCtrl.isUserInfoImcomplete()">
               <p>Informe seus dados pessoais abaixo para essa instituição:</p>

--- a/app/invites/suggestInstitutionController.js
+++ b/app/invites/suggestInstitutionController.js
@@ -13,6 +13,7 @@
         suggestInstCtrl.requested_invites = requested_invites;
         suggestInstCtrl.isHierarchy = isHierarchy;
         var ACTIVE_STATE = "active";
+        var PENDING_STATE = "pending";
 
         suggestInstCtrl.goToInstitution = function goToInstitution(institutionKey) {
             window.open(makeUrl(institutionKey), '_blank');
@@ -22,13 +23,17 @@
             $mdDialog.cancel();
         };
 
-        suggestInstCtrl.showSuggestion = function(state) {
+        suggestInstCtrl.showSuggestion = function showSuggestion(state) {
             var isActive = state === ACTIVE_STATE;
             return isActive && suggestInstCtrl.isHierarchy;
         };
 
-        suggestInstCtrl.isActive = function(state) {
+        suggestInstCtrl.isActive = function isActive(state) {
             return state === ACTIVE_STATE;
+        };
+
+        suggestInstCtrl.isPending = function isPending(state) {
+            return state === PENDING_STATE;
         };
 
         function makeUrl(institutionKey){

--- a/app/invites/suggestInstitutionController.js
+++ b/app/invites/suggestInstitutionController.js
@@ -24,8 +24,7 @@
         };
 
         suggestInstCtrl.showSuggestion = function showSuggestion(state) {
-            var isActive = state === ACTIVE_STATE;
-            return isActive && suggestInstCtrl.isHierarchy;
+            return suggestInstCtrl.isActive(state) && suggestInstCtrl.isHierarchy;
         };
 
         suggestInstCtrl.isActive = function isActive(state) {

--- a/handlers/invite_handler.py
+++ b/handlers/invite_handler.py
@@ -48,13 +48,15 @@ class InviteHandler(BaseHandler):
 
     @login_required
     def delete(self, user, key):
-        """Change invite status from 'sent' to 'resolved'."""
+        """Change invite status from 'sent' to 'rejected'."""
         invite_key = ndb.Key(urlsafe=key)
         invite = invite_key.get()
         invite.change_status('rejected')
+        invite.put()
 
-        stub_institution = invite.stub_institution_key.get()
-        stub_institution.change_state('inactive')
+        if invite.stub_institution_key:
+            stub_institution = invite.stub_institution_key.get()
+            stub_institution.change_state('inactive')
 
     @json_response
     @login_required

--- a/handlers/invite_handler.py
+++ b/handlers/invite_handler.py
@@ -52,7 +52,9 @@ class InviteHandler(BaseHandler):
         invite_key = ndb.Key(urlsafe=key)
         invite = invite_key.get()
         invite.change_status('rejected')
-        invite.put()
+
+        stub_institution = invite.stub_institution_key.get()
+        stub_institution.change_state('inactive')
 
     @json_response
     @login_required

--- a/models/institution.py
+++ b/models/institution.py
@@ -293,6 +293,12 @@ class Institution(ndb.Model):
                 child = child.get()
                 child.remove_institution_from_users(remove_hierarchy)
 
+    def change_state(self, state):
+        """Change the institution state."""
+        self.state = state
+        self.put()
+        search_module.updateDocument(self)
+
     def make(self, attributes):
         """Create an institution dictionary with specific filds."""
         institution = {}

--- a/models/invite.py
+++ b/models/invite.py
@@ -52,11 +52,14 @@ class Invite(PolyModel):
     @staticmethod
     def create(data, invite):
         """Create a post and check required fields."""
-        admin_key = ndb.Key(urlsafe=data.get('admin_key'))
-        invite.admin_key = admin_key
-        invite.sender_name = admin_key.get().name
+        invite.admin_key = ndb.Key(urlsafe=data.get('admin_key'))
         invite.is_request = data.get('is_request') or False
         invite.institution_key = ndb.Key(urlsafe=data.get('institution_key'))
+        invite.sender_key = invite.admin_key
+        if data.get('sender_key'):
+            invite.sender_key = ndb.Key(urlsafe=data.get('sender_key'))
+        invite.sender_name = invite.sender_key.get().name
+
         return invite
 
     def sendInvite(self, user, host):

--- a/models/invite.py
+++ b/models/invite.py
@@ -52,10 +52,11 @@ class Invite(PolyModel):
     @staticmethod
     def create(data, invite):
         """Create a post and check required fields."""
+        admin_key = ndb.Key(urlsafe=data.get('admin_key'))
+        invite.admin_key = admin_key
+        invite.sender_name = admin_key.get().name
         invite.is_request = data.get('is_request') or False
-        invite.admin_key = ndb.Key(urlsafe=data.get('admin_key'))
         invite.institution_key = ndb.Key(urlsafe=data.get('institution_key'))
-
         return invite
 
     def sendInvite(self, user, host):
@@ -108,6 +109,7 @@ class Invite(PolyModel):
         institution = institution.make(REQUIRED_PROPERTIES)
         return {
             'admin_name': self.admin_key.get().name,
+            'sender_name': self.sender_name,
             'key': self.key.urlsafe(),
             'status': self.status,
             'institution_admin': institution_admin,

--- a/test/model_test/request_user_test.py
+++ b/test/model_test/request_user_test.py
@@ -179,6 +179,6 @@ def initModels(cls):
     cls.inst_test.put()
     # new User inactive other user
     cls.other_user = User()
-    cls.other_user.name = 'other user'
+    cls.other_user.name = 'other_user'
     cls.other_user.email = ['otheruser@test.com']
     cls.other_user.put()


### PR DESCRIPTION
<p><b>Bug description:</b> Rejected institution invites were being shown as pending invites when the user tries to create an institution invite with the same name as one that has already been rejected.</p>

<p><b>Solution:</b> On invite handler delete method, when an invite is deleted, the corresponding stub institution has its state changed to inactive as well as its document.</p>

