### PR TITLE
Enable html5 on angularJS

### DIFF
--- a/backend/index.yaml
+++ b/backend/index.yaml
@@ -2,7 +2,8 @@ indexes:
 - kind: Post
   properties:
   - name: institution
-  - name: last_modified_date
+  - name: last_modified_date 
+    direction: desc
 - kind: Post
   properties:
   - name: state

--- a/backend/models/invite_institution.py
+++ b/backend/models/invite_institution.py
@@ -51,7 +51,7 @@ class InviteInstitution(Invite):
         body = body or """
         Sua empresa %s foi convidada a se cadastrar na plataforma.
         Para realizar o cadastro crie sua conta pessoal em
-        http://%s/app/#/institution/%s/%s/new_invite/INSTITUTION
+        http://%s/institution/%s/%s/new_invite/INSTITUTION
         e proceda com o cadastro da sua empresa.
         Equipe e-CIS
         """ % (self.suggestion_institution_name, host, institution_key, invite_key)

--- a/backend/models/invite_user.py
+++ b/backend/models/invite_user.py
@@ -56,7 +56,7 @@ class InviteUser(Invite):
 
         body = body or """Oi:
         Voce tem um novo convite. Acesse:
-        http://%s/app/#/institution/%s/%s/new_invite/USER
+        http://%s/institution/%s/%s/new_invite/USER
 
         Equipe e-CIS """ % (host, institution_key, invite_key)
         super(InviteUser, self).send_email(host, self.invitee, body)

--- a/backend/models/request_institution.py
+++ b/backend/models/request_institution.py
@@ -34,7 +34,7 @@ class RequestInstitution(Request):
         # TODO Set this message
         body = body or """Olá
         Sua instituição recebeu um novo pedido. Acesse:
-        http://%s/app/#/requests/%s/institution_children para analisar o mesmo.
+        http://%s/requests/%s/institution_children para analisar o mesmo.
 
         Equipe e-CIS """ % (host, request_key)
 

--- a/backend/models/request_institution_children.py
+++ b/backend/models/request_institution_children.py
@@ -27,7 +27,7 @@ class RequestInstitutionChildren(Request):
         # TODO Set this message
         body = body or """Olá
         Sua instituição recebeu um novo pedido. Acesse:
-        http://%s/app/#/requests/%s/institution_children para analisar o mesmo.
+        http://%s/requests/%s/institution_children para analisar o mesmo.
 
         Equipe e-CIS """ % (host, request_key)
         super(RequestInstitutionChildren, self).send_email(host, requested_email, body)

--- a/backend/models/request_institution_parent.py
+++ b/backend/models/request_institution_parent.py
@@ -27,7 +27,7 @@ class RequestInstitutionParent(Request):
         # TODO Set this message
         body = body or """Olá
         Sua instituição recebeu um novo pedido. Acesse:
-        http://%s/app/#/requests/%s/institution_parent para analisar o mesmo.
+        http://%s/requests/%s/institution_parent para analisar o mesmo.
 
         Equipe e-CIS """ % (host, request_key)
         super(RequestInstitutionParent, self).send_email(host, requested_email, body)

--- a/backend/models/request_user.py
+++ b/backend/models/request_user.py
@@ -61,7 +61,7 @@ class RequestUser(Invite):
         # TODO Set this message
         body = body or """Oi:
         Voce tem um novo convite. Acesse:
-        http://%s/app/#/institution/%s/%s/new_invite/USER
+        http://%s/institution/%s/%s/new_invite/USER
 
         Equipe e-CIS """ % (host, institution_key, invite_key)
         super(RequestUser, self).send_email(host, admin_email, body)
@@ -79,7 +79,7 @@ class RequestUser(Invite):
         Você foi aceito na plataforma como membro da instituição
         %s, seja bem vindo ao e-CIS.
         Realize seu login no link abaixo:
-        http://%s/app/#/signin
+        http://%s/signin
 
         Equipe e-CIS""" % (institution_name, host)
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -198,8 +198,7 @@
 
         $urlRouterProvider.otherwise("/");
 
-        $locationProvider.html5Mode(false);
-        $locationProvider.hashPrefix(''); // Uses # instead #!
+        $locationProvider.html5Mode(true);
 
         $httpProvider.interceptors.push('BearerAuthInterceptor');
 

--- a/frontend/frontend.yaml
+++ b/frontend/frontend.yaml
@@ -6,10 +6,6 @@ service: frontend
 default_expiration: "1s"
 
 handlers:
-- url: /
-  static_files: index.html
-  upload: index.html
-
 - url: /app/(.*)
   static_files: \1
   upload: (.*)

--- a/frontend/frontend.yaml
+++ b/frontend/frontend.yaml
@@ -6,10 +6,14 @@ service: frontend
 default_expiration: "1s"
 
 handlers:
-- url: /app/
+- url: /
   static_files: index.html
   upload: index.html
 
 - url: /app/(.*)
   static_files: \1
   upload: (.*)
+
+- url: /(.*)
+  static_files: index.html
+  upload: index.html

--- a/frontend/test/specs/suggestInstitutionControllerSpec.js
+++ b/frontend/test/specs/suggestInstitutionControllerSpec.js
@@ -23,7 +23,7 @@
         key: '1239'
     };
 
-    var url_splab = window.location.href + "#/institution/"+ splab.key + "/details";
+    var url_splab = window.location.href + "/institution/"+ splab.key + "/details";
 
     beforeEach(module('app'));
 


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> The frontend used a hash (#) on it's URL to be able to understand which state was reffered.</p>

<p><b>Solution:</b> Enabling html5mode on AngularJs, it's possible to remove that hash and have a clean URL displayed to the user. A URL mapping on frontend.yaml was needed to AppEngine understand the redirection.</p>

<p><b>TODO/FIXME:</b> n/a</p>
