### PR TITLE
Adding the missing events in notifications' action

### DIFF
--- a/frontend/notification/notificationDirective.js
+++ b/frontend/notification/notificationDirective.js
@@ -64,8 +64,8 @@
             "REQUEST_USER": {
                icon: "person_add",
                state: "process_request",
-               action: function (properties, notification) {
-                    return showDialog(properties, notification);
+               action: function (properties, notification, event) {
+                    return showDialog(properties, notification, event);
                 },
                properties: {
                     templateUrl: "app/requests/request_processing.html",
@@ -79,8 +79,8 @@
             "REQUEST_INSTITUTION_CHILDREN": {
                 icon: "account_balance",
                 state: "process_request",
-                action: function (properties, notification) {
-                    return showDialog(properties, notification);
+                action: function (properties, notification, event) {
+                    return showDialog(properties, notification, event);
                 },
                 properties: {
                      templateUrl: "app/requests/request_processing.html",
@@ -92,8 +92,8 @@
             "REQUEST_INSTITUTION_PARENT": {
                 icon: "account_balance",
                 state: "process_request",
-                action: function (properties, notification) {
-                    return showDialog(properties, notification);
+                action: function (properties, notification, event) {
+                    return showDialog(properties, notification, event);
                 },
                 properties: {
                      templateUrl: "app/requests/request_processing.html",
@@ -129,8 +129,8 @@
             "REQUEST_INSTITUTION": {
                 icon: "account_balance",
                 state: "process_request",
-                action: function (properties, notification) {
-                    return showDialog(properties, notification);
+                action: function (properties, notification, event) {
+                    return showDialog(properties, notification, event);
                 },
                 properties: {
                      templateUrl: "app/requests/request_institution_processing.html",
@@ -165,11 +165,11 @@
             }
         };
 
-        controller.action = function action(notification) {
+        controller.action = function action(notification, event) {
             var notificationProperties = type_data[notification.entity_type].properties;
             var  notificationAction = type_data[notification.entity_type].action;
             if (notificationAction){
-                notificationAction(notificationProperties, notification);
+                notificationAction(notificationProperties, notification, event);
             } else {
                 controller.goTo(notification);
             }
@@ -177,7 +177,7 @@
             controller.markAsRead(notification);
         };
 
-        function showDialog(dialogProperties, notification) {
+        function showDialog(dialogProperties, notification, event) {
             dialogProperties.locals.key = notification.entity.key;
             $mdDialog.show({
                 controller: dialogProperties.controller,

--- a/frontend/notification/notifications.html
+++ b/frontend/notification/notifications.html
@@ -15,7 +15,7 @@
         <md-icon>clear_all</md-icon>
       </md-button>
       </div>
-      <md-list-item class="md-2-line" ng-repeat="notification in controller.notifications | orderBy:'-timestamp'" ng-click="controller.action(notification)">
+      <md-list-item class="md-2-line" ng-repeat="notification in controller.notifications | orderBy:'-timestamp'" ng-click="controller.action(notification, $event)">
         <md-icon>{{controller.getIcon(notification.entity_type)}}</md-icon>
         <div class="md-list-item-text">
           <h3>{{controller.format(notification)}}</h3>


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
It was missing $event in some notification actions. This param is required by the mozilla firefox.
</p>

<p><b>Solution:</b>
I've added $event where It was missing.

![screenshot from 2018-02-02 10-21-17](https://user-images.githubusercontent.com/23387866/35735436-875f12f8-0803-11e8-9a8a-b35a70007cf4.png)


</p>

<p><b>TODO/FIXME:</b> n/a</p>
