### PR TITLE
Bug on showing the name of who deleted the post

### DIFF
--- a/frontend/post/post.js
+++ b/frontend/post/post.js
@@ -47,3 +47,8 @@ Post.prototype.hasImage = function hasImage() {
 Post.prototype.isDeleted = function isDeleted() {
     return this.state === 'deleted';
 };
+
+Post.prototype.remove = function remove(userName) {
+    this.state = 'deleted';
+    this.last_modified_by = userName;
+};

--- a/frontend/post/postDetailsDirective.js
+++ b/frontend/post/postDetailsDirective.js
@@ -31,6 +31,7 @@
             $mdDialog.show(confirm).then(function() {
                 PostService.deletePost(postDetailsCtrl.post).then(function success() {
                     postDetailsCtrl.post.state = 'deleted';
+                    postDetailsCtrl.post.last_modified_by = postDetailsCtrl.user.name;
                     MessageService.showToast('Post excluído com sucesso');
                 }, function error(response) {
                     MessageService.showToast(response.data.msg);

--- a/frontend/post/postDetailsDirective.js
+++ b/frontend/post/postDetailsDirective.js
@@ -29,9 +29,9 @@
                 .cancel('Cancelar');
 
             $mdDialog.show(confirm).then(function() {
+                postDetailsCtrl.post = new Post(postDetailsCtrl.post);
                 PostService.deletePost(postDetailsCtrl.post).then(function success() {
-                    postDetailsCtrl.post.state = 'deleted';
-                    postDetailsCtrl.post.last_modified_by = postDetailsCtrl.user.name;
+                    postDetailsCtrl.post.remove(postDetailsCtrl.user.name);
                     MessageService.showToast('Post excluído com sucesso');
                 }, function error(response) {
                     MessageService.showToast(response.data.msg);

--- a/frontend/test/specs/postSpec.js
+++ b/frontend/test/specs/postSpec.js
@@ -125,4 +125,18 @@ describe('Test Post Model:', function() {
             expect(post.hasImage()).toBe(false);
         });
     });
+
+    describe('remove()', function() {
+        it('should set the post state to false', function() {
+            post = new Post(data);
+            post.remove("userName");
+            expect(post.state).toBe('deleted');
+        });
+
+        it('should set post property last_modified_by to userName', function() {
+            post = new Post(data);
+            post.remove("userName");
+            expect(post.last_modified_by).toBe('userName');
+        });
+    });
 });

--- a/frontend/test/specs/postSpec.js
+++ b/frontend/test/specs/postSpec.js
@@ -127,7 +127,7 @@ describe('Test Post Model:', function() {
     });
 
     describe('remove()', function() {
-        it('should set the post state to false', function() {
+        it('should set the post state to deleted', function() {
             post = new Post(data);
             post.remove("userName");
             expect(post.state).toBe('deleted');


### PR DESCRIPTION

<p><b>Bug description:</b> When the post was deleted, the last_modified_by property was not been updated on frontend. So, it was been showing the name of the last person who modified the post and not the user who deleted it</p>

<p><b>Solution:</b> Set post property last_modified_by to current user name after the post is successfully  deleted</p>
