### PR TITLE
All users have to follow MS Institution

### DIFF
--- a/backend/handlers/institution_followers_handler.py
+++ b/backend/handlers/institution_followers_handler.py
@@ -60,6 +60,9 @@ class InstitutionFollowersHandler(BaseHandler):
 
         Utils._assert(institution.state == 'inactive',
                       "The institution has been deleted", NotAuthorizedException)
+        
+        Utils._assert(institution.name == 'Ministério da Saúde',
+                      "The institution can not be unfollowed", NotAuthorizedException)
 
         if(not type(institution) is Institution):
             raise Exception("Key is not an Institution")

--- a/backend/test/followers_institution_handler_test.py
+++ b/backend/test/followers_institution_handler_test.py
@@ -50,6 +50,36 @@ class InstitutionFollowersHandlerTest(TestBaseHandler):
         # Assert that the user hasn't been removed from the followers
         self.assertEquals(len(institution.followers), 1,
                           "The institution should have a follower")
+    
+    @patch('utils.verify_token', return_value=USER)
+    def teste_delete_usermember_health_ministry(self, verify_token):
+        """Test that user member try unfollow the health ministry institution."""
+        user = mocks.create_user(USER['email'])
+        institution = mocks.create_institution()
+        institution.address = mocks.create_address()
+        user.follow(institution.key)
+        user.add_institution(institution.key)
+        institution.followers = [user.key]
+        institution.name = "Ministério da Saúde"
+        institution.add_member(user)
+        self.assertEquals(len(institution.followers), 1,
+                          "The institution should have a follower")
+        self.assertEquals(len(user.follows), 1,
+                          "The user should follow an institution")
+
+        # Call the delete method
+        with self.assertRaises(Exception) as raises_context:
+            self.testapp.delete("/api/institutions/%s/followers" %
+                            institution.key.urlsafe())
+
+        message_exception = self.get_message_exception(str(raises_context.exception))
+
+        self.assertEqual(
+            message_exception,
+            "Error! The institution can not be unfollowed",
+            "Expected exception message must be equal to Error! The institution can not be unfollowed")
+
+        
 
     # TODO: fix this test because not work after add fiel 'description' in search_institution.py
     # Author: Tiago Pereira - 22/12/2017

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -127,17 +127,17 @@ def create_user(name, email):
     user.email = email
     user.name = name
     user.photo_url = "app/images/avatar.png"
-    ms = get_health_ministry()
-    user.follows.append(ms)
+    health_ministry = get_health_ministry().get()
+    if health_ministry is not None:
+        user.follows.append(health_ministry.key)
     user.put()
     
     return user
 
 def get_health_ministry():
     """Get health ministry institution by email."""
-    query = Institution.query(Institution.name == "Ministério da Saúde")
-    ms = query.get()
-    return ms.key
+    query = Institution.query(Institution.name == "Ministério da Saúde", Institution.acronym == "MS")
+    return query
 
 def json_response(method):
     """Add content type header to the response."""

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -135,7 +135,7 @@ def create_user(name, email):
     return user
 
 def get_health_ministry():
-    """Get health ministry institution by email."""
+    """Get health ministry institution."""
     query = Institution.query(Institution.name == "Ministério da Saúde", Institution.acronym == "MS")
     return query
 

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -127,10 +127,17 @@ def create_user(name, email):
     user.email = email
     user.name = name
     user.photo_url = "app/images/avatar.png"
+    ms = get_health_ministry()
+    user.follows.append(ms)
     user.put()
-
+    
     return user
 
+def get_health_ministry():
+    """Get health ministry institution by email."""
+    query = Institution.query(Institution.name == "Ministério da Saúde")
+    ms = query.get()
+    return ms.key
 
 def json_response(method):
     """Add content type header to the response."""

--- a/frontend/institution/base_institution_page.html
+++ b/frontend/institution/base_institution_page.html
@@ -33,7 +33,7 @@
                                 <!-- Buttons -->
                                 <div layout="row">
                                     <md-button flex class="md-primary md-raised md-hue-2" md-colors="{background: 'teal-500'}"
-                                    ng-if="!institutionCtrl.isMember" style="text-align: left;"
+                                    ng-if="institutionCtrl.showFollowButton()" style="text-align: left;"
                                     ng-click="institutionCtrl.isUserFollower ? institutionCtrl.unfollow() : institutionCtrl.follow()">
                                         <md-icon>rss_feed</md-icon>
                                         {{ institutionCtrl.isUserFollower ? 'Deixar de seguir' : 'Seguir' }}

--- a/frontend/institution/institutionController.js
+++ b/frontend/institution/institutionController.js
@@ -145,6 +145,10 @@
             institutionCtrl.showFullData = !institutionCtrl.showFullData;
         };
 
+        institutionCtrl.showFollowButton = function showFollowButton() {
+           return !institutionCtrl.isMember && institutionCtrl.current_institution.name !== "Ministério da Saúde";
+        };
+
         institutionCtrl.goToManageMembers = function goToManageMembers(){
             $state.go('app.manage_institution.members', {institutionKey: currentInstitutionKey});
         };


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>All users of platform have to follow Health Ministry Institution if exists</p>

<p><b>Solution:</b>Search for Health Ministry Institution when create_user method is called and follow this Institution if exists. The Handler throw error if the user tries to unfollow this Institution. In frontend, the button to follow/unfollow is hidden if the institution is Health Ministry.</p>

<p><b>TODO/FIXME:</b> n/a</p>
