### PR TITLE
Fix layout of pdf view

### DIFF
--- a/frontend/post/pdfDialog.html
+++ b/frontend/post/pdfDialog.html
@@ -1,3 +1,3 @@
-<md-dialog layout="column" flex-gt-lg="80" flex-lg="90" aria-label="portfólio">
-    <embed ng-src="{{ctrl.pdfUrl}}" flex flex-gt-lg flex-lg="90" type='application/pdf'></embed>
+<md-dialog layout-fill flex="80" aria-label="portfólio">
+    <embed layout="column" ng-src="{{ctrl.pdfUrl}}" flex="100" type='application/pdf'></embed>
 </md-dialog>


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> Broken pdfs preview layout on very large or very small screens.</p>

<p><b>Solution:</b> I used the fill layout so that the pdf preview mode would fill the entire area available on the screen.</p>

<p><b>TODO/FIXME:</b> n/a</p>
