### PR TITLE
Sending notification when the user is removed

### DIFF
--- a/backend/admin.py
+++ b/backend/admin.py
@@ -346,7 +346,7 @@ class ResetHandler(BaseHandler):
             user.follow(certbio.key)
             create_profile(user, certbio)
         for user in [jorge, mayza, maiana, luiz,
-                     raoni, ruan, tiago, admin]:
+                     raoni, ruan, tiago, admin, dalton]:
             certbio.follow(user.key)
             user.follow(certbio.key)
 

--- a/backend/handlers/institution_members_handler.py
+++ b/backend/handlers/institution_members_handler.py
@@ -52,11 +52,14 @@ class InstitutionMembersHandler(BaseHandler):
                 entity_type,
                 institution.key.urlsafe())
 
+        subject = "Remoção de vínculo"
         body = """Você foi removido por %s da instituição %s.
 
         Equipe e-CIS
         """ % (user.name, institution.name)
         send_message_email(
             member.email,
-            body
+            body,
+            subject
+
         )

--- a/backend/handlers/institution_members_handler.py
+++ b/backend/handlers/institution_members_handler.py
@@ -8,6 +8,7 @@ from handlers.institution_handler import is_admin
 from utils import login_required
 from utils import Utils
 from utils import json_response
+from service_messages import send_message_notification
 
 from handlers.base_handler import BaseHandler
 
@@ -40,3 +41,12 @@ class InstitutionMembersHandler(BaseHandler):
         member = member.get()
 
         institution.remove_member(member)
+
+        if member.state != 'inactive':
+            entity_type = 'DELETE_MEMBER'
+            message = {'type': 'DELETE_MEMBER', 'from': user.name.encode('utf8')}
+            send_message_notification(
+                member.key.urlsafe(),
+                json.dumps(message),
+                entity_type,
+                institution.key.urlsafe())

--- a/backend/handlers/institution_members_handler.py
+++ b/backend/handlers/institution_members_handler.py
@@ -9,6 +9,7 @@ from utils import login_required
 from utils import Utils
 from utils import json_response
 from service_messages import send_message_notification
+from service_messages import send_message_email
 
 from handlers.base_handler import BaseHandler
 
@@ -50,3 +51,12 @@ class InstitutionMembersHandler(BaseHandler):
                 json.dumps(message),
                 entity_type,
                 institution.key.urlsafe())
+
+        body = """Você foi removido por %s da instituição %s.
+
+        Equipe e-CIS
+        """ % (user.name, institution.name)
+        send_message_email(
+            member.email,
+            body
+        )

--- a/backend/handlers/institution_members_handler.py
+++ b/backend/handlers/institution_members_handler.py
@@ -62,5 +62,4 @@ class InstitutionMembersHandler(BaseHandler):
             member.email,
             body,
             subject
-
         )

--- a/backend/handlers/institution_members_handler.py
+++ b/backend/handlers/institution_members_handler.py
@@ -53,10 +53,11 @@ class InstitutionMembersHandler(BaseHandler):
                 institution.key.urlsafe())
 
         subject = "Remoção de vínculo"
-        body = """Você foi removido por %s da instituição %s.
+        body = """Lamentamos informar que seu vínculo com a instituição %s
+        foi removido pelo administrador %s.
 
         Equipe e-CIS
-        """ % (user.name, institution.name)
+        """ % (institution.name, user.name)
         send_message_email(
             member.email,
             body,

--- a/backend/service_messages.py
+++ b/backend/service_messages.py
@@ -30,7 +30,7 @@ def send_message_notification(user_key, message, entity_type, entity_key):
         }
     )
 
-def send_message_email(invitee, body):
+def send_message_email(invitee, body, subject=None):
     """Method of send email.
 
     Keywords arguments:
@@ -42,7 +42,7 @@ def send_message_email(invitee, body):
         target='worker',
         params={
             'invitee': invitee,
-            'subject': "Convite plataforma e-CIS",
+            'subject': subject or "Convite plataforma e-CIS",
             'body': body
         }
     )

--- a/backend/service_messages.py
+++ b/backend/service_messages.py
@@ -30,6 +30,9 @@ def send_message_notification(user_key, message, entity_type, entity_key):
         }
     )
 
+# TODO: Change the method to receive the subject dynamically
+# And change its calls
+# @author: Raoni Smaneoto
 def send_message_email(invitee, body, subject=None):
     """Method of send email.
 

--- a/backend/test/institution_member_handler_test.py
+++ b/backend/test/institution_member_handler_test.py
@@ -41,6 +41,17 @@ class InstitutionMemberHandlerTest(TestBaseHandler):
         self.assertTrue(mock_method.called, "send_message_notification should've been called.")
 
     @patch('utils.verify_token', return_value={'email': 'user@gmail.com'})
+    @mock.patch('service_messages.send_message_email')
+    def test_delete_with_email(self, verify_token, mock_method):
+        """Test if a notification is sent when the member is deleted."""
+        # Call the delete method
+        self.testapp.delete("/api/institutions/%s/members?removeMember=%s" %
+                            (self.institution.key.urlsafe(), self.second_user.key.urlsafe()))
+
+        # Assert that mock_method has been called
+        self.assertTrue(mock_method.called, "send_message_email should've been called.")
+
+    @patch('utils.verify_token', return_value={'email': 'user@gmail.com'})
     def test_delete(self, verify_token):
         """Test delete method with an user that is not admin"""
         # Assert the initial conditions

--- a/backend/test/institution_member_handler_test.py
+++ b/backend/test/institution_member_handler_test.py
@@ -5,6 +5,7 @@ from test_base_handler import TestBaseHandler
 from models.user import User
 from models.institution import Institution
 from handlers.institution_members_handler import InstitutionMembersHandler
+import mock
 from mock import patch
 
 
@@ -20,6 +21,24 @@ class InstitutionMemberHandlerTest(TestBaseHandler):
              ], debug=True)
         cls.testapp = cls.webtest.TestApp(app)
         initModels(cls)
+
+    @patch('utils.verify_token', return_value={'email': 'user@gmail.com'})
+    @mock.patch('service_messages.send_message_notification')
+    def test_delete_with_notification(self, verify_token, mock_method):
+        """Test if a notification is sent when the member is deleted."""
+        # Set up the second_user
+        self.second_user.institutions = [self.institution.key, self.other_institution.key]
+        self.institution.members.append(self.second_user.key)
+        self.other_institution.members.append(self.second_user.key)
+        self.second_user.put()
+        self.institution.put()
+        self.other_institution.put()
+        # Call the delete method
+        self.testapp.delete("/api/institutions/%s/members?removeMember=%s" %
+                            (self.institution.key.urlsafe(), self.second_user.key.urlsafe()))
+
+        # Assert that mock_method has been called
+        self.assertTrue(mock_method.called, "send_message_notification should've been called.")
 
     @patch('utils.verify_token', return_value={'email': 'user@gmail.com'})
     def test_delete(self, verify_token):
@@ -141,10 +160,21 @@ def initModels(cls):
     cls.institution.posts = []
     cls.institution.admin = cls.user.key
     cls.institution.put()
+    # another institution
+    cls.other_institution = Institution()
+    cls.other_institution.name = 'other_institution'
+    cls.other_institution.state = 'active'
+    cls.other_institution.email = 'other_institution@email.com'
+    cls.other_institution.members = [cls.user.key]
+    cls.other_institution.followers = [cls.user.key, cls.second_user.key]
+    cls.other_institution.posts = []
+    cls.other_institution.admin = cls.user.key
+    cls.other_institution.put()
 
-    cls.user.institutions = [cls.institution.key]
-    cls.user.institutions_admin = [cls.institution.key]
+    cls.user.institutions = [cls.institution.key, cls.other_institution.key]
+    cls.user.institutions_admin = [cls.institution.key, cls.other_institution.key]
     cls.user.add_permission("publish_post", cls.institution.key.urlsafe())
+    cls.user.add_permission("publish_post", cls.other_institution.key.urlsafe())
     cls.user.put()
     cls.second_user.institutions = [cls.institution.key]
     cls.second_user.add_permission(

--- a/frontend/notification/notificationDirective.js
+++ b/frontend/notification/notificationDirective.js
@@ -17,7 +17,7 @@
                 state: "app.post"
             },
             "DELETE_MEMBER": {
-                icon: "delete"
+                icon: "clear"
             },
             "POST": {
                 icon: "inbox",

--- a/frontend/notification/notificationDirective.js
+++ b/frontend/notification/notificationDirective.js
@@ -16,6 +16,9 @@
                 icon: "comment",
                 state: "app.post"
             },
+            "DELETE_MEMBER": {
+                icon: "delete"
+            },
             "POST": {
                 icon: "inbox",
                 state: "app.post"

--- a/frontend/notification/notificationService.js
+++ b/frontend/notification/notificationService.js
@@ -28,7 +28,8 @@
             'REJECT_INVITE_USER': 'rejeitou o convite para ser membro de sua instituição',
             'ACCEPT_INVITE_USER': 'aceitou o convite para ser membro de sua instituição',
             'REJECT_INVITE_INSTITUTION': 'rejeitou o seu convite para ser administrador',
-            'ACCEPT_INVITE_INSTITUTION': 'aceitou o seu convite para ser administrador'
+            'ACCEPT_INVITE_INSTITUTION': 'aceitou o seu convite para ser administrador',
+            'DELETE_MEMBER': 'removeu você de sua instituição'
         };
 
         var POST_NOTIFICATION = 'POST';


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
Send notification when a member is removed from an institution.
</p>

<p><b>Solution:</b>
I've called send_notification method from the handler where the user is removed and adapted the notification's message.
</p>

<p><b>TODO/FIXME:</b>
Refactor send_message_email to receive the subject dynamically and change its calls.
</p>
