### PR TITLE
Hide update button from post's author

### DIFF
--- a/frontend/post/post_details.html
+++ b/frontend/post/post_details.html
@@ -56,7 +56,7 @@
             Compartilhar
           </md-button>
         </md-menu-item>
-        <md-menu-item>
+        <md-menu-item ng-if="!postDetailsCtrl.isPostAuthor()">
           <md-button aria-label="Favorite" ng-click="postDetailsCtrl.addOrRemoveSubscriber()"
             ng-disabled="postDetailsCtrl.disableButton()" ng-class="postDetailsCtrl.isSubscriber()?'md-warn':''"
             title="Marcar interesse e receber notificações">


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
Hide update button from post's author
</p>

<p><b>Solution:</b>
I've added ng-if="!isPostAuthor()" in the md-menu-item.

![screenshot from 2018-01-30 17-04-09](https://user-images.githubusercontent.com/23387866/35588733-4ddfbf70-05e0-11e8-8757-1259d6d14367.png)


</p>

<p><b>TODO/FIXME:</b> n/a</p>
