### PR TITLE
Fixing description height

### DIFF
--- a/frontend/institution/create_inst_form.html
+++ b/frontend/institution/create_inst_form.html
@@ -207,7 +207,7 @@
                                     Uma breve descrição da sua instituição
                                   </label>
                                   <textarea ng-model="configInstCtrl.newInstitution.description" maxlength="1100"
-                                    md-select-on-focus required>
+                                    md-select-on-focus required style="max-height: 100px; overflow-y: scroll;">
                                   </textarea>
                                   <md-icon title="{{configInstCtrl.descriptionGuide}}" style="font-size: 20px;">
                                         help_outline


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
When the description was too large the view would break.
</p>

<p><b>Solution:</b>
I've inserted max-height and overflow-y css' property into <textarea>.
</p>

<p><b>TODO/FIXME:</b> n/a</p>
