### PR TITLE
Receive subject as a parameter in send_message_email

### DIFF
--- a/backend/models/invite.py
+++ b/backend/models/invite.py
@@ -76,10 +76,12 @@ class Invite(PolyModel):
 
         Equipe e-CIS
         """ % (host)
+        subject = "Convite plataforma e-CIS"
 
         send_message_email(
             receiver_email,
-            body
+            body,
+            subject
         )
 
     def send_notification(self, user, receiver_key, entity_type=None):

--- a/backend/service_messages.py
+++ b/backend/service_messages.py
@@ -30,10 +30,8 @@ def send_message_notification(user_key, message, entity_type, entity_key):
         }
     )
 
-# TODO: Change the method to receive the subject dynamically
-# And change its calls
-# @author: Raoni Smaneoto
-def send_message_email(invitee, body, subject=None):
+
+def send_message_email(invitee, body, subject):
     """Method of send email.
 
     Keywords arguments:
@@ -45,7 +43,7 @@ def send_message_email(invitee, body, subject=None):
         target='worker',
         params={
             'invitee': invitee,
-            'subject': subject or "Convite plataforma e-CIS",
+            'subject': subject,
             'body': body
         }
     )


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
The method send_message_email had a default and static subject, which have made it impossible to send an email with different subjects, for example.
</p>

<p><b>Solution:</b>
Now the subject is received as a parameter, what made it became dynamic.
</p>

<p><b>TODO/FIXME:</b> n/a</p>
