### PR TITLE
Resend invite member

### DIFF
--- a/backend/handlers/resend_invite_handler.py
+++ b/backend/handlers/resend_invite_handler.py
@@ -21,6 +21,9 @@ class ResendInviteHandler(BaseHandler):
         host = self.request.host
         invite = ndb.Key(urlsafe=invite_key).get()
         
+        Utils._assert(invite.status != 'sent',
+                      "The invite has already been used", NotAuthorizedException)
+
         can_invite_members = user.has_permission(
             "invite_members", invite.institution_key.urlsafe())
 

--- a/backend/handlers/resend_invite_handler.py
+++ b/backend/handlers/resend_invite_handler.py
@@ -27,11 +27,11 @@ class ResendInviteHandler(BaseHandler):
         can_invite_members = user.has_permission(
             "invite_members", invite.institution_key.urlsafe())
 
-        if(can_invite_members):
-            institution = invite.institution_key.get()
-            Utils._assert(institution.state == 'inactive',
-                          "The institution has been deleted", NotAuthorizedException)
+        Utils._assert(not can_invite_members,
+            "User is not allowed to send invites", NotAuthorizedException)
 
-            invite.sendInvite(user, host)
-        else:
-            raise NotAuthorizedException("User is not allowed to send invites")
+        institution = invite.institution_key.get()
+        Utils._assert(institution.state == 'inactive',
+                        "The institution has been deleted", NotAuthorizedException)
+
+        invite.sendInvite(user, host)

--- a/backend/handlers/resend_invite_handler.py
+++ b/backend/handlers/resend_invite_handler.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""Resend Invite Handler."""
+
+import json
+
+from utils import login_required
+from utils import json_response
+from utils import Utils
+from custom_exceptions.notAuthorizedException import NotAuthorizedException
+from handlers.base_handler import BaseHandler
+from google.appengine.ext import ndb
+
+
+class ResendInviteHandler(BaseHandler):
+    """Resend Invite Handler."""
+
+    @json_response
+    @login_required
+    def post(self, user, invite_key):
+        """Handle POST Requests."""
+        host = self.request.host
+        invite = ndb.Key(urlsafe=invite_key).get()
+        
+        can_invite_members = user.has_permission(
+            "invite_members", invite.institution_key.urlsafe())
+
+        if(can_invite_members):
+            institution = invite.institution_key.get()
+            Utils._assert(institution.state == 'inactive',
+                          "The institution has been deleted", NotAuthorizedException)
+
+            invite.sendInvite(user, host)
+        else:
+            raise NotAuthorizedException("User is not allowed to send invites")

--- a/backend/main.py
+++ b/backend/main.py
@@ -39,6 +39,7 @@ from handlers.institution_children_request_handler import InstitutionChildrenReq
 from handlers.institution_hierarchy_handler import InstitutionHierarchyHandler
 from handlers.request_handler import RequestHandler
 from handlers.institution_events_handler import InstitutionEventsHandler
+from handlers.resend_invite_handler import ResendInviteHandler
 
 methods = set(webapp2.WSGIApplication.allowed_methods)
 methods.add('PATCH')
@@ -48,6 +49,7 @@ app = webapp2.WSGIApplication([
     ("/api/requests/(.*)/user", RequestHandler),
     ("/api/invites", InviteCollectionHandler), 
     ("/api/invites/institution", InviteInstitutionHandler),
+    ("/api/invites/(.*)/resend", ResendInviteHandler),
     ("/api/invites/(.*)", InviteHandler),
     ("/api/requests/(.*)/institution", InstitutionRequestHandler),
     ("/api/requests/(.*)/institution_parent", InstitutionParentRequestHandler),

--- a/backend/test/mocks.py
+++ b/backend/test/mocks.py
@@ -9,6 +9,7 @@ from models.institution import Address
 from models.post import Post
 from models.post import Comment
 from models.event import Event
+from models.factory_invites import InviteFactory
 
 
 def getHash(obj):
@@ -96,3 +97,17 @@ def create_event(author, institution):
     event.institution_image = event_hash
     event.put()
     return event
+
+def create_invite(admin, institution_key, type_of_invite):
+    """Create an invite."""
+    data = {
+        'invitee': str(admin.email),
+        'admin_key': admin.key.urlsafe(),
+        'institution_key': institution_key.urlsafe()
+    }
+
+    invite = InviteFactory.create(data, type_of_invite)
+    invite_hash = getHash(invite)
+    invite.sender_name = invite_hash
+    invite.put()
+    return invite

--- a/backend/test/resend_invite_handler_test.py
+++ b/backend/test/resend_invite_handler_test.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""Invite Handler Test."""
+
+import json
+from search_module.search_institution import SearchInstitution
+from test_base_handler import TestBaseHandler
+from models.user import User
+from models.institution import Institution
+from models.institution import Address
+from models.invite_user import InviteUser
+from models.invite_institution import InviteInstitution
+from handlers.resend_invite_handler import ResendInviteHandler
+import mocks
+
+import mock
+from mock import patch
+
+
+class ResendInviteHandlerTest(TestBaseHandler):
+    """Resend Invite Handler Test."""
+
+    INVITE_URI = "/api/invites/(.*)/resend"
+
+    @classmethod
+    def setUp(cls):
+        """Provide the base for the tests."""
+        super(ResendInviteHandlerTest, cls).setUp()
+
+        methods = set(cls.webapp2.WSGIApplication.allowed_methods)
+        methods.add('PATCH')
+        cls.webapp2.WSGIApplication.allowed_methods = frozenset(methods)
+
+        app = cls.webapp2.WSGIApplication(
+            [(ResendInviteHandlerTest.INVITE_URI, ResendInviteHandler),
+             ], debug=True)
+        cls.testapp = cls.webtest.TestApp(app)
+
+    @mock.patch('models.invite_user.InviteUser.send_email')
+    @mock.patch('models.invite_user.InviteUser.send_notification')
+    @patch('utils.verify_token', return_value={'email': 'user@gmail.com'})
+    def test_post(self, verify_token, mock_method, second_mock_method):
+        """Test post."""
+        user = mocks.create_user("user@gmail.com")
+        institution = mocks.create_institution()
+        invite = mocks.create_invite(user, institution.key, "USER")
+        user.add_permission("invite_members", institution.key.urlsafe())
+        user.put()
+        # Call the post method
+        self.testapp.post("/api/invites/%s/resend" %
+                          invite.key.urlsafe())
+        self.assertTrue(mock_method.called)
+        self.assertTrue(second_mock_method.called)

--- a/backend/test/resend_invite_handler_test.py
+++ b/backend/test/resend_invite_handler_test.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Invite Handler Test."""
+"""Resend Invite Handler Test."""
 
 import json
 from search_module.search_institution import SearchInstitution
@@ -25,11 +25,6 @@ class ResendInviteHandlerTest(TestBaseHandler):
     def setUp(cls):
         """Provide the base for the tests."""
         super(ResendInviteHandlerTest, cls).setUp()
-
-        methods = set(cls.webapp2.WSGIApplication.allowed_methods)
-        methods.add('PATCH')
-        cls.webapp2.WSGIApplication.allowed_methods = frozenset(methods)
-
         app = cls.webapp2.WSGIApplication(
             [(ResendInviteHandlerTest.INVITE_URI, ResendInviteHandler),
              ], debug=True)

--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -200,6 +200,29 @@
             return Utils.calculateHeight(list, itemHeight);
         };
 
+        manageMemberCtrl.resendInvite = function resendInvite(inviteKey, event) {
+            var confirm = $mdDialog.confirm();
+            confirm
+                .clickOutsideToClose(false)
+                .title('Reenviar convite')
+                .textContent('Você deseja reenviar o convite?')
+                .ariaLabel('Reenviar convite')
+                .targetEvent(event)
+                .ok('Reenviar convite')
+                .cancel('Cancelar');
+            var promise = $mdDialog.show(confirm);
+            promise.then(function () {
+                InviteService.resendInvite(inviteKey).then(function success() {
+                    MessageService.showToast("Convite reenviado com sucesso.");
+                }, function error(response) {
+                    MessageService.showToast(response.data.msg);
+                });
+            }, function () {
+                MessageService.showToast('Cancelado.');
+            });
+            return promise;
+        };
+
         function createRequestSelector(status, type_of_invite) {
             return function(request) {
                 return request.status === status && request.type_of_invite === type_of_invite;

--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -56,7 +56,10 @@
 
             if (manageMemberCtrl.isUserInviteValid(invite)) {
                 var promise = InviteService.sendInvite(invite);
-                promise.then(function success() {
+                promise.then(function success(response) {
+                    console.log(response);
+                    console.log(":>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>.");
+                    invite.key = response.data.key;
                     manageMemberCtrl.sent_invitations.push(invite);
                     manageMemberCtrl.invite = {};
                     manageMemberCtrl.showInvites = true; 

--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -57,8 +57,6 @@
             if (manageMemberCtrl.isUserInviteValid(invite)) {
                 var promise = InviteService.sendInvite(invite);
                 promise.then(function success(response) {
-                    console.log(response);
-                    console.log(":>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>.");
                     invite.key = response.data.key;
                     manageMemberCtrl.sent_invitations.push(invite);
                     manageMemberCtrl.invite = {};
@@ -204,7 +202,7 @@
         };
 
         manageMemberCtrl.resendInvite = function resendInvite(inviteKey, event) {
-            var confirm = $mdDialog.confirm();
+            var confirm = $mdDialog.confirm({ onComplete: designOptions });
             confirm
                 .clickOutsideToClose(false)
                 .title('Reenviar convite')
@@ -225,6 +223,17 @@
             });
             return promise;
         };
+
+        function designOptions() {
+            var $dialog = angular.element(document.querySelector('md-dialog'));
+            var $actionsSection = $dialog.find('md-dialog-actions');
+            var $cancelButton = $actionsSection.children()[0];
+            var $confirmButton = $actionsSection.children()[1];
+            angular.element($confirmButton).removeClass('md-primary');
+            angular.element($cancelButton).removeClass('md-primary');
+            angular.element($confirmButton).addClass('green-button-text');
+            angular.element($cancelButton).addClass('green-button-text');
+        }
 
         function createRequestSelector(status, type_of_invite) {
             return function(request) {

--- a/frontend/institution/management_members.html
+++ b/frontend/institution/management_members.html
@@ -101,6 +101,11 @@
               <h3> {{ invite.invitee }} </h3>
               <p> Convidado por: {{invite.sender_name}}</p>
             </div>
+            <div layout-align="end center">
+              <md-button class="md-raised" ng-click="manageMemberCtrl.resendInvite(invite.key, $event)">
+                Reenviar
+              </md-button>
+            </div>
           </md-list-item>
         </md-list>
       </md-card-content>

--- a/frontend/invites/inviteService.js
+++ b/frontend/invites/inviteService.js
@@ -29,6 +29,16 @@
             return deferred.promise;
         };
 
+        service.resendInvite = function resendInvite(inviteKey) {
+            var deferred = $q.defer();
+            $http.post(INVITES_URI + "/" + inviteKey + "/resend").then(function success(response) {
+                deferred.resolve(response);
+            }, function error(response) {
+                deferred.reject(response);
+            });
+            return deferred.promise;
+        };
+
         service.sendInviteInst = function sendInviteInst(invite) {
             var deferred = $q.defer();
             $http.post(INVITES_URI + '/institution', invite).then(function success(response) {

--- a/frontend/styles/custom.css
+++ b/frontend/styles/custom.css
@@ -492,6 +492,11 @@ a:active {
     color: #FFFFFF;
 }
 
+.green-button-text {
+    color: #009688;
+    background-color: #FFFFFFFF;
+}
+
 .hide-scrollbar::-webkit-scrollbar {
     display: none;
 }

--- a/frontend/test/specs/managementMembersControllerSpec.js
+++ b/frontend/test/specs/managementMembersControllerSpec.js
@@ -124,12 +124,14 @@
             });
         });
 
-        describe('sendUserInvite()', function() {
+        fdescribe('sendUserInvite()', function() {
             beforeEach(function() {
                 spyOn(inviteService, 'sendInvite').and.callFake(function() {
                     return {
                         then: function(callback) {
-                            return callback();
+                            return callback(
+                                {data: {key: '123'}}
+                            );
                         }
                     };
                 });
@@ -141,7 +143,8 @@
                     type_of_invite: 'USER',
                     institution_key: '987654321',
                     admin_key: '54321',
-                    sender_name: 'User'
+                    sender_name: 'User',
+                    key: '123'
                 };
                 var newInvite = new Invite(manageMemberCtrl.invite);
                 expect(manageMemberCtrl.sent_invitations.length).toBe(2);
@@ -195,7 +198,7 @@
         });
 
         describe('resendInvite()', function () {
-            it('', function () {
+            it('should resend the invite', function () {
                 spyOn(mdDialog, 'confirm').and.callThrough();
                 spyOn(mdDialog, 'show').and.callFake(function () {
                     return {

--- a/frontend/test/specs/managementMembersControllerSpec.js
+++ b/frontend/test/specs/managementMembersControllerSpec.js
@@ -11,6 +11,7 @@
                         type_of_invite: 'USER',
                         status: 'sent',
                         institution_key: '987654321',
+                        key: '123',
                         admin_key: '12345'});
 
     var otherInvite = new Invite({invitee: "other_user@example.com",
@@ -190,6 +191,32 @@
                 manageMemberCtrl.cancelInvite();
 
                 expect(manageMemberCtrl.invite).toEqual({});
+            });
+        });
+
+        describe('resendInvite()', function () {
+            it('', function () {
+                spyOn(mdDialog, 'confirm').and.callThrough();
+                spyOn(mdDialog, 'show').and.callFake(function () {
+                    return {
+                        then: function (callback) {
+                            return callback();
+                        }
+                    };
+                });
+                spyOn(inviteService, 'resendInvite').and.callFake(function () {
+                    return {
+                        then: function (callback) {
+                            return callback();
+                        }
+                    };
+                });
+
+                manageMemberCtrl.resendInvite(invite.key, '$event');
+
+                expect(mdDialog.confirm).toHaveBeenCalled();
+                expect(mdDialog.show).toHaveBeenCalled();
+                expect(inviteService.resendInvite).toHaveBeenCalled();
             });
         });
     });

--- a/frontend/test/specs/managementMembersControllerSpec.js
+++ b/frontend/test/specs/managementMembersControllerSpec.js
@@ -124,7 +124,7 @@
             });
         });
 
-        fdescribe('sendUserInvite()', function() {
+        describe('sendUserInvite()', function() {
             beforeEach(function() {
                 spyOn(inviteService, 'sendInvite').and.callFake(function() {
                     return {


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
Resend the email and the notification to the user that received an invite to be an institution's member.

![screenshot from 2018-01-18 08-14-16](https://user-images.githubusercontent.com/23387866/35095785-8dcb958a-fc28-11e7-9279-9c0abffe06eb.png)


</p>

<p><b>Solution:</b>
I've created a handler that with its post method calls invite.sendInvite().

![screenshot from 2018-01-18 08-14-31](https://user-images.githubusercontent.com/23387866/35095817-b2cdcf88-fc28-11e7-8e61-a757e5dd06bc.png)

![screenshot from 2018-01-18 08-14-45](https://user-images.githubusercontent.com/23387866/35095835-c3755338-fc28-11e7-8589-a4e65fb42d48.png)


</p>

<p><b>TODO/FIXME:</b> n/a</p>
