### PR TITLE
Fix delete post and event's consistency

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -74,6 +74,9 @@
                         templateUrl: "app/event/event.html",
                         controller: "EventController as eventCtrl",
                     }
+                },
+                params: {
+                    posts: undefined
                 }
             })
             .state("app.user.invite_inst", {

--- a/frontend/event/eventController.js
+++ b/frontend/event/eventController.js
@@ -75,9 +75,9 @@
                 clickOutsideToClose: true,
                 locals: {
                     user: eventCtrl.user,
-                    posts: [],
+                    posts: $state.params.posts,
                     post: event,
-                    addPost: false
+                    addPost: true
                 }
             });
         };

--- a/frontend/event/eventDetailsDirective.js
+++ b/frontend/event/eventDetailsDirective.js
@@ -26,7 +26,7 @@
                     user: eventCtrl.user,
                     posts: [],
                     post: event,
-                    addPost: false
+                    addPost: true
                 }
             });
         };

--- a/frontend/home/homeController.js
+++ b/frontend/home/homeController.js
@@ -64,7 +64,7 @@
 
         homeCtrl.goToEvents = function goToEvents() {
             homeCtrl.stateView = "events";
-            $state.go('app.user.events');
+            $state.go('app.user.events', {posts: homeCtrl.posts});
         };
 
         homeCtrl.goInvite = function goInvite() {

--- a/frontend/post/postDetailsDirective.js
+++ b/frontend/post/postDetailsDirective.js
@@ -33,6 +33,10 @@
                 postDetailsCtrl.post = new Post(postDetailsCtrl.post);
                 PostService.deletePost(postDetailsCtrl.post).then(function success() {
                     postDetailsCtrl.post.remove(postDetailsCtrl.user.name);
+                    _.remove(postDetailsCtrl.posts, function (post) {
+                        return post.key === postDetailsCtrl.post.key;
+                    });
+                    postDetailsCtrl.posts.push(postDetailsCtrl.post);
                     MessageService.showToast('Post excluído com sucesso');
                 }, function error(response) {
                     MessageService.showToast(response.data.msg);

--- a/frontend/test/specs/postDetailsControllerSpec.js
+++ b/frontend/test/specs/postDetailsControllerSpec.js
@@ -68,6 +68,7 @@
    describe('deletePost()', function(){
         beforeEach(function() {
             postDetailsCtrl.post = posts[0];
+            postDetailsCtrl.posts = [];
             spyOn(mdDialog, 'confirm').and.callThrough();
             spyOn(mdDialog, 'show').and.callFake(function(){
                 return {


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
When a post was deleted its state wasn't been refreshed in the timeline posts. Beyond that, a event that has just been shared wasn't in the timeline till it gets refreshed.
</p>

<p><b>Solution:</b>
I've refreshed the timeline's posts in the deletePost method and added the shared event to the timeline's posts, as well.
</p>

<p><b>TODO/FIXME:</b> n/a</p>
