### PR TITLE
Fix creation of many events at once

### DIFF
--- a/frontend/event/eventController.js
+++ b/frontend/event/eventController.js
@@ -315,6 +315,7 @@
 
         dialogCtrl.nextStepOrSave = function nextStepOrSave() {
             if (dialogCtrl.getStep(3)) {
+                dialogCtrl.blockPublishButton = true;
                 dialogCtrl.save();
             } else {
                 dialogCtrl.nextStep();

--- a/frontend/event/event_dialog.html
+++ b/frontend/event/event_dialog.html
@@ -207,7 +207,7 @@
                 hide-gt-xs ng-if="controller.getStep(2) || controller.getStep(3)">
                   <span style="color: white;">voltar</span>
               </md-button>
-              <md-button class="md-raised" type="submit" md-colors="{background: 'default-teal-500'}">
+              <md-button class="md-raised" type="submit" md-colors="{background: 'default-teal-500'}" ng-disabled="controller.blockPublishButton">
                   <span style="color: white;">{{controller.getStep(3) ? "publicar" : "avançar"}}</span>
               </md-button>
           </md-dialog-actions>


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
The create event's button wasn't blocked if it had already been clicked.
</p>

<p><b>Solution:</b>
I've added a ng-disabled and controlled it in the dialogController.
</p>

<p><b>TODO/FIXME:</b> n/a</p>
