### PR TITLE
Remove is_admin_of_requested_inst from request institution links handlers

### DIFF
--- a/backend/handlers/institution_children_request_handler.py
+++ b/backend/handlers/institution_children_request_handler.py
@@ -5,10 +5,8 @@ import json
 from utils import Utils
 from utils import login_required
 from utils import json_response
-from utils import is_admin_of_requested_inst
 from handlers.base_handler import BaseHandler
 from google.appengine.ext import ndb
-import permissions
 from custom_exceptions.notAuthorizedException import NotAuthorizedException
 
 
@@ -27,9 +25,9 @@ class InstitutionChildrenRequestHandler(BaseHandler):
     @json_response
     @ndb.transactional(xg=True)
     def put(self, user, request_key):
-        """Handler PUT Requests. Change request status from 'sent' to 'accepted'."""
+        """Handler PUT Requests. Change status of children_request from 'sent' to 'accepted'."""
         request = ndb.Key(urlsafe=request_key).get()
-        Utils._assert(not user.has_permission('link_insts', request.institution_requested_key.urlsafe()),
+        Utils._assert(not user.has_permission('answer_link_inst_request', request.institution_requested_key.urlsafe()),
                         'User is not allowed to accept link between institutions',
                         NotAuthorizedException)
         request.change_status('accepted')
@@ -52,7 +50,7 @@ class InstitutionChildrenRequestHandler(BaseHandler):
     def delete(self, user, request_key):
         """Change request status from 'sent' to 'rejected'."""
         request = ndb.Key(urlsafe=request_key).get()
-        Utils._assert(not user.has_permission('link_insts', request.institution_requested_key.urlsafe()),
+        Utils._assert(not user.has_permission('answer_link_inst_request', request.institution_requested_key.urlsafe()),
                         'User is not allowed to reject link between institutions',
                         NotAuthorizedException)
         request.change_status('rejected')

--- a/backend/handlers/institution_children_request_handler.py
+++ b/backend/handlers/institution_children_request_handler.py
@@ -2,11 +2,15 @@
 """Institution Children Request Handler."""
 
 import json
+from utils import Utils
 from utils import login_required
 from utils import json_response
 from utils import is_admin_of_requested_inst
 from handlers.base_handler import BaseHandler
 from google.appengine.ext import ndb
+import permissions
+from custom_exceptions.notAuthorizedException import NotAuthorizedException
+
 
 
 class InstitutionChildrenRequestHandler(BaseHandler):
@@ -21,11 +25,13 @@ class InstitutionChildrenRequestHandler(BaseHandler):
 
     @login_required
     @json_response
-    @is_admin_of_requested_inst
     @ndb.transactional(xg=True)
     def put(self, user, request_key):
-        """Handler PUT Requests."""
+        """Handler PUT Requests. Change request status from 'sent' to 'accepted'."""
         request = ndb.Key(urlsafe=request_key).get()
+        Utils._assert(not user.has_permission('link_insts', request.institution_requested_key.urlsafe()),
+                        'User is not allowed to accept link between institutions',
+                        NotAuthorizedException)
         request.change_status('accepted')
         request.put()
 
@@ -43,11 +49,12 @@ class InstitutionChildrenRequestHandler(BaseHandler):
 
     @login_required
     @json_response
-    @is_admin_of_requested_inst
     def delete(self, user, request_key):
         """Change request status from 'sent' to 'rejected'."""
-        request_key = ndb.Key(urlsafe=request_key)
-        request = request_key.get()
+        request = ndb.Key(urlsafe=request_key).get()
+        Utils._assert(not user.has_permission('link_insts', request.institution_requested_key.urlsafe()),
+                        'User is not allowed to reject link between institutions',
+                        NotAuthorizedException)
         request.change_status('rejected')
         request.put()
 

--- a/backend/handlers/institution_children_request_handler.py
+++ b/backend/handlers/institution_children_request_handler.py
@@ -2,12 +2,10 @@
 """Institution Children Request Handler."""
 
 import json
-from utils import Utils
 from utils import login_required
 from utils import json_response
 from handlers.base_handler import BaseHandler
 from google.appengine.ext import ndb
-from custom_exceptions.notAuthorizedException import NotAuthorizedException
 
 
 
@@ -27,9 +25,9 @@ class InstitutionChildrenRequestHandler(BaseHandler):
     def put(self, user, request_key):
         """Handler PUT Requests. Change status of children_request from 'sent' to 'accepted'."""
         request = ndb.Key(urlsafe=request_key).get()
-        Utils._assert(not user.has_permission('answer_link_inst_request', request.institution_requested_key.urlsafe()),
-                        'User is not allowed to accept link between institutions',
-                        NotAuthorizedException)
+        user.has_permission('answer_link_inst_request',
+                            'User is not allowed to accept link between institutions',
+                            request.institution_requested_key.urlsafe())
         request.change_status('accepted')
         request.put()
 
@@ -50,9 +48,9 @@ class InstitutionChildrenRequestHandler(BaseHandler):
     def delete(self, user, request_key):
         """Change request status from 'sent' to 'rejected'."""
         request = ndb.Key(urlsafe=request_key).get()
-        Utils._assert(not user.has_permission('answer_link_inst_request', request.institution_requested_key.urlsafe()),
-                        'User is not allowed to reject link between institutions',
-                        NotAuthorizedException)
+        user.has_permission('answer_link_inst_request',
+                            'User is not allowed to reject link between institutions',
+                            request.institution_requested_key.urlsafe())
         request.change_status('rejected')
         request.put()
 

--- a/backend/handlers/institution_parent_request_handler.py
+++ b/backend/handlers/institution_parent_request_handler.py
@@ -2,11 +2,14 @@
 """Institution Parent Request Handler."""
 
 import json
+from utils import Utils
 from utils import login_required
 from utils import json_response
 from utils import is_admin_of_requested_inst
 from handlers.base_handler import BaseHandler
 from google.appengine.ext import ndb
+import permissions
+from custom_exceptions.notAuthorizedException import NotAuthorizedException
 
 
 class InstitutionParentRequestHandler(BaseHandler):
@@ -21,11 +24,13 @@ class InstitutionParentRequestHandler(BaseHandler):
 
     @login_required
     @json_response
-    @is_admin_of_requested_inst
     @ndb.transactional(xg=True)
     def put(self, user, request_key):
-        """Handler PUT Requests."""
+        """Handler PUT Requests. Change request status from 'sent' to 'accepted'."""
         request = ndb.Key(urlsafe=request_key).get()
+        Utils._assert(not user.has_permission('link_insts', request.institution_requested_key.urlsafe()),
+                'User is not allowed to accept link between institutions',
+                NotAuthorizedException)
         request.change_status('accepted')
         request.put()
 
@@ -39,11 +44,12 @@ class InstitutionParentRequestHandler(BaseHandler):
 
     @login_required
     @json_response
-    @is_admin_of_requested_inst
     def delete(self, user, request_key):
         """Change request status from 'sent' to 'rejected'."""
-        request_key = ndb.Key(urlsafe=request_key)
-        request = request_key.get()
+        request = ndb.Key(urlsafe=request_key).get()
+        Utils._assert(not user.has_permission('link_insts', request.institution_requested_key.urlsafe()),
+                    'User is not allowed to reject link between institutions',
+                    NotAuthorizedException)
         request.change_status('rejected')
         request.put()
 

--- a/backend/handlers/institution_parent_request_handler.py
+++ b/backend/handlers/institution_parent_request_handler.py
@@ -2,12 +2,10 @@
 """Institution Parent Request Handler."""
 
 import json
-from utils import Utils
 from utils import login_required
 from utils import json_response
 from handlers.base_handler import BaseHandler
 from google.appengine.ext import ndb
-from custom_exceptions.notAuthorizedException import NotAuthorizedException
 
 
 class InstitutionParentRequestHandler(BaseHandler):
@@ -26,9 +24,9 @@ class InstitutionParentRequestHandler(BaseHandler):
     def put(self, user, request_key):
         """Handler PUT Requests. Change status of parent_request from 'sent' to 'accepted'."""
         request = ndb.Key(urlsafe=request_key).get()
-        Utils._assert(not user.has_permission('answer_link_inst_request', request.institution_requested_key.urlsafe()),
-                'User is not allowed to accept link between institutions',
-                NotAuthorizedException)
+        user.has_permission('answer_link_inst_request',
+                            'User is not allowed to accept link between institutions',
+                            request.institution_requested_key.urlsafe())
         request.change_status('accepted')
         request.put()
 
@@ -45,9 +43,9 @@ class InstitutionParentRequestHandler(BaseHandler):
     def delete(self, user, request_key):
         """Change request status from 'sent' to 'rejected'."""
         request = ndb.Key(urlsafe=request_key).get()
-        Utils._assert(not user.has_permission('answer_link_inst_request', request.institution_requested_key.urlsafe()),
-                    'User is not allowed to reject link between institutions',
-                    NotAuthorizedException)
+        user.has_permission('answer_link_inst_request',
+                            'User is not allowed to reject link between institutions',
+                            request.institution_requested_key.urlsafe())
         request.change_status('rejected')
         request.put()
 

--- a/backend/handlers/institution_parent_request_handler.py
+++ b/backend/handlers/institution_parent_request_handler.py
@@ -5,10 +5,8 @@ import json
 from utils import Utils
 from utils import login_required
 from utils import json_response
-from utils import is_admin_of_requested_inst
 from handlers.base_handler import BaseHandler
 from google.appengine.ext import ndb
-import permissions
 from custom_exceptions.notAuthorizedException import NotAuthorizedException
 
 
@@ -26,9 +24,9 @@ class InstitutionParentRequestHandler(BaseHandler):
     @json_response
     @ndb.transactional(xg=True)
     def put(self, user, request_key):
-        """Handler PUT Requests. Change request status from 'sent' to 'accepted'."""
+        """Handler PUT Requests. Change status of parent_request from 'sent' to 'accepted'."""
         request = ndb.Key(urlsafe=request_key).get()
-        Utils._assert(not user.has_permission('link_insts', request.institution_requested_key.urlsafe()),
+        Utils._assert(not user.has_permission('answer_link_inst_request', request.institution_requested_key.urlsafe()),
                 'User is not allowed to accept link between institutions',
                 NotAuthorizedException)
         request.change_status('accepted')
@@ -47,7 +45,7 @@ class InstitutionParentRequestHandler(BaseHandler):
     def delete(self, user, request_key):
         """Change request status from 'sent' to 'rejected'."""
         request = ndb.Key(urlsafe=request_key).get()
-        Utils._assert(not user.has_permission('link_insts', request.institution_requested_key.urlsafe()),
+        Utils._assert(not user.has_permission('answer_link_inst_request', request.institution_requested_key.urlsafe()),
                     'User is not allowed to reject link between institutions',
                     NotAuthorizedException)
         request.change_status('rejected')

--- a/backend/permissions.py
+++ b/backend/permissions.py
@@ -7,7 +7,7 @@ DEFAULT_ADMIN_PERMISSIONS  = [
     "update_inst",
     "remove_posts", 
     "remove_insts",
-    "link_insts"
+    "answer_link_inst_request"
     ]
 
 DEFAULT_SUPER_USER_PERMISSIONS = [

--- a/backend/permissions.py
+++ b/backend/permissions.py
@@ -6,7 +6,8 @@ DEFAULT_ADMIN_PERMISSIONS  = [
     "remove_inst", 
     "update_inst",
     "remove_posts", 
-    "remove_insts"
+    "remove_insts",
+    "link_insts"
     ]
 
 DEFAULT_SUPER_USER_PERMISSIONS = [

--- a/backend/test/institution_children_request_handler_test.py
+++ b/backend/test/institution_children_request_handler_test.py
@@ -130,7 +130,7 @@ def initModels(cls):
     cls.inst_requested.address = cls.address
     cls.inst_requested.put()
     # Update Institutions admin by other user
-    cls.other_user.add_permission("link_insts", cls.inst_requested.key.urlsafe())
+    cls.other_user.add_permission("answer_link_inst_request", cls.inst_requested.key.urlsafe())
     cls.other_user.put()
     # new Request
     cls.request = RequestInstitutionChildren()

--- a/backend/test/institution_children_request_handler_test.py
+++ b/backend/test/institution_children_request_handler_test.py
@@ -130,7 +130,7 @@ def initModels(cls):
     cls.inst_requested.address = cls.address
     cls.inst_requested.put()
     # Update Institutions admin by other user
-    cls.user.add_permission("link_insts", cls.inst_requested.key.urlsafe())
+    cls.other_user.add_permission("link_insts", cls.inst_requested.key.urlsafe())
     cls.other_user.put()
     # new Request
     cls.request = RequestInstitutionChildren()

--- a/backend/test/institution_children_request_handler_test.py
+++ b/backend/test/institution_children_request_handler_test.py
@@ -71,9 +71,9 @@ class InstitutionChildrenRequestHandlerTest(TestBaseHandler):
 
         exception_message = self.get_message_exception(ex.exception.message)
         self.assertEqual(
-            "Error! User is not admin",
+            "Error! User is not allowed to accept link between institutions",
             exception_message,
-            "Expected error message is Error! User is not admin")
+            "Expected error message is Error! User is not allowed to accept link between institutions")
 
     @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
     @mock.patch('service_messages.send_message_notification')
@@ -130,7 +130,7 @@ def initModels(cls):
     cls.inst_requested.address = cls.address
     cls.inst_requested.put()
     # Update Institutions admin by other user
-    cls.other_user.institutions_admin = [cls.inst_requested.key]
+    cls.user.add_permission("link_insts", cls.inst_requested.key.urlsafe())
     cls.other_user.put()
     # new Request
     cls.request = RequestInstitutionChildren()

--- a/backend/test/institution_parent_request_handler_test.py
+++ b/backend/test/institution_parent_request_handler_test.py
@@ -116,7 +116,7 @@ def initModels(cls):
     cls.inst_requested.address = cls.address
     cls.inst_requested.put()
     # Update Institutions admin by other user
-    cls.user.add_permission("link_insts", cls.inst_requested.key.urlsafe())
+    cls.other_user.add_permission("link_insts", cls.inst_requested.key.urlsafe())
     cls.other_user.put()
     # new Request
     cls.request = RequestInstitutionParent()

--- a/backend/test/institution_parent_request_handler_test.py
+++ b/backend/test/institution_parent_request_handler_test.py
@@ -116,7 +116,7 @@ def initModels(cls):
     cls.inst_requested.address = cls.address
     cls.inst_requested.put()
     # Update Institutions admin by other user
-    cls.other_user.add_permission("link_insts", cls.inst_requested.key.urlsafe())
+    cls.other_user.add_permission("answer_link_inst_request", cls.inst_requested.key.urlsafe())
     cls.other_user.put()
     # new Request
     cls.request = RequestInstitutionParent()

--- a/backend/test/institution_parent_request_handler_test.py
+++ b/backend/test/institution_parent_request_handler_test.py
@@ -57,9 +57,9 @@ class InstitutionParentRequestHandlerTest(TestBaseHandler):
 
         exception_message = self.get_message_exception(ex.exception.message)
         self.assertEqual(
-            "Error! User is not admin",
+            "Error! User is not allowed to accept link between institutions",
             exception_message,
-            "Expected error message is Error! User is not admin")
+            "Expected error message is Error! User is not allowed to accept link between institutions")
 
     @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
     @mock.patch('service_messages.send_message_notification')
@@ -116,7 +116,7 @@ def initModels(cls):
     cls.inst_requested.address = cls.address
     cls.inst_requested.put()
     # Update Institutions admin by other user
-    cls.other_user.institutions_admin = [cls.inst_requested.key]
+    cls.user.add_permission("link_insts", cls.inst_requested.key.urlsafe())
     cls.other_user.put()
     # new Request
     cls.request = RequestInstitutionParent()


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> Changing decorator verification to permissions verification in institution_parent_request_handler and institution_children_request_handler.</p>

<p><b>Solution:</b> Removing decorator from put and delete methods and verifying if the user has permission to link institutions.</p>

<p><b>TODO/FIXME:</b> n/a</p>
