### PR TITLE
Adding notification in pending requests toolbar on invite_inst page

### DIFF
--- a/frontend/invites/invite_institution.html
+++ b/frontend/invites/invite_institution.html
@@ -67,12 +67,12 @@
         </md-card>
 
         <md-card flex layout="column">
-          <md-toolbar md-colors="{background: 'teal-500'}" layout="row"
+          <md-toolbar md-colors="(inviteInstCtrl.sent_requests.length > 0) ? {background: 'light-green-500'} : {background: 'teal-500'}" layout="row"
             ng-click="inviteInstCtrl.toggleElement('showRequests')" class="clickable-no-hover">
             <div class="md-toolbar-tools" flex layout="row" layout-align="center center">
               <h1>
-                <md-icon>feedback</md-icon>
-                Convites requisitados
+                <md-icon ng-class="(inviteInstCtrl.sent_requests.length > 0) ? 'notification-badge' : ''" data-badge>feedback</md-icon>
+                <span md-colors="{color: 'grey-50'}">Convites requisitados</span>
               </h1>
               <span flex md-truncate></span>
               <md-button class="md-icon-button md-secondary">


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> The toolbar of pending requests not display notification when have new requests.</p>

<p><b>Solution:</b> Adding notification in toolbar of pending requests in inivite_institution page.</p>

![screenshot from 2017-12-15 11-00-04](https://user-images.githubusercontent.com/20300259/34045402-821749ca-e187-11e7-9919-605011aa4f7e.png)


<p><b>TODO/FIXME:</b> n/a</p>
