### PR TITLE
Fix edit profile's image in mozilla

### DIFF
--- a/frontend/auth/configProfileController.js
+++ b/frontend/auth/configProfileController.js
@@ -47,8 +47,8 @@
             });
         }
 
-        configProfileCtrl.cropImage = function cropImage(imageFile) {
-            CropImageService.crop(imageFile).then(function success(croppedImage) {
+        configProfileCtrl.cropImage = function cropImage(imageFile, event) {
+            CropImageService.crop(imageFile, event).then(function success(croppedImage) {
                 configProfileCtrl.addImage(croppedImage);
             }, function error() {
                 configProfileCtrl.file = null;

--- a/frontend/auth/config_profile.html
+++ b/frontend/auth/config_profile.html
@@ -18,7 +18,7 @@
                   <img style="border-radius: 50%;" ng-src="{{ configProfileCtrl.photo_url }}" width="200px" height="200px">
                   <md-button ng-show="configProfileCtrl.showButton()" ng-click="null" ng-model="configProfileCtrl.file" ngf-pattern="'image/*'"
                   ngf-accept="'image/*'" ngf-max-size="5MB"
-                  ngf-select="configProfileCtrl.cropImage(configProfileCtrl.file)"
+                  ngf-select="configProfileCtrl.cropImage(configProfileCtrl.file, $event)"
                   class="md-icon-button edit-profile-avatar-button" style="width: 200px; height: 200px; margin-left: -1px;">
                   <md-icon class="edit-profile-avatar-icon">add_a_photo</md-icon>
                   <p><b style="color: white;">Alterar foto</b></p>

--- a/frontend/imageUpload/cropImageService.js
+++ b/frontend/imageUpload/cropImageService.js
@@ -6,7 +6,7 @@
     app.service("CropImageService", function CropImageService($mdDialog, $q) {
         var service = this;
 
-        service.crop = function crop(image_file) {
+        service.crop = function crop(image_file, event) {
             var deferred = $q.defer();
 
             $mdDialog.show({

--- a/frontend/institution/configInstDirective.js
+++ b/frontend/institution/configInstDirective.js
@@ -85,8 +85,8 @@
             return promise;
         };
 
-        configInstCtrl.cropImage = function cropImage(image_file) {
-            CropImageService.crop(image_file).then(function success(croppedImage) {
+        configInstCtrl.cropImage = function cropImage(image_file, event) {
+            CropImageService.crop(image_file, event).then(function success(croppedImage) {
                 configInstCtrl.addImage(croppedImage);
             }, function error() {
                 configInstCtrl.file = null;

--- a/frontend/institution/create_inst_form.html
+++ b/frontend/institution/create_inst_form.html
@@ -139,14 +139,14 @@
                                                 md-colors="{background: 'teal-900'}" ng-show="configInstCtrl.showButton()" ng-click="null"
                                                 ng-model="configInstCtrl.file" ngf-pattern="'image/*'"
                                                 ngf-accept="'image/*'" ngf-max-size="5MB" class="md-raised"
-                                                ngf-select="configInstCtrl.cropImage(configInstCtrl.file)" ng-if="!configInstCtrl.showImage()">
+                                                ngf-select="configInstCtrl.cropImage(configInstCtrl.file, $event)" ng-if="!configInstCtrl.showImage()">
                                                 <md-icon flex-xs="10" style="color: #FFFFFF; font-size: 35px; margin: 0 0 10px 8px;">add_a_photo</md-icon>
                                             </md-button>
                                             <md-button layout="row" class="md-icon-button" style="border-radius: 50%; height: 80px; width: 80px;"
                                                 ng-show="configInstCtrl.showButton()" ng-click="null"
                                                 ng-model="configInstCtrl.file" ngf-pattern="'image/*'"
                                                 ngf-accept="'image/*'" ngf-max-size="5MB" class="md-raised"
-                                                ngf-select="configInstCtrl.cropImage(configInstCtrl.file)" ng-if="configInstCtrl.showImage()">
+                                                ngf-select="configInstCtrl.cropImage(configInstCtrl.file, $event)" ng-if="configInstCtrl.showImage()">
                                                 <img ng-if="configInstCtrl.showImage()" style="border-radius: 50%; width: 100%; height: 100%;" ng-src="{{ configInstCtrl.newInstitution.photo_url }}"/>
                                             </md-button>
                                         </div>

--- a/frontend/institution/submit_form.html
+++ b/frontend/institution/submit_form.html
@@ -13,7 +13,7 @@
                     <md-button ng-show="configInstCtrl.showButton()" ng-click="null"
                         ng-model="configInstCtrl.file" ngf-pattern="'image/*'"
                         ngf-accept="'image/*'" ngf-max-size="5MB" class="md-raised"
-                        ngf-select="configInstCtrl.cropImage(configInstCtrl.file)">
+                        ngf-select="configInstCtrl.cropImage(configInstCtrl.file, $event)">
                         <b>Adicionar imagem</b>
                     </md-button>
                     <md-progress-linear ng-show="configInstCtrl.loading" md-mode="indeterminate"

--- a/frontend/styles/custom.css
+++ b/frontend/styles/custom.css
@@ -387,7 +387,7 @@ a:active {
     padding auto auto auto auto;
     overflow: hidden;
     max-width:100%;
-    height: 50%;
+    height: 50vh;
 }
 
 .break {


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
It wasn't possible to edit the profile's image in mozilla because the browser doesn't work with percentage in the height property and It was missing a $event in the html.
</p>

<p><b>Solution:</b>
I've changed the height property from percentage to vh and added $event where it was missing.

![screenshot from 2018-01-30 08-56-25](https://user-images.githubusercontent.com/23387866/35565401-2a669a4e-059c-11e8-83ba-3f3feef2554c.png)


</p>

<p><b>TODO/FIXME:</b> n/a</p>
