### PR TITLE
Adding a missing verification in showEventImage()

### DIFF
--- a/frontend/event/eventController.js
+++ b/frontend/event/eventController.js
@@ -255,7 +255,7 @@
             var isImageEmpty = dialogCtrl.event.photo_url === "";
             var isImageNull = dialogCtrl.event.photo_url === null;
             var isImageUndefined = dialogCtrl.event.photo_url === undefined;
-            return !isImageEmpty && !isImageNull && !isImageUndefined;
+            return !isImageEmpty && !isImageNull && !isImageUndefined && !dialogCtrl.showImage();
         };
 
         dialogCtrl.cleanImage = function() {


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
When an event with the end_time >= start_time was created, an exception was raised and the event's image showed twice in the dialog, if there was one in the event previously.
</p>

<p><b>Solution:</b>
I've added another verification into showEventImage method.
</p>

<p><b>TODO/FIXME:</b> n/a</p>
