### PR TITLE
Search by occupation area

### DIFF
--- a/backend/search_module.py
+++ b/backend/search_module.py
@@ -26,7 +26,8 @@ def createDocument(institution):
         'name': institution.name,
         'state': institution.state,
         'admin': admin,
-        'acronym': institution.acronym
+        'acronym': institution.acronym,
+        'occupation_area': institution.occupation_area
     }
     # Make the structure of the document by setting the fields and its id.
     document = search.Document(
@@ -37,7 +38,8 @@ def createDocument(institution):
             search.TextField(name='name', value=content['name']),
             search.TextField(name='state', value=content['state']),
             search.TextField(name='admin', value=content['admin']),
-            search.TextField(name='acronym', value=content['acronym'])
+            search.TextField(name='acronym', value=content['acronym']),
+            search.TextField(name='occupation_area', value=content['occupation_area'])
         ]
     )
     saveDocument(document)
@@ -71,7 +73,7 @@ def getDocuments(value, state):
     query_string = makeQueryStr(value, state)
     index = search.Index(INDEX_NAME)
     query_options = search.QueryOptions(
-        returned_fields=['name', 'state', 'admin', 'acronym']
+        returned_fields=['name', 'state', 'admin', 'acronym', 'occupation_area']
     )
     query = search.Query(query_string=query_string, options=query_options)
     documents = index.search(query)
@@ -103,7 +105,7 @@ def makeQueryStr(value, state):
             state_string += states[i]
         else:
             state_string += " OR " + states[i]
-    return "(name: %s OR acronym: %s) AND state: %s" % (value, value, state_string)
+    return "(name: %s OR acronym: %s OR occupation_area: %s) AND state: %s" % (value, value, value, state_string)
 
 
 def deleteDocument(doc_id):

--- a/backend/test/search_handler_test.py
+++ b/backend/test/search_handler_test.py
@@ -59,6 +59,11 @@ class SearchHandlerTest(TestBaseHandler):
         institutions = self.testapp.get(
             "/api/search/institution?value=%s&state=%s" % ('SPLAB', 'pending'))
         self.assertTrue('SPLAB' in institutions)
+        # Search for institutions by its occupation area
+        institutions = self.testapp.get(
+            "/api/search/institution?value=%s&state=%s"
+            % ('Universidades', 'active'))
+        self.assertTrue('CERTBIO' in institutions)
 
     def tearDown(cls):
         """Deactivate the test."""
@@ -83,6 +88,7 @@ def initModels(cls):
     cls.certbio.name = 'Lab. de Desenvolvimento de Biomateriais do Nordeste'
     cls.certbio.acronym = 'CERTBIO'
     cls.certbio.state = 'active'
+    cls.certbio.occupation_area = 'Universidades'
     cls.certbio.members = [cls.mayza.key]
     cls.certbio.followers = [cls.mayza.key]
     cls.certbio.admin = cls.mayza.key
@@ -92,6 +98,7 @@ def initModels(cls):
     cls.splab.name = 'Software Practice Laboratory'
     cls.splab.acronym = 'SPLAB'
     cls.splab.state = 'pending'
+    cls.splab.occupation_area = 'Universidades'
     cls.splab.members = [cls.mayza.key]
     cls.splab.followers = [cls.mayza.key]
     cls.splab.admin = cls.mayza.key

--- a/backend/test/search_handler_test.py
+++ b/backend/test/search_handler_test.py
@@ -62,8 +62,8 @@ class SearchHandlerTest(TestBaseHandler):
         # Search for institutions by its occupation area
         institutions = self.testapp.get(
             "/api/search/institution?value=%s&state=%s"
-            % ('Universidades', 'active'))
-        self.assertTrue('CERTBIO' in institutions)
+            % ('Universidades', 'active, pending'))
+        self.assertTrue('CERTBIO' and 'SPLAB' in institutions)
 
     def tearDown(cls):
         """Deactivate the test."""

--- a/frontend/institution/institution_page.html
+++ b/frontend/institution/institution_page.html
@@ -49,7 +49,7 @@
                             </div>
                             <div layout="row" flex>
                                 <div layout="column" flex>
-                                    <p><b>Área de Atuação:</b> {{ institutionCtrl.current_institution.occupation_area ? institutionCtrl.occupation_areas[institutionCtrl.current_institution.occupation_area] : 'Não informado' }}</p>
+                                    <p><b>Área de Atuação:</b> {{ institutionCtrl.current_institution.occupation_area ? institutionCtrl.current_institution.occupation_area : 'Não informado' }}</p>
                                 </div>
                                 <span flex md-truncate></span>
                                 <div layout="column" flex>
@@ -66,8 +66,8 @@
                                 </div>
                             </div>
                             <p align="justify"><b>Descrição:</b> {{ institutionCtrl.current_institution.description ? institutionCtrl.current_institution.description : 'Não informado' }}</p>
-                            
-                            <p ng-if="institutionCtrl.hasParentActive(institutionCtrl.current_institution)" align="justify"><b>Instituição hierarquicamente superior:</b> 
+
+                            <p ng-if="institutionCtrl.hasParentActive(institutionCtrl.current_institution)" align="justify"><b>Instituição hierarquicamente superior:</b>
                             <a href class="hyperlink" ng-click="institutionCtrl.goToInstitution(institutionCtrl.current_institution.parent_institution.key)">
                                 {{ institutionCtrl.current_institution.parent_institution.name}}</p>
                             </a>

--- a/frontend/institution/submit_form.html
+++ b/frontend/institution/submit_form.html
@@ -135,7 +135,7 @@
                 <label>Área de Atuação</label>
                 <md-select  name="occupationArea" ng-model="configInstCtrl.newInstitution.occupation_area" required>
                   <md-option  ng-repeat="area in configInstCtrl.occupationAreas | orderBy: 'name'"
-                    ng-value="area.value">{{ area.name }}
+                    ng-value="area.name">{{ area.name }}
                   </md-option>
                 </md-select>
                 <div ng-messages="instForm.occupationArea.$error">


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
Now it's possible to search by the institution's occupation area.
</p>

<p><b>Solution:</b>
I've added another field in the docs and changed the language that the occupation area was saved from english to portuguese, to avoid translate and to keep the full text search. 
</p>

<p><b>TODO/FIXME:</b> n/a</p>
