### PR TITLE
Sending notification when invite or request is accepted or rejected

### DIFF
--- a/app/notification/notificationDirective.js
+++ b/app/notification/notificationDirective.js
@@ -78,6 +78,24 @@
                      controllerAs: "requestCtrl",
                      locals: {}
                 }
+            },
+            "ACCEPT_INSTITUTION_LINK": {
+                icon: "account_balance",
+            },
+            "REJECT_INSTITUTION_LINK": {
+                icon: "account_balance",
+            },
+            "ACCEPT_INVITE_USER": {
+                icon: "person"
+            },
+            "REJECT_INVITE_USER": {
+                icon: "person"
+            },
+            "ACCEPT_INVITE_INSTITUION": {
+                icon: "account_balance"
+            },
+            "REJECT_INVITE_INSTITUTION": {
+                icon: "account_balance"
             }
         };
 

--- a/app/notification/notificationDirective.js
+++ b/app/notification/notificationDirective.js
@@ -91,7 +91,7 @@
             "REJECT_INVITE_USER": {
                 icon: "person"
             },
-            "ACCEPT_INVITE_INSTITUION": {
+            "ACCEPT_INVITE_INSTITUTION": {
                 icon: "account_balance"
             },
             "REJECT_INVITE_INSTITUTION": {

--- a/app/notification/notificationService.js
+++ b/app/notification/notificationService.js
@@ -21,7 +21,13 @@
             'REQUEST_INSTITUTION_CHILDREN': 'solicitou um novo vínculo entre sua instituição e a dele',
             'REPLY_COMMENT': 'respondeu o seu comentário',
             'LIKE_COMMENT': 'curtiu seu comentário',
-            'LIKE_POST': 'curtiu seu post'
+            'LIKE_POST': 'curtiu seu post',
+            'REJECT_INSTITUTION_LINK': 'rejeitou sua solicitação de vínculo entre instituições',
+            'ACCEPT_INSTITUTION_LINK': 'aceitou sua solicitação de vínculo entre instituições',
+            'REJECT_INVITE_USER': 'rejeitou o convite para ser membro de sua instituição',
+            'ACCEPT_INVITE_USER': 'aceitou o convite para ser membro de sua instituição',
+            'REJECT_INVITE_INSTITUTION': 'rejeitou o seu convite para ser administrador',
+            'ACCEPT_INVITE_INSTITUTION': 'aceitou o seu convite para ser administrador'
         };
 
         var POST_NOTIFICATION = 'POST';

--- a/handlers/institution_children_request_handler.py
+++ b/handlers/institution_children_request_handler.py
@@ -33,6 +33,8 @@ class InstitutionChildrenRequestHandler(BaseHandler):
         institution_children.parent_institution = request.institution_key
         institution_children.put()
 
+        request.send_response_notification(user, request.admin_key.urlsafe(), 'ACCEPT_INSTITUTION_LINK')
+
         self.response.write(json.dumps(request.make()))
 
     @login_required
@@ -43,3 +45,5 @@ class InstitutionChildrenRequestHandler(BaseHandler):
         request = request_key.get()
         request.change_status('rejected')
         request.put()
+
+        request.send_response_notification(user, request.admin_key.urlsafe(), 'REJECT_INSTITUTION_LINK')

--- a/handlers/institution_parent_request_handler.py
+++ b/handlers/institution_parent_request_handler.py
@@ -33,6 +33,8 @@ class InstitutionParentRequestHandler(BaseHandler):
         parent_institution.children_institutions.append(request.institution_key)
         parent_institution.put()
 
+        request.send_response_notification(user, request.admin_key.urlsafe(), 'ACCEPT_INSTITUTION_LINK')
+
         self.response.write(json.dumps(request.make()))
 
     @login_required
@@ -43,3 +45,5 @@ class InstitutionParentRequestHandler(BaseHandler):
         request = request_key.get()
         request.change_status('rejected')
         request.put()
+
+        request.send_response_notification(user, request.admin_key.urlsafe(), 'REJECT_INSTITUTION_LINK')

--- a/handlers/invite_handler.py
+++ b/handlers/invite_handler.py
@@ -53,6 +53,7 @@ class InviteHandler(BaseHandler):
         invite = invite_key.get()
         invite.change_status('rejected')
         invite.put()
+        invite.send_response_notification(user, invite.admin_key.urlsafe(), 'REJECT')
 
     @json_response
     @login_required
@@ -75,6 +76,8 @@ class InviteHandler(BaseHandler):
         institution.follow(user.key)
 
         JsonPatch.load(data, user, define_entity)
+
+        invite.send_response_notification(user, invite.admin_key.urlsafe(), 'ACCEPT')
         # TODO: Change the method is valid to check only
         # the new institution profile of this patch
         # @author: Mayza Nunes 19/09/2017

--- a/models/institution.py
+++ b/models/institution.py
@@ -218,6 +218,8 @@ class Institution(ndb.Model):
         user.follows.append(institution.key)
         user.put()
 
+        invite.send_response_notification(user, invite.admin_key.urlsafe(), 'ACCEPT')
+
         return institution
 
     @ndb.transactional(xg=True)

--- a/models/invite_institution.py
+++ b/models/invite_institution.py
@@ -67,6 +67,11 @@ class InviteInstitution(Invite):
         if user_found:
             super(InviteInstitution, self).send_notification(user, user_found.key.urlsafe(), entity_type)
 
+    def send_response_notification(self, user, receiver_key, operation):
+        """Send notification to sender of invite when invite is accepted or rejected."""
+        response_type = 'ACCEPT_INVITE_INSTITUTION' if operation == 'ACCEPT' else 'REJECT_INVITE_INSTITUTION'
+        super(InviteInstitution, self).send_notification(user, receiver_key, response_type)
+
     def make(self):
         """Create json of invite to institution."""
         invite_inst_json = super(InviteInstitution, self).make()

--- a/models/invite_user.py
+++ b/models/invite_user.py
@@ -67,6 +67,11 @@ class InviteUser(Invite):
         if user_found:
             super(InviteUser, self).send_notification(user, user_found.key.urlsafe(), entity_type)
 
+    def send_response_notification(self, user, receiver_key, operation):
+        """Send notification to sender of invite when invite is accepted or rejected."""
+        response_type = 'ACCEPT_INVITE_USER' if operation == 'ACCEPT' else 'REJECT_INVITE_USER'
+        super(InviteUser, self).send_notification(user, receiver_key, response_type)
+
     def make(self):
         """Create json of invite to user."""
         invite_user_json = super(InviteUser, self).make()

--- a/models/request_institution_children.py
+++ b/models/request_institution_children.py
@@ -37,6 +37,10 @@ class RequestInstitutionChildren(Request):
         entity_type = 'REQUEST_INSTITUTION_CHILDREN'
         super(RequestInstitutionChildren, self).send_notification(user, self.institution_requested_key.get().admin.urlsafe(), entity_type)
 
+    def send_response_notification(self, user, receiver_key, entity_type):
+        """Send notification to sender of invite when invite is accepted or rejected."""
+        super(RequestInstitutionChildren, self).send_notification(user, receiver_key, entity_type)
+
     def make(self):
         """Create json of request to institution children."""
         request_inst_children_json = super(RequestInstitutionChildren, self).make()

--- a/models/request_institution_parent.py
+++ b/models/request_institution_parent.py
@@ -37,6 +37,10 @@ class RequestInstitutionParent(Request):
         entity_type = 'REQUEST_INSTITUTION_PARENT'
         super(RequestInstitutionParent, self).send_notification(user, self.institution_requested_key.get().admin.urlsafe(), entity_type)
 
+    def send_response_notification(self, user, receiver_key, entity_type):
+        """Send notification to sender of invite when invite is accepted or rejected."""
+        super(RequestInstitutionParent, self).send_notification(user, receiver_key, entity_type)
+
     def make(self):
         """Create json of request to parent institution."""
         request_inst_parent_json = super(RequestInstitutionParent, self).make()

--- a/test/institution_handler_test.py
+++ b/test/institution_handler_test.py
@@ -2,7 +2,7 @@
 """Post handler test."""
 
 from test_base_handler import TestBaseHandler
-from models.invite import Invite
+from models.invite_institution import InviteInstitution
 from models.user import User
 from models.institution import Institution
 from handlers.institution_handler import InstitutionHandler
@@ -281,7 +281,7 @@ def initModels(cls):
     cls.splab.admin = None
     cls.splab.put()
     # Invite for Raoni create new inst
-    cls.invite = Invite()
+    cls.invite = InviteInstitution()
     cls.invite.invitee = 'raoni.smaneoto@ccc.ufcg.edu.br'
     cls.invite.admin_key = cls.mayza.key
     cls.invite.type_of_invite = 'institution'

--- a/test/invite_handler_test.py
+++ b/test/invite_handler_test.py
@@ -11,6 +11,7 @@ from models.invite_user import InviteUser
 from models.invite_institution import InviteInstitution
 from handlers.invite_handler import InviteHandler
 
+import mock
 from mock import patch
 
 
@@ -47,7 +48,8 @@ class InviteHandlerTest(TestBaseHandler):
             "Expected invite should be equal to make")
 
     @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
-    def test_delete(self, verify_token):
+    @mock.patch('service_messages.send_message_notification')
+    def test_delete(self, verify_token, mock_method):
         """Test method delete of InviteHandler."""
         stub_institution = self.invite_institution.stub_institution_key.get()
         stub_inst_document = search_module.getDocuments(
@@ -107,8 +109,12 @@ class InviteHandlerTest(TestBaseHandler):
             'inactive', "The searched institution state should be inactive"
         )
 
+        self.assertTrue(mock_method.assert_called,
+                        "Should call the send_message_notification")
+
     @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
-    def test_patch(self, verify_token):
+    @mock.patch('service_messages.send_message_notification')
+    def test_patch(self, verify_token, mock_method):
         """Test method patch of InviteHandler."""
         profile = '{"email": "otheruser@test.com", "office": "Developer"}'
         json_patch = '[{"op": "add", "path": "/institution_profiles/-", "value": ' + profile + '}]'
@@ -136,6 +142,9 @@ class InviteHandlerTest(TestBaseHandler):
             user.state,
             'active',
             "Expected state should be equal to active")
+
+        self.assertTrue(mock_method.assert_called,
+                        "Should call the send_message_notification")
 
     @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
     def test_patch_fail(self, verify_token):


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> When invites or requests is accepted or rejected the sender is not notified when is accepted or rejected.</p>

<p><b>Solution:</b> When user or admin accept or reject invite (or request), invite_handler send notification to sender of invite.</p>

<p><b>TODO/FIXME:</b> n/a</p>
