### PR TITLE
Changing color and text of the submit comment button in post

### DIFF
--- a/frontend/post/post_details.html
+++ b/frontend/post/post_details.html
@@ -240,7 +240,7 @@
             ng-disabled="postDetailsCtrl.savingComment"></textarea>
             <div layout="row" layout-align="end center">
               <md-button ng-show="postDetailsCtrl.newComment"
-              class="md-raised md-primary" aria-label="postar" type="submit">Escrever</md-button>
+              class="md-raised md-primary" aria-label="postar" type="submit" md-colors="{background: 'teal-500'}">Enviar</md-button>
             </div>
           </form>
         </md-input-container>


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> The button to submit comment in post is not compatible with the system set of colors.</p>

<p><b>Solution:</b> Adding md-colors teal-500 and changing "ESCREVER" to "ENVIAR" in exhibition of button.</p>

<p><b>TODO/FIXME:</b> n/a</p>
