### PR TITLE
Fix shared post title in modal

### DIFF
--- a/frontend/post/share_post_dialog.html
+++ b/frontend/post/share_post_dialog.html
@@ -28,9 +28,9 @@
             <img class="md-card-image" style="border-radius: 3%;" ng-src="{{ sharePostCtrl.post.photo_url }}"/>
           </div>
           <p></p>
-          <a ng-if="!sharePostCtrl.isSurvey()" href class="md-text hyperlink" ng-click="sharePostCtrl.goTo()">
-            <span>{{ sharePostCtrl.post.title }}</span>
-          </a>
+          <span ng-if="!sharePostCtrl.isSurvey()" class="md-text">
+            <b>{{ sharePostCtrl.post.title }}</b>
+          </span>
           <p ng-if="sharePostCtrl.isEvent()">
             <span class="md-caption">Local:</span> 
             <span md-colors="{color: 'default-teal-900'}">{{ sharePostCtrl.post.local }}</span> | 


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
The shared post's title in the modal shouldn't be clickable.
</p>

<p><b>Solution:</b>
I've removed ng-click, "<a>" and href.
</p>

<p><b>TODO/FIXME:</b> n/a</p>
