### PR TITLE
Fix wrong variable sintaxe on main script

### DIFF
--- a/ecis
+++ b/ecis
@@ -59,7 +59,7 @@ case "$1" in
 
         if [ ! -z $2 ]; then
             version=$2
-            url=$version"."BACKEND_DOMAIN
+            url=$version"."$BACKEND_DOMAIN
             set_backend_url $url
 
             if [ ! -z $3 ]; then # Especified one or more yaml configuration files


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> The variable BACKEND_DOMAIN has been accessed without the $ character, turning the variable into a string.</p>

<p><b>Solution:</b> Add the $ to the variable.</p>

<p><b>TODO/FIXME:</b> n/a</p>
