### PR TITLE
Add generic param to ecis run script

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,8 @@ pipeline {
 
                 bower install --allow-root
 
-                karma start --single-run'''            
+                karma start --single-run'''
+            
           }
         )
       }
@@ -40,5 +41,17 @@ pipeline {
   environment {
     GIT_COMMITTER_NAME = 'user'
     GIT_COMMITTER_EMAIL = 'email'
+  }
+  post {
+    success {
+      slackSend(color: '#00FF00', message: "SUCCESSFUL: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
+      
+    }
+    
+    failure {
+      slackSend(color: '#FF0000', message: "FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
+      
+    }
+    
   }
 }

--- a/ecis
+++ b/ecis
@@ -70,7 +70,7 @@ case "$1" in
 
         set_landingpage_url $LANDINGPAGE_LOCAL
 
-        dev_appserver.py $APP_YAML $FRONTEND_YAML $BACKEND_YAML $WORKER_YAML
+        dev_appserver.py $APP_YAML $FRONTEND_YAML $BACKEND_YAML $WORKER_YAML $2
     ;;
 
     test)


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> The ecis run script not allow pass parameters to the dev_appserver,
 difficulting to set some flags when serving the server.</p>

<p><b>Solution:</b> Add a new parameter to the script that can receive any of the dev_appserver flags,
 like sendmail flag.</p>

<p><b>TODO/FIXME:</b> n/a</p>
