### PR TITLE
Improving display of hours and adding official site in event page

### DIFF
--- a/backend/models/event.py
+++ b/backend/models/event.py
@@ -20,6 +20,9 @@ class Event(ndb.Model):
     # Userful link to the event
     useful_links = ndb.JsonProperty(indexed=False, repeated=True)
 
+    # Official site of event
+    official_site = ndb.StringProperty()
+
     # Programation of event
     programation = ndb.StringProperty(indexed=False)
 
@@ -94,6 +97,7 @@ class Event(ndb.Model):
         event.title = data.get('title')
         event.photo_url = data.get('photo_url')
         event.useful_links = data.get('useful_links', [])
+        event.official_site = data.get('official_site')
         event.author_key = author.key
         event.author_photo = author.photo_url
         event.author_name = author.name
@@ -126,6 +130,7 @@ class Event(ndb.Model):
             'programation': event.programation,
             'video_url': event.video_url,
             'useful_links': event.useful_links,
+            'official_site': event.official_site,
             'address': event.address.make() if event.address else {},
             'local': event.local,
             'start_time': start_time,

--- a/frontend/event/eventController.js
+++ b/frontend/event/eventController.js
@@ -213,6 +213,8 @@
         dialogCtrl.usefulLinks = [];
         dialogCtrl.isAnotherCountry = false;
         dialogCtrl.steps = [true, false, false];
+        dialogCtrl.now = new Date();
+        dialogCtrl.start_time = null;
         var emptyUrl = {
             url: '',
             description: ''
@@ -244,6 +246,12 @@
 
         dialogCtrl.getEmptyUrl = function(urlList){
             return _.find(urlList, emptyUrl);
+        };
+
+        dialogCtrl.createInitDate = function() {
+           if(dialogCtrl.event.start_time) {
+                dialogCtrl.start_time = new Date(dialogCtrl.event.start_time);
+           }
         };
 
         function saveImageAndCallEventFunction(callback) {

--- a/frontend/event/event_details.html
+++ b/frontend/event/event_details.html
@@ -83,10 +83,18 @@
                   <md-icon style="font-size: 40px;">access_time</md-icon>
                 </p>
                 <div layout="column" style="margin-left: 40px;">
-                  <h3>{{eventDetailsCtrl.event.start_time | amUtc | amLocal | amDateFormat:'H:mm' | uppercase}} às
-                      {{eventDetailsCtrl.event.end_time | amUtc | amLocal | amDateFormat:'H:mm' | uppercase}}
+                  <h3>
+                      De {{eventCtrl.event.start_time | amUtc | amLocal | amDateFormat: 'DD' }}
+                       de {{eventCtrl.event.start_time | amUtc | amLocal | amDateFormat: 'MMM' }}
+                       de {{eventCtrl.event.start_time | amUtc | amLocal | amDateFormat: 'YYYY' }}
+                       às {{eventDetailsCtrl.event.start_time | amUtc | amLocal | amDateFormat:'H:mm' | uppercase}}
                   </h3>
-                  <span style="margin-top: -15px; color: #959796;">Carga horária: não definida</span>
+                  <span style="margin-top: -15px; color: #959796;">
+                      até {{eventCtrl.event.start_time | amUtc | amLocal | amDateFormat: 'DD' }}
+                       de {{eventCtrl.event.start_time | amUtc | amLocal | amDateFormat: 'MMM' }}
+                        de {{eventCtrl.event.start_time | amUtc | amLocal | amDateFormat: 'YYYY' }}
+                      às {{eventDetailsCtrl.event.end_time | amUtc | amLocal | amDateFormat:'H:mm' | uppercase}}
+                  </span>
                 </div>
               </div>
             </div>
@@ -97,7 +105,12 @@
                   <md-icon style="font-size: 40px;">public</md-icon>
                 </p>
                 <div layout="column" style="margin-left: 40px;">
-                  <h3>Não definido</h3>
+                  <h3>
+                    <a target="_blank" href="{{eventDetailsCtrl.event.official_site}}">
+                      {{eventDetailsCtrl.event.official_site ?
+                      eventDetailsCtrl.event.official_site : 'Não definido'}}
+                    </a>
+                  </h3>
                 </div>
               </div>
             </div>

--- a/frontend/event/event_details.html
+++ b/frontend/event/event_details.html
@@ -69,7 +69,8 @@
             </p>
             <div layout="column" style="margin-left: 40px;">
               <h3>{{eventDetailsCtrl.event.local}}</h3>
-              <span style="margin-top: -15px; color: #959796;">{{eventDetailsCtrl.event.address.street}}, {{eventDetailsCtrl.event.address.number}}
+              <span style="margin-top: -15px; color: #959796;">{{eventDetailsCtrl.event.address.street}},
+                 {{eventDetailsCtrl.event.address.number ? eventDetailsCtrl.event.address.number : 'S/N'}}
                 </br>
                 {{eventDetailsCtrl.event.address.city}} - {{eventDetailsCtrl.event.address.federal_state}} - {{eventDetailsCtrl.event.address.country}}
               </span>
@@ -84,21 +85,15 @@
                 </p>
                 <div layout="column" style="margin-left: 40px;">
                   <h3>
-                      De {{eventCtrl.event.start_time | amUtc | amLocal | amDateFormat: 'DD' }}
-                       de {{eventCtrl.event.start_time | amUtc | amLocal | amDateFormat: 'MMM' }}
-                       de {{eventCtrl.event.start_time | amUtc | amLocal | amDateFormat: 'YYYY' }}
-                       às {{eventDetailsCtrl.event.start_time | amUtc | amLocal | amDateFormat:'H:mm' | uppercase}}
+                      De {{eventDetailsCtrl.event.start_time | amUtc | amLocal | amCalendar:referenceTime:formats }}
                   </h3>
                   <span style="margin-top: -15px; color: #959796;">
-                      até {{eventCtrl.event.start_time | amUtc | amLocal | amDateFormat: 'DD' }}
-                       de {{eventCtrl.event.start_time | amUtc | amLocal | amDateFormat: 'MMM' }}
-                        de {{eventCtrl.event.start_time | amUtc | amLocal | amDateFormat: 'YYYY' }}
-                      às {{eventDetailsCtrl.event.end_time | amUtc | amLocal | amDateFormat:'H:mm' | uppercase}}
+                      até {{eventDetailsCtrl.event.end_time | amUtc | amLocal | amCalendar:referenceTime:formats }}
                   </span>
                 </div>
               </div>
             </div>
-            <div layout="column" style="margin-left: 200px;">
+            <div layout="column" style="margin-left: 100px;">
               <h4 style="color: #03b3a1;">Site oficial</h4>
               <div layout="row" class="left-justify">
                 <p>
@@ -106,10 +101,10 @@
                 </p>
                 <div layout="column" style="margin-left: 40px;">
                   <h3>
-                    <a target="_blank" href="{{eventDetailsCtrl.event.official_site}}">
-                      {{eventDetailsCtrl.event.official_site ?
-                      eventDetailsCtrl.event.official_site : 'Não definido'}}
+                    <a ng-if"eventDetailsCtrl.event.official_site" target="_blank" href="{{eventDetailsCtrl.event.official_site}}">
+                      {{ eventDetailsCtrl.event.official_site }}
                     </a>
+                    <b ng-if="!eventDetailsCtrl.event.official_site">Não definido</b>
                   </h3>
                 </div>
               </div>

--- a/frontend/event/event_dialog.html
+++ b/frontend/event/event_dialog.html
@@ -70,13 +70,13 @@
               <div layout="row" layout-align="space-between center">
                   <md-input-container style="margin: 0" flex="45">
                       <input mdc-datetime-picker="" short-time="false" date="true" time="true" type="text" format="DD-MM-YYYY HH:mm" lang="pt-BR"
-                      placeholder="Data inicial" ng-model="controller.event.start_time" class=" md-input" today-text="Hoje" min-date="null"
-                      max-date="controller.event.end_time" readonly="readonly" cancel-text="Cancelar" required/>
+                      placeholder="Data inicial" ng-model="controller.event.start_time" class=" md-input" today-text="Hoje" min-date="controller.now"
+                      max-date="controller.event.end_time" readonly="readonly" cancel-text="Cancelar" ng-change="controller.createInitDate()" required/>
                   </md-input-container flex="45">
                   <md-input-container style="margin: 0">
                       <input mdc-datetime-picker="" ng-change="controller.changeDate('endTime')" date="true" time="true" type="text" lang="pt-BR" today-text="Hoje"
-                      placeholder="Data final" class=" md-input" readonly="readonly" format="YYYY-MM-DD HH:mm" max-date="null"
-                      ng-model="controller.event.end_time" cancel-text="Cancelar" min-date="null" required>
+                      placeholder="Data final" class=" md-input" readonly="readonly" format="DD-MM-YYYY HH:mm" max-date="null"
+                      ng-model="controller.event.end_time" cancel-text="Cancelar" min-date="controller.start_time" required>
                   </md-input-container>
               </div>
               <md-input-container style="margin: 0">
@@ -115,7 +115,7 @@
                     </md-select>
                 </md-input-container>
             </div>
-            <div layout="row">
+            <div layout="row" layout-align="space-between center">
                 <md-input-container style="margin: 0" flex="45" ng-if="controller.isAnotherCountry">
                     <label>Cidade</label>
                     <input type="text" name="city" ng-model="controller.event.city">
@@ -126,6 +126,10 @@
                       required/>
                       <md-option ng-repeat="city in controller.cities" ng-value="city">{{city}}</md-option>
                     </md-select>
+                </md-input-container>
+                <md-input-container style="margin: 0; margin-top: 25px;" flex="45">
+                    <label>Site oficial</label>
+                    <input type="url" ng-model="controller.event.official_site"/>
                 </md-input-container>
             </div>
           </md-dialog-content>

--- a/frontend/event/event_dialog.html
+++ b/frontend/event/event_dialog.html
@@ -80,8 +80,8 @@
                   </md-input-container>
               </div>
               <md-input-container style="margin: 0">
-                  <label>Local (Onde o evento vai acontecer)</label>
-                  <input ng-model="controller.event.local" required/>
+                  <label>Site oficial</label>
+                  <input type="url" ng-model="controller.event.official_site"/>
               </md-input-container>
               <div layout="row">
                   <md-input-container style="margin: 0">
@@ -95,6 +95,10 @@
               </div>
             </div>
             <div layout="row" layout-align="space-between center">
+                <md-input-container style="margin: 0; margin-top: 25px;" flex="45">
+                    <label>Local </label>
+                    <input ng-model="controller.event.local" required/>
+                </md-input-container>
                 <md-input-container style="margin: 0" flex="45">
                     <label>Pais</label>
                     <md-select ng-model="controller.event.country" ng-change="controller.setAnotherCountry()">
@@ -102,6 +106,8 @@
                           ng-value="country.nome_pais">{{country.nome_pais}}</md-option>
                     </md-select>
                 </md-input-container>
+            </div>
+            <div layout="row" layout-align="space-between center">
                 <md-input-container style="margin: 0" flex="45" ng-if="controller.isAnotherCountry">
                     <label>Estado</label>
                     <input type="text" name="state" ng-model="controller.event.federal_state">
@@ -114,8 +120,6 @@
                         ng-value="federal_state">{{federal_state.sigla}}</md-option>
                     </md-select>
                 </md-input-container>
-            </div>
-            <div layout="row" layout-align="space-between center">
                 <md-input-container style="margin: 0" flex="45" ng-if="controller.isAnotherCountry">
                     <label>Cidade</label>
                     <input type="text" name="city" ng-model="controller.event.city">
@@ -126,10 +130,6 @@
                       required/>
                       <md-option ng-repeat="city in controller.cities" ng-value="city">{{city}}</md-option>
                     </md-select>
-                </md-input-container>
-                <md-input-container style="margin: 0; margin-top: 25px;" flex="45">
-                    <label>Site oficial</label>
-                    <input type="url" ng-model="controller.event.official_site"/>
                 </md-input-container>
             </div>
           </md-dialog-content>


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> The start and end date and time is not specific. Also the official site is not defined in creation of event.</p>

<p><b>Solution:</b> Added the start and end date, hours and year and added the official site field in creation of event.</p>

![screenshot from 2018-01-12 14-58-55](https://user-images.githubusercontent.com/20300259/34888580-83f17a08-f7a9-11e7-83c4-a57075759c2c.png)

![screenshot from 2018-01-12 14-58-26](https://user-images.githubusercontent.com/20300259/34888575-8070db80-f7a9-11e7-91f2-e211d1095c32.png)



<p><b>TODO/FIXME:</b> n/a</p>
