### PR TITLE
Fix name of message notification

### DIFF
--- a/frontend/notification/notificationService.js
+++ b/frontend/notification/notificationService.js
@@ -28,7 +28,7 @@
             'REJECT_INVITE_USER': 'rejeitou o convite para ser membro de sua instituição',
             'ACCEPT_INVITE_USER': 'aceitou o convite para ser membro de sua instituição',
             'REJECT_INVITE_INSTITUTION': 'rejeitou o seu convite para ser administrador',
-            'ACCEPTED_INVITE_INSTITUTION': 'aceitou o seu convite para ser administrador',
+            'ACCEPT_INVITE_INSTITUTION': 'aceitou o seu convite para ser administrador',
             'DELETE_MEMBER': 'removeu você de sua instituição',
             'ACCEPTED_LINK': 'aceitou sua solicitação de vínculo'
         };


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> The notification send when the user accept one invite to be admin of one institution was undefined</p>

<p><b>Solution:</b> The problem is on translate message because the correct name of notification is ACCEPT_INVITE_INSTITUTION </p>

<p><b>TODO/FIXME:</b> n/a</p>
