### PR TITLE
Add script for check browser version in frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -25,6 +25,17 @@
 
   <div flex layout="column" ui-view="main"></div>
 
+  <script> 
+    var $buoop = {notify:{i:14,f:-4,o:-4,s:-2,c:-4},insecure:true,api:5,noclose:true,l:"pt-br"};
+    function $buo_f(){ 
+     var e = document.createElement("script"); 
+     e.src = "//browser-update.org/update.min.js"; 
+     document.body.appendChild(e);
+    };
+    try {document.addEventListener("DOMContentLoaded", $buo_f,false)}
+    catch(e){window.attachEvent("onload", $buo_f)}
+  </script>
+
   <!-- ngScrollbar Library -->
   <script src="app/libs/jquery-1.11.0.min.js"></script>
   <script src="app/libs/jquery.mCustomScrollbar.js"></script>

--- a/frontend/main/main.html
+++ b/frontend/main/main.html
@@ -7,7 +7,7 @@
 
     <a ui-sref="app.user.home" layout="row" layout-align="center center">
       <md-button disabled="true">
-        <img src="app/images/logo.png" aria-label="Plataforma Virtual CIS" style="height: 50%;">
+        <img src="app/images/logo.png" aria-label="Plataforma Virtual CIS" style="height: 35px;">
       </md-button>
     </a>
 


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> Add a script that checks the version of the browser that is accessing the platform to block access to old browsers that no longer has support and adjust the platform logo to support the Mozilla browser.</p>

<p><b>Solution:</b> Add the same script already added in the index.html from the landing page to the index.html of the frontend and change the size of the platform logo to pixels.</p>

![screenshot from 2018-01-22 11-39-34](https://user-images.githubusercontent.com/18005317/35226299-a3ef502e-ff69-11e7-8438-87fd0aa5b96a.png)

<p><b>TODO/FIXME:</b> n/a</p>
