### PR TITLE
fixing the unknow sender_name in request user

### DIFF
--- a/backend/models/invite.py
+++ b/backend/models/invite.py
@@ -55,8 +55,12 @@ class Invite(PolyModel):
         invite.admin_key = ndb.Key(urlsafe=data.get('admin_key'))
         invite.is_request = data.get('is_request') or False
         invite.institution_key = ndb.Key(urlsafe=data.get('institution_key'))
-        invite.sender_name = data.get('sender_name') if data.get('sender_name') else invite.sender_key.get().name
-        invite.sender_key = ndb.Key(urlsafe=data.get('sender_key')) if data.get('sender_key') else invite.admin_key
+        invite.sender_key = invite.admin_key
+        if data.get('sender_key'):
+            invite.sender_key = ndb.Key(urlsafe=data.get('sender_key'))
+        invite.sender_name = invite.sender_key.get().name
+        if data.get('sender_name'):
+            invite.sender_name = data.get('sender_name')
 
         return invite
 

--- a/backend/models/invite.py
+++ b/backend/models/invite.py
@@ -55,10 +55,8 @@ class Invite(PolyModel):
         invite.admin_key = ndb.Key(urlsafe=data.get('admin_key'))
         invite.is_request = data.get('is_request') or False
         invite.institution_key = ndb.Key(urlsafe=data.get('institution_key'))
-        invite.sender_key = invite.admin_key
-        if data.get('sender_key'):
-            invite.sender_key = ndb.Key(urlsafe=data.get('sender_key'))
-        invite.sender_name = invite.sender_key.get().name
+        invite.sender_name = data.get('sender_name') if data.get('sender_name') else invite.sender_key.get().name
+        invite.sender_key = ndb.Key(urlsafe=data.get('sender_key')) if data.get('sender_key') else invite.admin_key
 
         return invite
 


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> If the user is a new user, when sending a request to some institution, the sender_name of the user is Unknow or the last sender_name from another invite.</p>

<p><b>Solution:</b> Changing the logic in creating invite to construct RequestUser with correct sender_name.</p>

<p><b>TODO/FIXME:</b> n/a</p>
