### PR TITLE
Add alert to update browser

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -16,6 +16,17 @@
 
   <div layout="column" ui-view="main" flex></div>
 
+  <script> 
+    var $buoop = {notify:{i:14,f:-4,o:-4,s:-2,c:-4},insecure:true,api:5,noclose:true,l:"pt-br"};
+    function $buo_f(){ 
+     var e = document.createElement("script"); 
+     e.src = "//browser-update.org/update.min.js"; 
+     document.body.appendChild(e);
+    };
+    try {document.addEventListener("DOMContentLoaded", $buo_f,false)}
+    catch(e){window.attachEvent("onload", $buo_f)}
+  </script>
+
   <!-- Angular Material requires Angular.js Libraries -->
   <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.6.4/angular.min.js"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.6.4/angular-animate.min.js"></script>


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> The landing page is broken in some browsers, like Internet Explorer, because those are out of date with the new web technologies (CSS3, HTML5, etc).</p>

<p><b>Solution:</b> Display an alert that tells the user that his browser needs to be updated to a new browser or a new version.

This solution was implemented using the [Browser Update](https://github.com/browser-update/browser-update) module, under MIT license.
</p>

![screenshot from 2017-12-20 09-09-55](https://user-images.githubusercontent.com/2967288/34206922-1e835974-e567-11e7-8076-fe2c46b064d6.png)

<b>PS.:</b> In case the need to test, It is just type the key value `test:true` to the variable `buoop`.

<p><b>TODO/FIXME:</b> n/a</p>
