### PR TITLE
CSS for small icon buttons

### DIFF
--- a/frontend/styles/custom.css
+++ b/frontend/styles/custom.css
@@ -476,3 +476,19 @@ md-switch.md-checked .md-thumb {
 md-switch.md-checked .md-bar {
     background-color: #80CBC4;
 }
+
+.md-button.sm-icon-button {
+    height:32px; 
+    width: 32px; 
+    min-height: 32px;
+    min-width: 0;
+    padding: 0;
+    border-radius: 50%;
+}
+
+.sm-icon-button md-icon {
+    font-size: 20px; 
+    margin: 6px; 
+    width: unset !important; 
+    min-width: unset !important;
+}


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> Angular Material don't have small icon buttons and the new system design needs them.</p>

<p><b>Solution:</b> Create a new css class to style the md-buttons.</p>

<p><b>TODO/FIXME:</b> n/a</p>
