### PR TITLE
Fix none type error when editing user or institution

### DIFF
--- a/backend/search_module/search_institution.py
+++ b/backend/search_module/search_institution.py
@@ -36,7 +36,7 @@ class SearchInstitution(SearchDocument):
         relationed to the institution.
         """
         index = api.search.Index(name=self.index_name)
-        if not index.get(institution.key.urlsafe()):
+        if index.get(institution.key.urlsafe()) is None:
             admin = institution.email
             if institution.admin:
                 admin = institution.admin.get().email[0]

--- a/backend/search_module/search_user.py
+++ b/backend/search_module/search_user.py
@@ -21,7 +21,7 @@ class SearchUser(SearchDocument):
         relationed to the user.
         """
         index = api.search.Index(name=self.index_name)
-        if not index.get(user.key.urlsafe()):
+        if index.get(user.key.urlsafe()) is None:
             content = {
                 'id': user.key.urlsafe(),
                 'name': user.name,


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> The error, `'NoneType' has no attributes fields`, occurred when the user attempted to do any modification in the institution or user entities. That was happening because the document wasn't created when the modification occurred, once the _post_put was triggered calling the create_document, the system does the following verification:

```
if not index.get(user.key.urlsafe()):
    // CREATE DOCUMENT
else:
   self.updateDocument(user)
```

The first line negates the return of the call to get index, that call returns an **object** _NoneType_ that is the object form of none. Them implicates in the execution of the update of an inexistent document.
</p>

<p><b>Solution:</b> Change the verification to: 

```
if index.get(user.key.urlsafe()) is None:
    // CREATE DOCUMENT
```

That is recognized as a comparison with None or Object NoneType.
</p>

<p><b>TODO/FIXME:</b> n/a</p>
