### PR TITLE
Fixing inviteIsMember and inviteeIsInvited functions

### DIFF
--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -3,7 +3,7 @@
     var app = angular.module('app');
 
     app.controller("ManagementMembersController", function InviteUserController(
-        InviteService, $mdToast, $state, $mdDialog, InstitutionService, AuthService, MessageService, 
+        InviteService, $mdToast, $state, $mdDialog, InstitutionService, AuthService, MessageService,
         RequestInvitationService, ProfileService) {
         var manageMemberCtrl = this;
 
@@ -130,11 +130,15 @@
         }
 
         function inviteeIsMember(invite) {
-            return _.includes(_.map(manageMemberCtrl.members, getEmail), invite.invitee);
+            return _.find(_.map(manageMemberCtrl.members, getEmail), function(emails) {
+                return _.includes(emails, invite.invitee);
+            });
         }
 
         function inviteeIsInvited(invite) {
-            return _.some(manageMemberCtrl.sent_invitations, invite);
+            return _.find(manageMemberCtrl.sent_invitations, function(sentInvitation) {
+                return sentInvitation.invitee === invite.invitee;
+            });
         }
 
         manageMemberCtrl.isUserInviteValid = function isUserInviteValid(invite) {

--- a/frontend/test/specs/managementMembersControllerSpec.js
+++ b/frontend/test/specs/managementMembersControllerSpec.js
@@ -20,7 +20,7 @@
     var institution = {
             name: 'institution',
             key: '987654321',
-            sent_invitations: [invite]  ,
+            sent_invitations: [invite, otherInvite]  ,
             members: [member]
     };
 
@@ -86,8 +86,8 @@
     describe('ManagementMembersController properties', function() {
 
         it('should exist one sent sent invitations', function() {
-            expect(manageMemberCtrl.sent_invitations).toEqual([invite]);
-            expect(manageMemberCtrl.sent_invitations.length).toBe(1);
+            expect(manageMemberCtrl.sent_invitations).toEqual([invite, otherInvite]);
+            expect(manageMemberCtrl.sent_invitations.length).toBe(2);
         });
     });
 
@@ -131,16 +131,20 @@
             });
 
             it('should call inviteService.sendInvite()', function(done) {
-                manageMemberCtrl.invite.invitee = "pedro@gmail.com";
-                expect(manageMemberCtrl.sent_invitations.length).toBe(1);
+                manageMemberCtrl.invite = {invitee: "teste@gmail.com",
+                                            type_of_invite: 'USER',
+                                            institution_key: '987654321',
+                                            admin_key: '12345'};
+                var newInvite = new Invite(manageMemberCtrl.invite);
+                expect(manageMemberCtrl.sent_invitations.length).toBe(2);
                 var promise = manageMemberCtrl.sendUserInvite();
                 promise.then(function() {
-                    expect(inviteService.sendInvite).toHaveBeenCalledWith(otherInvite);
+                    expect(inviteService.sendInvite).toHaveBeenCalledWith(newInvite);
                     expect(manageMemberCtrl.invite).toEqual({});
                     expect(manageMemberCtrl.showButton).toBe(true);
                     expect(manageMemberCtrl.sent_invitations).toContain(invite);
-                    expect(manageMemberCtrl.sent_invitations).toContain(otherInvite);
-                    expect(manageMemberCtrl.sent_invitations.length).toBe(2);
+                    expect(manageMemberCtrl.sent_invitations).toContain(newInvite);
+                    expect(manageMemberCtrl.sent_invitations.length).toBe(3);
                     done();
                 });
                 scope.$apply();
@@ -150,7 +154,7 @@
         describe('isUserInviteValid()', function() {
 
             it('should be true with new invite', function() {
-                var newInvite = new Invite({invitee: "pedro@gmail.com",
+                var newInvite = new Invite({invitee: "teste@gmail.com",
                                             type_of_invite: 'USER',
                                             institution_key: '987654321',
                                             admin_key: '12345'});

--- a/frontend/test/specs/managementMembersControllerSpec.js
+++ b/frontend/test/specs/managementMembersControllerSpec.js
@@ -4,7 +4,7 @@
     var INSTITUTIONS_URI = "/api/institutions/";
     var REQUESTS_URI = "/api/institutions/";
 
-    var manageMemberCtrl, httpBackend, scope, inviteService, createCtrl, state, authService, 
+    var manageMemberCtrl, httpBackend, scope, inviteService, createCtrl, state, authService,
         mdDialog, institutionService;
 
     var invite = new Invite({invitee: "mayzabeel@gmail.com",
@@ -42,7 +42,7 @@
 
     beforeEach(module('app'));
 
-    beforeEach(inject(function($controller, $mdDialog, $httpBackend, $rootScope, $state, InviteService, AuthService, 
+    beforeEach(inject(function($controller, $mdDialog, $httpBackend, $rootScope, $state, InviteService, AuthService,
         InstitutionService) {
         httpBackend = $httpBackend;
         mdDialog = $mdDialog;
@@ -52,7 +52,7 @@
         institutionService = InstitutionService;
         httpBackend.when('GET', INSTITUTIONS_URI + institution.key).respond(institution);
         httpBackend.when('GET', REQUESTS_URI + institution.key + "/requests/user").respond([]);
-        httpBackend.when('GET', INSTITUTIONS_URI + institution.key + '/members').respond([member]);
+        httpBackend.when('GET', INSTITUTIONS_URI + institution.key + '/members').respond([member, user]);
         httpBackend.when('GET', 'app/institution/institution_page.html').respond(200);
         httpBackend.when('GET', "app/main/main.html").respond(200);
         httpBackend.when('GET', "app/home/home.html").respond(200);
@@ -107,7 +107,7 @@
             });
 
             it('Should remove event of events', function() {
-                httpBackend.expect('DELETE', INSTITUTIONS_URI + institution.key + 
+                httpBackend.expect('DELETE', INSTITUTIONS_URI + institution.key +
                         "/members?removeMember=" + member.key).respond(200);
                 manageMemberCtrl.removeMember("$event", member);
 

--- a/frontend/test/specs/managementMembersControllerSpec.js
+++ b/frontend/test/specs/managementMembersControllerSpec.js
@@ -85,7 +85,7 @@
 
     describe('ManagementMembersController properties', function() {
 
-        it('should exist one sent sent invitations', function() {
+        it('should exist two sent sent invitations', function() {
             expect(manageMemberCtrl.sent_invitations).toEqual([invite, otherInvite]);
             expect(manageMemberCtrl.sent_invitations.length).toBe(2);
         });


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
When the admin tried to invite an user that had already been invited or that was a member he was redirected to the error page because the frontend wasn't catching the error.
</p>

<p><b>Solution:</b>
_.includes and _.some weren't doing what they were supposed to do when were implemented. Then, I've fixed inviteeIsMember and inviteeIsInvited, the functions that used to use the first ones.
</p>

<p><b>TODO/FIXME:</b> n/a</p>
