### PR TITLE
Hide more button in post page

### DIFF
--- a/frontend/post/post_details.html
+++ b/frontend/post/post_details.html
@@ -165,7 +165,7 @@
           <p ng-bind-html="postDetailsCtrl.postToURL(postDetailsCtrl.post).text" class="break">
             {{postDetailsCtrl.postToURL(postDetailsCtrl.post).text}}
           </p>
-          <div layout="row" layout-align="end-center">
+          <div layout="row" layout-align="end-center" ng-if="!postDetailsCtrl.isPostPage">
           <a href class="md-text hyperlink" ng-click="postDetailsCtrl.goToPost(postDetailsCtrl.post)">
             <md-icon style="margin-bottom: -15px; margin-right: -12px;" md-colors="{color: 'light-green'}">more_horiz</md-icon>
               </a>


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
The post's "more button" was in post page with no action.

![screenshot from 2018-01-25 09-10-39](https://user-images.githubusercontent.com/23387866/35387960-a4b7178c-01b0-11e8-8443-a1e62e08abfb.png)


</p>

<p><b>Solution:</b> 
I've added a verification that doesn't allow the more button to be in post page. This verification uses the directive's property "isPostPage".

![screenshot from 2018-01-25 09-10-14](https://user-images.githubusercontent.com/23387866/35388020-e565e74a-01b0-11e8-9eab-13e14b53c3ca.png)


</p>

<p><b>TODO/FIXME:</b> n/a</p>
