### PR TITLE
fixing showing files when post is changed of common to survey

### DIFF
--- a/frontend/post/postDirective.js
+++ b/frontend/post/postDirective.js
@@ -239,7 +239,7 @@
         };
 
         postCtrl.clearPost = function clearPost() {
-            postCtrl.typePost === "Common" ? postCtrl.post = {}: ()=>{};
+            if (postCtrl.typePost === "Common") postCtrl.post = {};
             postCtrl.pdfFiles = [];
             postCtrl.hideImage();
             postCtrl.options = [];

--- a/frontend/post/postDirective.js
+++ b/frontend/post/postDirective.js
@@ -56,7 +56,7 @@
         postCtrl.choiceSurvey = function() {
             if(postCtrl.typePost === "Common"){
                 postCtrl.typePost = "Survey";
-                postCtrl.options = [];
+                postCtrl.clearPost();
                 postCtrl.options.push(angular.copy(option_empty));
                 postCtrl.options.push(angular.copy(option_empty));
             }
@@ -239,11 +239,10 @@
         };
 
         postCtrl.clearPost = function clearPost() {
-            postCtrl.post = {};
+            postCtrl.typePost == "Common" ? postCtrl.post = {}: ()=>{};
             postCtrl.pdfFiles = [];
             postCtrl.hideImage();
             postCtrl.options = [];
-            postCtrl.typePost = "Common";
         };
 
         postCtrl.showVideo = function showVideo() {

--- a/frontend/post/postDirective.js
+++ b/frontend/post/postDirective.js
@@ -239,7 +239,7 @@
         };
 
         postCtrl.clearPost = function clearPost() {
-            postCtrl.typePost == "Common" ? postCtrl.post = {}: ()=>{};
+            postCtrl.typePost === "Common" ? postCtrl.post = {}: ()=>{};
             postCtrl.pdfFiles = [];
             postCtrl.hideImage();
             postCtrl.options = [];


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> When the type of post is changed of common to survey, the files in post keep displayed in post.</p>

<p><b>Solution:</b> Added different behavior in clearPost function when type of post is common or survey.</p>

<p><b>TODO/FIXME:</b> n/a</p>
