### PR TITLE
Fix attach pdf with size greater than 5 mb

### DIFF
--- a/frontend/post/postDirective.js
+++ b/frontend/post/postDirective.js
@@ -25,6 +25,7 @@
                             };
         var observer;
         var timelineContent = document.getElementById('content');
+        var MAXIMUM_PDF_SIZE = 5242880; // 5Mb in bytes
 
         postCtrl.hasMedia = function hasMedia() {
             return postCtrl.photoBase64Data || postCtrl.pdfFiles.length > 0 || postCtrl.hasVideo || postCtrl.photoUrl;
@@ -64,7 +65,11 @@
         };
 
         postCtrl.addPdf = function addPdf(files) {
-            postCtrl.pdfFiles = files;
+            if(files[0].size > MAXIMUM_PDF_SIZE) {
+                MessageService.showToast('O arquivo deve ser um pdf menor que 5 Mb');
+            } else {
+                postCtrl.pdfFiles = files;
+            }      
         };
 
         postCtrl.createEditedPost = function createEditedPost(post) {
@@ -136,7 +141,7 @@
                         }
                         deferred.resolve();
                     }, function error(response) {
-                        MessageService.showToast(response.data.msg);
+                        MessageService.showToast(response);
                         deferred.reject();
                 });
             } else {

--- a/frontend/post/save_post.html
+++ b/frontend/post/save_post.html
@@ -68,7 +68,7 @@
               <md-menu-item ng-if="postCtrl.typePost === 'Common'">
                 <md-button ng-click="null" ng-file-model="postCtrl.files"
                   ngf-pattern="'application/pdf'" title="Adicionar pdf"
-                  ngf-accept="'application/pdf'" ngf-max-size="5MB"
+                  ngf-accept="'application/pdf'"
                   ngf-max-files="1"
                   ngf-select="postCtrl.addPdf($files)"
                   ng-disabled="postCtrl.hasMedia() && !postCtrl.showFiles()">


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
The pdfs with size greater 5mb weren't attached and the user wasn't informed about it.
</p>

<p><b>Solution:</b>
I've added a showToast that is called if the pdf's size is greater than 5mb.

![screenshot from 2018-01-31 15-44-16](https://user-images.githubusercontent.com/23387866/35641213-51b889ec-069e-11e8-93f0-05b453a77a12.png)


</p>

<p><b>TODO/FIXME:</b> n/a</p>
