### PR TITLE
Fix the accepted requests weren't removed from the controller

### DIFF
--- a/backend/models/request_user.py
+++ b/backend/models/request_user.py
@@ -87,12 +87,17 @@ class RequestUser(Invite):
         body = acceptMessage if operation == "ACCEPT" else rejectMessage
         super(RequestUser, self).send_email(host, sender_email, body)
 
+    """ 
+    The sender, in this case, is the user who is asking to be an institution's members.
+    The receiver is the institution's admin, who is receive the notification of the request.
+    """
     def send_notification(self, current_institution):
         """Method of send notification of invite user."""
         entity_type = 'REQUEST_USER'
         super(RequestUser, self).send_notification(
             current_institution=current_institution, 
-            sender_key=self.admin_key,
+            sender_key=self.sender_key,
+            receiver_key=self.admin_key,
             entity_type=entity_type
         )
 

--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -81,6 +81,9 @@
             promise.then(function success(response) {
                 manageMemberCtrl.members.push(response);
                 request.status = 'accepted';
+                _.remove(manageMemberCtrl.requests, function (each) {
+                    return each.key === request.key;
+                });
                 MessageService.showToast("Pedido aceito!");
             });
             return promise;

--- a/frontend/test/specs/managementMembersControllerSpec.js
+++ b/frontend/test/specs/managementMembersControllerSpec.js
@@ -5,7 +5,7 @@
     var REQUESTS_URI = "/api/institutions/";
 
     var manageMemberCtrl, httpBackend, scope, inviteService, createCtrl, state, authService,
-        mdDialog, institutionService;
+        mdDialog, institutionService, requestInvitationService;
 
     var invite = new Invite({invitee: "testuser@example.com",
                         type_of_invite: 'USER',
@@ -49,10 +49,16 @@
          institutions: [institution]
      };
 
+     var request = {
+         status: 'sent',
+         key: '123',
+         type_of_invite: 'REQUEST_USER'
+     }
+
     beforeEach(module('app'));
 
     beforeEach(inject(function($controller, $mdDialog, $httpBackend, $rootScope, $state, InviteService, AuthService,
-        InstitutionService) {
+        InstitutionService, RequestInvitationService) {
         httpBackend = $httpBackend;
         mdDialog = $mdDialog;
         scope = $rootScope.$new();
@@ -60,7 +66,7 @@
         inviteService = InviteService;
         institutionService = InstitutionService;
         httpBackend.when('GET', INSTITUTIONS_URI + institution.key).respond(institution);
-        httpBackend.when('GET', REQUESTS_URI + institution.key + "/requests/user").respond([]);
+        httpBackend.when('GET', REQUESTS_URI + institution.key + "/requests/user").respond([request]);
         httpBackend.when('GET', INSTITUTIONS_URI + institution.key + '/members').respond([member, user]);
         httpBackend.when('GET', 'app/institution/institution_page.html').respond(200);
         httpBackend.when('GET', "app/main/main.html").respond(200);
@@ -68,6 +74,7 @@
         httpBackend.when('GET', 'app/auth/login.html').respond(200);
         httpBackend.when('GET', "app/user/user_inactive.html").respond(200);
         authService = AuthService;
+        requestInvitationService = RequestInvitationService;
 
         authService.getCurrentUser = function() {
             return new User(user);
@@ -221,6 +228,21 @@
                 expect(mdDialog.show).toHaveBeenCalled();
                 expect(inviteService.resendInvite).toHaveBeenCalled();
             });
+        });
+
+        describe('acceptRequest', function() {
+            fit('should remove the request from the array', function() {
+                spyOn(requestInvitationService, 'acceptRequest').and.callFake(function () {
+                    return {
+                        then: function (callback) {
+                            return callback();
+                        }
+                    };
+                });
+                manageMemberCtrl.acceptRequest(request);
+                expect(request.status).toEqual('accepted');
+                expect(manageMemberCtrl.requests).toEqual([]);
+            })
         });
     });
 }));


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
When a request was accepted, it wasn't removed from the controller.
Besides, the REQUEST_USER notification wasn't been sent because it was missing receiver_key property in requestUser.send_notification method.
</p>

<p><b>Solution:</b>
I've removed the request from the controller in acceptRequest function.
I've added receiver_key in requestUser.send_notification method and fixed the sender_key field.
</p>

<p><b>TODO/FIXME:</b> n/a</p>
