### PR TITLE
Fix home layout and post creation card

### DIFF
--- a/frontend/home/home.html
+++ b/frontend/home/home.html
@@ -116,10 +116,10 @@
     </md-sidenav>
 
     <!-- CONTENT -->
-    <div flex-md="75" flex-gt-md="50" layout-align="center center">
-      <div flex-md="100" flex-gt-md="100" layout="column">
+    <div flex-md="75" flex-gt-md="50" layout-align="center center" layout="column">
+      <div layout="column">
         <div>
-          <save-post flex is-dialog="false" posts="homeCtrl.posts"></save-post>
+          <save-post is-dialog="false" posts="homeCtrl.posts"></save-post>
         </div>
         <md-content id="content" class="body hide-scrollbar">         
             <div layout="row">

--- a/frontend/post/save_post.html
+++ b/frontend/post/save_post.html
@@ -1,4 +1,4 @@
-<md-card flex="100">
+<md-card flex="90" flex-gt-xs="95">
   <md-card-content layout="row" style="padding:5px;">
     <md-card-content>
       <img ng-src="{{ postCtrl.getInstPhotoUrl()}}"


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> The timeline on the home page had the height larger than the screen size, causing an unnecessary scrollbar, as well as, the post creation card width. </p>

<p><b>Solution:</b> Use the right set of layout rules of the angular material.</p>

<p><b>TODO/FIXME:</b> n/a</p>
