### PR TITLE
removing the inactive user from display of followers

### DIFF
--- a/backend/handlers/institution_followers_handler.py
+++ b/backend/handlers/institution_followers_handler.py
@@ -26,6 +26,7 @@ class InstitutionFollowersHandler(BaseHandler):
         institution = institution_key.get()
 
         array = [member.get() for member in institution.followers]
+        array = [member for member in array if member.state == 'active']
 
         self.response.write(json.dumps(Utils.toJson(array)))
 

--- a/backend/handlers/institution_followers_handler.py
+++ b/backend/handlers/institution_followers_handler.py
@@ -26,6 +26,9 @@ class InstitutionFollowersHandler(BaseHandler):
         institution = institution_key.get()
 
         array = [member.get() for member in institution.followers]
+        # TODO: This process is unnecessary,
+        # need to optimized
+        # @author: Tiago Pereira
         array = [member for member in array if member.state == 'active']
 
         self.response.write(json.dumps(Utils.toJson(array)))


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> If the institution that user is a member is deleted, the user state is changed to inactive, however, the institutions followed by the user display the user even if his inactive.</p>

<p><b>Solution:</b> The solution is very simple: in getFollowers, the server side sends only followers with the active state.</p>

<p><b>TODO/FIXME:</b> n/a</p>
