### PR TITLE
Fix the reset MS to create the admin profile.

### DIFF
--- a/backend/admin.py
+++ b/backend/admin.py
@@ -688,6 +688,7 @@ class ResetMSHandler(BaseHandler):
 
         admin.add_permissions(permissions.DEFAULT_ADMIN_PERMISSIONS, ms.key.urlsafe())
         admin.add_permissions(permissions.DEFAULT_SUPER_USER_PERMISSIONS, ms.key.urlsafe())
+        create_profile(admin, ms)
         admin.put()
 
         self.response.write(json.dumps(jsonList))


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>When reset the datastore to create MS, the profile of admin is not created.</p>

<p><b>Solution:</b>Create profile for admin of MS institution</p>

<p><b>TODO/FIXME:</b> n/a</p>
