### PR TITLE
Hide finalized events in home page

### DIFF
--- a/frontend/home/home.html
+++ b/frontend/home/home.html
@@ -43,7 +43,7 @@
                   Nenhum evento próximo
                 </center>
               </div>
-              <div layout="row" ng-repeat="event in homeCtrl.events | filter: homeCtrl.showEvent" class="event-item">
+              <div layout="row" ng-repeat="event in homeCtrl.events | filter: homeCtrl.isNotFinalizedEvent" class="event-item">
                 <div layout="row">
                   <div class="rounded-circle event-date">
                     <span class="event-day">

--- a/frontend/home/home.html
+++ b/frontend/home/home.html
@@ -43,7 +43,7 @@
                   Nenhum evento próximo
                 </center>
               </div>
-              <div layout="row" ng-repeat="event in homeCtrl.events" class="event-item">
+              <div layout="row" ng-repeat="event in homeCtrl.events | filter: homeCtrl.showEvent" class="event-item">
                 <div layout="row">
                   <div class="rounded-circle event-date">
                     <span class="event-day">

--- a/frontend/home/home.html
+++ b/frontend/home/home.html
@@ -43,7 +43,7 @@
                   Nenhum evento próximo
                 </center>
               </div>
-              <div layout="row" ng-repeat="event in homeCtrl.events | filter: homeCtrl.isNotFinalizedEvent" class="event-item">
+              <div layout="row" ng-repeat="event in homeCtrl.events | filter: homeCtrl.eventInProgress" class="event-item">
                 <div layout="row">
                   <div class="rounded-circle event-date">
                     <span class="event-day">

--- a/frontend/home/homeController.js
+++ b/frontend/home/homeController.js
@@ -19,6 +19,7 @@
         homeCtrl.refreshTimeline = false;
         homeCtrl.instMenuExpanded = false;
         homeCtrl.isLoadingPosts = true;
+        homeCtrl.showMessageOfEmptyEvents = true;
         homeCtrl.stateView = "";
 
         homeCtrl.user = AuthService.getCurrentUser();
@@ -33,6 +34,18 @@
 
         homeCtrl.goToInstitution = function goToInstitution(institutionKey) {
             $state.go('app.institution.timeline', {institutionKey: institutionKey});
+        };
+
+        homeCtrl.showEvent = function showEvent(event) {
+            var end_time = event.end_time;
+            var date = new Date();
+            var current_time = date.toISOString().substr(0, end_time.length);
+
+            if (current_time <= end_time) {
+                homeCtrl.showMessageOfEmptyEvents = false;
+            }
+
+            return current_time <= end_time;
         };
 
         homeCtrl.showUserProfile = function showUserProfile(userKey, ev) {
@@ -110,7 +123,7 @@
         };
 
         homeCtrl.isEventsEmpty = function isEventsEmpty() {
-            return homeCtrl.events.length === 0;
+            return homeCtrl.events.length === 0 || homeCtrl.showMessageOfEmptyEvents;
         };
 
         homeCtrl.showRefreshTimelineButton = function showRefreshTimelineButton() {

--- a/frontend/home/homeController.js
+++ b/frontend/home/homeController.js
@@ -36,7 +36,7 @@
             $state.go('app.institution.timeline', {institutionKey: institutionKey});
         };
 
-        homeCtrl.isNotFinalizedEvent = function isNotFinalizedEvent(event) {
+        homeCtrl.eventInProgress = function eventInProgress(event) {
             var end_time = event.end_time;
             var date = new Date();
             var current_time = date.toISOString().substr(0, end_time.length);

--- a/frontend/home/homeController.js
+++ b/frontend/home/homeController.js
@@ -36,7 +36,7 @@
             $state.go('app.institution.timeline', {institutionKey: institutionKey});
         };
 
-        homeCtrl.showEvent = function showEvent(event) {
+        homeCtrl.isNotFinalizedEvent = function isNotFinalizedEvent(event) {
             var end_time = event.end_time;
             var date = new Date();
             var current_time = date.toISOString().substr(0, end_time.length);

--- a/frontend/test/specs/homeControllerSpec.js
+++ b/frontend/test/specs/homeControllerSpec.js
@@ -151,16 +151,16 @@
             });
         });
 
-        describe('showEvent()', function() {
-            it('Should be true or false the call of showEvent', function() {
+        describe('isNotFinalizedEvent()', function() {
+            it('Should be true or false the call of isNotFinalizedEvent', function() {
                 var date = new Date();
                 date.setYear(3000);
                 var event = {end_time: date.toISOString()};
-                expect(homeCtrl.showEvent(event)).toEqual(true);
+                expect(homeCtrl.isNotFinalizedEvent(event)).toEqual(true);
 
                 date.setYear(2000);
                 event.end_time = date.toISOString();
-                expect(homeCtrl.showEvent(event)).toEqual(false);
+                expect(homeCtrl.isNotFinalizedEvent(event)).toEqual(false);
             });
         });
     });

--- a/frontend/test/specs/homeControllerSpec.js
+++ b/frontend/test/specs/homeControllerSpec.js
@@ -151,16 +151,16 @@
             });
         });
 
-        describe('isNotFinalizedEvent()', function() {
-            it('Should be true or false the call of isNotFinalizedEvent', function() {
+        describe('eventInProgress()', function() {
+            it('Should be true or false the call of eventInProgress', function() {
                 var date = new Date();
                 date.setYear(3000);
                 var event = {end_time: date.toISOString()};
-                expect(homeCtrl.isNotFinalizedEvent(event)).toEqual(true);
+                expect(homeCtrl.eventInProgress(event)).toEqual(true);
 
                 date.setYear(2000);
                 event.end_time = date.toISOString();
-                expect(homeCtrl.isNotFinalizedEvent(event)).toEqual(false);
+                expect(homeCtrl.eventInProgress(event)).toEqual(false);
             });
         });
     });

--- a/frontend/test/specs/homeControllerSpec.js
+++ b/frontend/test/specs/homeControllerSpec.js
@@ -150,5 +150,18 @@
                 scope.$apply();
             });
         });
+
+        describe('showEvent()', function() {
+            it('Should be true or false the call of showEvent', function() {
+                var date = new Date();
+                date.setYear(3000);
+                var event = {end_time: date.toISOString()};
+                expect(homeCtrl.showEvent(event)).toEqual(true);
+
+                date.setYear(2000);
+                event.end_time = date.toISOString();
+                expect(homeCtrl.showEvent(event)).toEqual(false);
+            });
+        });
     });
 }));


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> Hide preview events that are already finalized on the home page.</p>

<p><b>Solution:</b> I created a function in homeController that checks if the end date of the event has passed, if yes it does not let the event be viewed.</p>

<p><b>TODO/FIXME:</b> n/a</p>
