### PR TITLE
Fix tests of reply comment handler test

### DIFF
--- a/backend/handlers/reply_comment_handler.py
+++ b/backend/handlers/reply_comment_handler.py
@@ -78,10 +78,7 @@ class ReplyCommentHandler(BaseHandler):
                 post.key.urlsafe()
             )
 
-        print "passou aqui>>>>>>>>>>>>>>>>>>>>>>>"
         self.response.write(json.dumps(Utils.toJson(reply)))
-        print "passou aqui>>>>>>>>>>>>>>>>>>>>>>>"
-
 
     @json_response
     @login_required

--- a/backend/handlers/reply_comment_handler.py
+++ b/backend/handlers/reply_comment_handler.py
@@ -78,7 +78,10 @@ class ReplyCommentHandler(BaseHandler):
                 post.key.urlsafe()
             )
 
+        print "passou aqui>>>>>>>>>>>>>>>>>>>>>>>"
         self.response.write(json.dumps(Utils.toJson(reply)))
+        print "passou aqui>>>>>>>>>>>>>>>>>>>>>>>"
+
 
     @json_response
     @login_required
@@ -96,7 +99,7 @@ class ReplyCommentHandler(BaseHandler):
                       "Comment with activity can't be removed", NotAuthorizedException)
 
         check_permission(user, institution, post, replies.get(reply_id))
-        
+
         del replies[reply_id]
 
         post.put()

--- a/backend/test/reply_comment_handler_test.py
+++ b/backend/test/reply_comment_handler_test.py
@@ -14,6 +14,7 @@ from utils import Utils
 
 import json
 
+
 class ReplyCommentHandlerTest(TestBaseHandler):
     """Test the post_handler class."""
 
@@ -47,7 +48,7 @@ class ReplyCommentHandlerTest(TestBaseHandler):
         # Call the post method
         data_reply = {"text": "reply of comment",
                         "institution_key": self.institution.key.urlsafe()}
-        self.testapp.post(self.URL_REPLY_COMMENT % 
+        self.testapp.post(self.URL_REPLY_COMMENT %
             (self.user_post.key.urlsafe(), self.comment.id),
                           json.dumps(data_reply))
 
@@ -71,9 +72,17 @@ class ReplyCommentHandlerTest(TestBaseHandler):
 
         # Assert that Exception is raised when the user try
         # to comment a deleted post
-        with self.assertRaises(Exception):
-            self.testapp.post(self.URL_REPLY_COMMENT % self.user_post.key.urlsafe(),
+        with self.assertRaises(Exception) as raises_context:
+            comment_id = 21456
+            self.testapp.post(self.URL_REPLY_COMMENT % (self.user_post.key.urlsafe(), comment_id),
                               json.dumps(data_reply))
+
+        exception_message = self.get_message_exception(str(raises_context.exception))
+        self.assertEqual(
+            exception_message,
+            "Error! This post has been deleted",
+            "Expected exception message must be equal to " +
+            "Error! This post has been deleted")
 
     @patch('utils.verify_token', return_value=USER_DATA)
     def test_delete(self, verify_token):
@@ -106,7 +115,6 @@ class ReplyCommentHandlerTest(TestBaseHandler):
         user_comment = self.user_post.key.get().get_comment(self.comment.id)
         self.assertEquals(len(user_comment.get('replies')), 0,
                           "Expected size of replies list should be zero")
-        
 
     def tearDown(cls):
         """Deactivate the test."""


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> Tests that expected an exception to be thrown were not verifying that the exception thrown was expected.</p>

<p><b>Solution:</b> I added checks for the thrown exceptions to see if they match  expected.</p>

<p><b>TODO/FIXME:</b> n/a</p>
