### PR TITLE
Fix square "following"

### DIFF
--- a/frontend/styles/custom.css
+++ b/frontend/styles/custom.css
@@ -516,6 +516,8 @@ a:active {
     margin-right: 10px;
     width: 50px;
     height: 50px;
+    min-width: 40px;
+    min-height: 40px;
     max-width: 50px;
     max-height: 50px;
     -webkit-border-radius: 50%;


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> In the square "following" there are sizes of the screen, in which the images are very close.
 </p>

<p><b>Solution:</b> Put minimum size to image.</p>


![following](https://user-images.githubusercontent.com/18709274/35332504-ed82d414-00e9-11e8-8c57-ce03afffef1a.png)

<p><b>TODO/FIXME:</b> n/a</p>
