### PR TITLE
Fix user inactive page's back button

### DIFF
--- a/frontend/notification/notificationService.js
+++ b/frontend/notification/notificationService.js
@@ -103,8 +103,10 @@
         * service notifications.
         */
         AuthService.$onLogout(function destroy() {
-            firebaseArrayNotifications.$destroy();
-            firebaseArrayNotifications = undefined;
+            if(firebaseArrayNotifications) {
+                firebaseArrayNotifications.$destroy();
+                firebaseArrayNotifications = undefined;
+            }
         });
     });
 })();


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
The back button wasn't working.
The error was that AuthService.$onLogout() was trying to call $destroy from firebaseArrayNotifications,
but sometimes this array was undefined.
</p>

<p><b>Solution:</b>
I've added a verification to AuthService.$onLogout() method.
</p>

<p><b>TODO/FIXME:</b> n/a</p>
