### PR TITLE
Create new layout of search filter

### DIFF
--- a/frontend/search/search.html
+++ b/frontend/search/search.html
@@ -5,24 +5,15 @@
           <md-card>
             <md-subhead layout-padding class="md-primary" md-colors="{background: 'teal-900'}">Filtrar pesquisa</md-subhead>
             <md-card-content>
-                <md-radio-group flex>
-                    <md-list
-                    md-cols="5" md-cols-gt-md="15"
-                    md-row-height="1:1"
-                    md-gutter="4px" md-gutter-gt-sm="4px">
-                        <md-list-item md-rowspan="1" md-colspan="1" md-colspan-sm="1">
-                            <div class="column">
-                                <md-radio-button class="md-primary" ng-value="'*'" ng-click="searchCtrl.searchByActuationArea('*')"><b>Pesquisar em todas as áreas</b></md-radio-button>
-                            </div>
-                        </md-list-item>
-                        <md-list-item md-rowspan="1" md-colspan="1" md-colspan-sm="1"
-                        ng-repeat="actuation_area in searchCtrl.actuationAreas | orderBy: 'name'">
-                            <div class="column">
-                                <md-radio-button class="md-primary" ng-value="actuation_area.name" ng-click="searchCtrl.searchByActuationArea(actuation_area.name)">{{actuation_area.name}}</md-radio-button>
-                            </div>
-                        </md-list-item>
-                    </md-list>
-                </md-radio-group>
+                <md-select ng-model="searCtrl.search" placeholder="Filtrar por...">
+                    <md-option ng-click="searchCtrl.searchByActuationArea('*')" value="Pesquisar em todas as áreas">
+                        Pesquisar em todas as áreas
+                    </md-option>
+                    <md-option ng-repeat="actuation_area in searchCtrl.actuationAreas | orderBy: 'name'" 
+                        ng-value="actuation_area.name" ng-click="searchCtrl.searchByActuationArea(actuation_area.name)">
+                        {{actuation_area.name}}
+                    </md-option>
+                </md-select>
             </md-card-content>
           </md-card>
         </div>


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> Search filter content layout is too large and passing from the screen.</p>

<p><b>Solution:</b> Create a select that encapsulates all the options.</p>

<p><b>TODO/FIXME:</b> n/a</p>
