### PR TITLE
Fixed bug in view user inactive

### DIFF
--- a/frontend/user/userInactiveController.js
+++ b/frontend/user/userInactiveController.js
@@ -36,6 +36,11 @@
             return userInactiveCtrl.choicedInst && !userInactiveCtrl.isFinished;
         };
 
+        userInactiveCtrl.showButtonNext =  function showButtonNext(){
+            var hasInstFound = userInactiveCtrl.institutions.length > 0;
+            return !userInactiveCtrl.choicedInst && hasInstFound;
+        };
+
         userInactiveCtrl.sendRequest = function sendRequest() {
             var dataInvite = {
                 institution_key : userInactiveCtrl.institutionSelect.key,

--- a/frontend/user/user_inactive.html
+++ b/frontend/user/user_inactive.html
@@ -63,7 +63,7 @@
                         </md-list>
                     </md-content>
                     <div layout-gt-xs="row" layout-xs="column" layout-align="end center"
-                        ng-if="!userInactiveCtrl.choicedInst">
+                        ng-if="userInactiveCtrl.showButtonNext()">
                         <md-button flex-order-xs="1" class="md-raised md-primary" md-colors="{background: 'teal-500'}" 
                         ng-click="userInactiveCtrl.confirmInst()">AVANÇAR</md-button>
                     </div>


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> The button 'AVANÇAR' of user_inactive was showing all time but should show only when exists institutions searched by user</p>

![next](https://user-images.githubusercontent.com/18709274/34301618-0f2efe1e-e70c-11e7-9ace-8344b5f459de.png)

![nnexiste](https://user-images.githubusercontent.com/18709274/34301619-0f4a6a82-e70c-11e7-9a88-09df19a759db.png)

![none](https://user-images.githubusercontent.com/18709274/34301620-0f65606c-e70c-11e7-8c8c-c27adbfb483c.png)

<p><b>Solution:</b> Added verification if there are institutions found.</p>

<p><b>TODO/FIXME:</b> n/a</p>
