### PR TITLE
Fix portfolio's button

### DIFF
--- a/frontend/institution/configInstDirective.js
+++ b/frontend/institution/configInstDirective.js
@@ -296,6 +296,22 @@
             }
         };
 
+        configInstCtrl.getPortfolioButtonMessage = function getPortfolioButtonMessage () {
+            if(configInstCtrl.newInstitution.portfolio_url || configInstCtrl.file) {
+                return "Trocar Portfólio";
+            } else {
+                return "Adicionar Portfólio";
+            }
+        };
+
+        configInstCtrl.getPortfolioButtonIcon = function getPortfolioButtonIcon() {
+            if (configInstCtrl.newInstitution.portfolio_url || configInstCtrl.file) {
+                return "insert_drive_file";
+            } else {
+                return "attach_file";
+            }
+        };
+
         function getFields() {
             var necessaryFieldsForStep = {
                 0: {fields: [configInstCtrl.newInstitution.address], size: 7},

--- a/frontend/institution/submit_form.html
+++ b/frontend/institution/submit_form.html
@@ -254,8 +254,8 @@
                 <md-button ng-click="null" ng-model="configInstCtrl.file" ngf-pattern="'application/pdf'"
                     ngf-accept="'application/pdf'" ngf-max-size="5MB"
                     ngf-select="null" class="md-raised">
-                    <md-icon>{{configInstCtrl.file? 'insert_drive_file': 'attach_file'}}</md-icon>
-                    {{configInstCtrl.file? 'Portfólio adicionado': 'Adicionar Portfólio'}}
+                    <md-icon>{{configInstCtrl.getPortfolioButtonIcon()}}</md-icon>
+                    {{configInstCtrl.getPortfolioButtonMessage()}}
                 </md-button>
             </md-input-container>
             <div layout="row" layout-align="end center">

--- a/frontend/test/specs/configInstDirectiveSpec.js
+++ b/frontend/test/specs/configInstDirectiveSpec.js
@@ -312,4 +312,44 @@ describe('Test ConfigInstDirective', function() {
             expect(greenButton).toEqual(false);
         });
     });
+
+    describe('getPortfolioButtonMessage()', function() {
+        it('should return "Trocar Portfólio"', function() {
+            editInstCtrl.newInstitution.portfolio_url = "portfolio/test";
+            var message = editInstCtrl.getPortfolioButtonMessage();
+            expect(message).toEqual("Trocar Portfólio");
+            delete editInstCtrl.newInstitution.portfolio_url;
+            editInstCtrl.file = "portfolio/test";
+            message = editInstCtrl.getPortfolioButtonMessage();
+            expect(message).toEqual("Trocar Portfólio");
+            editInstCtrl.newInstitution.portfolio_url = "portfolio/test";
+            message = editInstCtrl.getPortfolioButtonMessage();
+            expect(message).toEqual("Trocar Portfólio");
+        });
+
+        it('should return "Adicionar Portfólio"', function () {
+            var message = editInstCtrl.getPortfolioButtonMessage();
+            expect(message).toEqual("Adicionar Portfólio");
+        });
+    });
+
+    describe('getPortfolioButtonIcon()', function () {
+        it('should return "insert_drive_file"', function () {
+            editInstCtrl.newInstitution.portfolio_url = "portfolio/test";
+            var message = editInstCtrl.getPortfolioButtonIcon();
+            expect(message).toEqual("insert_drive_file");
+            delete editInstCtrl.newInstitution.portfolio_url;
+            editInstCtrl.file = "portfolio/test";
+            message = editInstCtrl.getPortfolioButtonIcon();
+            expect(message).toEqual("insert_drive_file");
+            editInstCtrl.newInstitution.portfolio_url = "portfolio/test";
+            message = editInstCtrl.getPortfolioButtonIcon();
+            expect(message).toEqual("insert_drive_file");
+        });
+
+        it('should return "attach_file"', function () {
+            var message = editInstCtrl.getPortfolioButtonIcon();
+            expect(message).toEqual("attach_file");
+        });
+    });
 });


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
The portfolio button's message was wrong, It was "Adicionar portfólio" even if the institution's already have one.
</p>

<p><b>Solution:</b>
I've created a two functions that handles with some conditions to know if there is a portfolio or not. Thus the controller can choose the right message and icon.

![screenshot from 2018-01-29 13-51-51](https://user-images.githubusercontent.com/23387866/35522873-45614a38-04fc-11e8-83a4-866e2500dee5.png)


</p>

<p><b>TODO/FIXME:</b> n/a</p>
