### PR TITLE
Fix landing page responsiveness with css media orientation

### DIFF
--- a/landing/styles/custom.css
+++ b/landing/styles/custom.css
@@ -76,6 +76,13 @@ body {
     }
 }
 
+
+@media screen and (max-width: 960px) and (orientation:landscape) {
+    .section {
+        min-height: 1000px;
+    }
+}
+
 @media screen and (min-width: 960px) {
     .header-image {
         width: 70%;

--- a/landing/styles/custom.css
+++ b/landing/styles/custom.css
@@ -76,7 +76,6 @@ body {
     }
 }
 
-
 @media screen and (max-width: 960px) and (orientation:landscape) {
     .section {
         min-height: 1000px;


### PR DESCRIPTION

<p><b>Feature/Bug description:</b> The landing page when turned into mobile responsive version and rotated the screen to landscape mode, it was causing the section content to overflow the div.

![peek 2017-12-14 09-28](https://user-images.githubusercontent.com/2967288/33992584-fde4d5b2-e0b1-11e7-93fc-c7814caafae8.gif)

</p>

<p><b>Solution:</b> Use CSS media query with a orientation parameter, that tell's the browser to respond accordingly to the internal styles. In this case, it was necessary to set a minimum height to prevent that the section content overflows.

```
@media screen and (max-width: 960px) and (orientation:landscape) {
    .section {
        min-height: 1000px;
    }
}
```
![peek 2017-12-14 09-29](https://user-images.githubusercontent.com/2967288/33992591-02b87fee-e0b2-11e7-8a5e-784b31ae0dcb.gif)

</p>

<p><b>TODO/FIXME:</b> n/a</p>
