### PR TITLE
improving the texts displayed in events widget, management Inst. and Inst. page

### DIFF
--- a/frontend/home/home.html
+++ b/frontend/home/home.html
@@ -57,7 +57,7 @@
           <md-toolbar md-colors="{background: 'teal-800'}" layout="row">
             <md-icon style="margin-left: 7%;">event</md-icon>
             <div class="md-toolbar-tools" flex layout="row">
-              Eventos
+              Próximos eventos
             </div>
           </md-toolbar>
           <md-card-content>

--- a/frontend/institution/institution_page.html
+++ b/frontend/institution/institution_page.html
@@ -67,12 +67,12 @@
                             </div>
                             <p align="justify"><b>Descrição:</b> {{ institutionCtrl.current_institution.description ? institutionCtrl.current_institution.description : 'Não informado' }}</p>
                             
-                            <p ng-if="institutionCtrl.hasParentActive(institutionCtrl.current_institution)" align="justify"><b>Instituição superior:</b> 
+                            <p ng-if="institutionCtrl.hasParentActive(institutionCtrl.current_institution)" align="justify"><b>Instituição hierarquicamente superior:</b> 
                             <a href class="hyperlink" ng-click="institutionCtrl.goToInstitution(institutionCtrl.current_institution.parent_institution.key)">
                                 {{ institutionCtrl.current_institution.parent_institution.name}}</p>
                             </a>
                             <p ng-if="institutionCtrl.hasChildrenActive(institutionCtrl.current_institution)"
-                            align="justify"><b>Instituições subordinadas:</b>
+                            align="justify"><b>Instituições hierarquicamente subordinadas:</b>
                             <spam ng-repeat="institution in institutionCtrl.current_institution.children_institutions | filter : {state : 'active'}">
                                 <a href class="hyperlink" ng-click="institutionCtrl.goToInstitution(institution.key)">
                                     {{ institution.name }}

--- a/frontend/invites/invite_institution_hierarchie.html
+++ b/frontend/invites/invite_institution_hierarchie.html
@@ -35,7 +35,7 @@
           </section>
         </div>
         <md-list class="md-dense" flex>
-          <md-subheader class="md-no-sticky">Instituição superior</md-subheader>
+          <md-subheader class="md-no-sticky">Instituição hierarquicamente superior</md-subheader>
           <md-list-item class="md-3-line" ng-if="inviteInstCtrl.hasParent">
             <md-icon class="md-avatar-icon" >account_balance</md-icon>
             <div class="md-list-item-text" layout="column">
@@ -58,7 +58,7 @@
               </md-button>
             </div>
           </md-list-item>
-          <md-subheader class="md-no-sticky">Instituições subordinadas</md-subheader>
+          <md-subheader class="md-no-sticky">Instituições hierarquicamente subordinadas</md-subheader>
           <md-list-item class="md-3-line"
           ng-repeat="institution in inviteInstCtrl.institution.children_institutions">
             <md-icon class="md-avatar-icon" >account_balance</md-icon>


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> The text displayed in right side of timeline is "Evento" and in institution page is "Instituições subordinadas" and "Instituição superior".</p>

<p><b>Solution:</b> Changed "Evento" to "Próximos eventos", "Instituições subordinadas" to "Instituições hierarquicamente subordinadas" and "Instituição superior" to "Instituição hierarquicamente superior".</p>

<p><b>TODO/FIXME:</b> n/a</p>
