### PR TITLE
Changing display of institution suggestions

### DIFF
--- a/frontend/invites/existing_institutions.html
+++ b/frontend/invites/existing_institutions.html
@@ -2,7 +2,7 @@
 
     <div>
         <md-dialog-content class="md-dialog-content" layout="column">
-            <h3>{{suggestInstCtrl.showMessage()}}</h3>
+            <h3>{{suggestInstCtrl.titleMessage()}}</h3>
             <md-radio-group ng-model="suggestInstCtrl.chosen_institution" required flex>
                 <md-list ng-repeat="institution in suggestInstCtrl.institutions" flex>
                     <md-list-item class="md-2-line" ng-if="suggestInstCtrl.showSuggestion(institution.state)">
@@ -14,17 +14,17 @@
                             </md-button>
                         </div>
                     </md-list-item>
-                    <md-list-item ng-if="suggestInstCtrl.isPending(institution.state)" ng-click="null" class="md-2-line">
+                    <md-list-item ng-if="suggestInstCtrl.suggestionToSimpleInvite(institution.state)" ng-click="null" class="md-2-line">
                         <div class="md-list-item-text">
                             <h3 style="color: #616161">{{institution.name}}</h3>
-                            <p style="color: #9E9E9E">Convite enviado para: {{institution.admin}}<p>
+                            <p style="color: #9E9E9E">{{suggestInstCtrl.instStatusMessage(institution.admin, institution.state)}}<p>
                         </div>
                         <md-icon style="color: #424242">error</md-icon>
                     </md-list-item>
                 </md-list>
                 <md-list>
-                    <md-list-item>
-                        <md-radio-button ng-value="null" class="md-primary" flex>Não, desejo convidar outra instituição</md-radio-button>
+                    <md-list-item ng-if="suggestInstCtrl.isHierarchy">
+                        <md-radio-button ng-value="null" class="md-primary" flex>Convidar nova instituição</md-radio-button>
                     </md-list-item>
                 </md-list>
             </md-radio-group>

--- a/frontend/invites/suggestInstitutionController.js
+++ b/frontend/invites/suggestInstitutionController.js
@@ -16,7 +16,8 @@
         var PENDING_STATE = "pending";
 
         suggestInstCtrl.goToInstitution = function goToInstitution(institutionKey) {
-            window.open(makeUrl(institutionKey), '_blank');
+            const url = $state.href('app.institution', {institutionKey: institutionKey});
+            window.open(url, '_blank');
         };
 
         suggestInstCtrl.cancel = function cancel() {
@@ -27,6 +28,11 @@
             return suggestInstCtrl.isActive(state) && suggestInstCtrl.isHierarchy;
         };
 
+        suggestInstCtrl.suggestionToSimpleInvite = function suggestionToSimpleInvite(state) {
+            return suggestInstCtrl.isPending(state) ||
+                (suggestInstCtrl.isActive(state) && !suggestInstCtrl.isHierarchy);
+        }
+
         suggestInstCtrl.isActive = function isActive(state) {
             return state === ACTIVE_STATE;
         };
@@ -34,12 +40,6 @@
         suggestInstCtrl.isPending = function isPending(state) {
             return state === PENDING_STATE;
         };
-
-        function makeUrl(institutionKey){
-            var currentUrl = window.location.href;
-            currentUrl = currentUrl.split('#');
-            return currentUrl[0] + $state.href('app.institution', {institutionKey: institutionKey});
-        }
 
         suggestInstCtrl.checkAndSendInvite = function checkAndSendInvite() {
             if (suggestInstCtrl.chosen_institution) {
@@ -51,14 +51,22 @@
             }
         };
 
-        suggestInstCtrl.showMessage = function() {
-            var message;
-            if(suggestInstCtrl.institutions.length === 1) {
-                message = 'A instituição que você quer convidar é essa?';
-            } else {
-                message = 'A instituição que você quer convidar é alguma dessas?';
-            }
-            return message;
+        suggestInstCtrl.titleMessage = function() {
+            const oneInst = 'Já existe uma instituição com esse nome.';
+            const moreThanOneInst = 'Já existem instituições com esse nome.';
+            const question = ' Deseja convidar mesmo assim?';
+            const selectMsg = 'instituição existente se deseja convidá-la ou selecione a opção de convidar uma nova instituição.'
+            return suggestInstCtrl.institutions.length === 1 ?
+                suggestInstCtrl.isHierarchy ? oneInst +
+                ' Selecione a ' + selectMsg :
+                oneInst + question : suggestInstCtrl.isHierarchy ?
+                moreThanOneInst + ' Selecione uma ' + selectMsg :
+                moreThanOneInst + question;
+        };
+
+        suggestInstCtrl.instStatusMessage = function instStatusMessage(admin, state) {
+            return suggestInstCtrl.isPending(state) ?
+                'Instituição pendente - convite enviado para: ' + admin : 'Instituição ativa'
         };
 
         function sendInviteToExistingInst() {

--- a/frontend/invites/suggestInstitutionController.js
+++ b/frontend/invites/suggestInstitutionController.js
@@ -52,16 +52,14 @@
         };
 
         suggestInstCtrl.titleMessage = function() {
-            const oneInst = 'Já existe uma instituição com esse nome.';
-            const moreThanOneInst = 'Já existem instituições com esse nome.';
-            const question = ' Deseja convidar mesmo assim?';
-            const selectMsg = 'instituição existente se deseja convidá-la ou selecione a opção de convidar uma nova instituição.'
-            return suggestInstCtrl.institutions.length === 1 ?
-                suggestInstCtrl.isHierarchy ? oneInst +
-                ' Selecione a ' + selectMsg :
-                oneInst + question : suggestInstCtrl.isHierarchy ?
-                moreThanOneInst + ' Selecione uma ' + selectMsg :
-                moreThanOneInst + question;
+            const hasOnlyOneInst = suggestInstCtrl.institutions.length === 1;
+            const firstPhrase = hasOnlyOneInst ?
+                'Já existe uma instituição com esse nome. ' : 'Já existem instituições com esse nome. ';
+            const optionsPhrase = hasOnlyOneInst ?
+                'Selecione a instituição existente se deseja convidá-la ou selecione a opção de convidar uma nova instituição.' :
+                'Selecione uma das instituições existentes se deseja convidá-la ou selecione a opção de convidar uma nova instituição';
+            const lastPhrase = suggestInstCtrl.isHierarchy ? optionsPhrase : 'Deseja convidar mesmo assim?';
+            return firstPhrase + lastPhrase;
         };
 
         suggestInstCtrl.instStatusMessage = function instStatusMessage(admin, state) {

--- a/frontend/test/specs/suggestInstitutionControllerSpec.js
+++ b/frontend/test/specs/suggestInstitutionControllerSpec.js
@@ -23,7 +23,7 @@
         key: '1239'
     };
 
-    var url_splab = window.location.href + "/institution/"+ splab.key + "/details";
+    var url_splab = "/institution/"+ splab.key + "/details";
 
     beforeEach(module('app'));
 


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> When the admin of institution invite institution without hierarchy the dialog displayed is the same when the invite is to hierarchy. Also, button "ver detalhes" is behaving unexpectedly, not redirecting to institution page.</p>

<p><b>Solution:</b> Changing the display to be different in case of invite are without hierarchy and delegate the responsibility of redirect to institution page to $state of ui-router library.</p>

<p><b>TODO/FIXME:</b> n/a</p>
