### PR TITLE
Fix pdf visualization in institution page

### DIFF
--- a/frontend/institution/portfolioDialog.html
+++ b/frontend/institution/portfolioDialog.html
@@ -1,4 +1,4 @@
-
-<md-dialog layout="column" flex-gt-lg="80" flex-lg="90" aria-label="portfólio">
-    <embed ng-src="{{ctrl.portfolioUrl}}" flex flex-gt-lg flex-lg="90" type='application/pdf'></embed>
+<md-dialog layout-fill flex="80" aria-label="portfólio">
+        <embed layout="column" ng-src="{{ctrl.portfolioUrl}}" flex="100" type='application/pdf'></embed>
 </md-dialog>
+    


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> PDF preview is broken when the screen is too large.</p>

<p><b>Solution:</b> Modify the layout of the preview so that it fills the screen.</p>

<p><b>TODO/FIXME:</b> n/a</p>
