### PR TITLE
Fix position of icons buttons like and reply

### DIFF
--- a/frontend/styles/custom.css
+++ b/frontend/styles/custom.css
@@ -734,6 +734,7 @@ md-radio-button.md-default-theme.md-checked .md-off, md-radio-button.md-checked 
     width: unset !important;
     min-width: unset !important;
     color: white;
+    text-align: center;
 }
 
 .md-button.xs-icon-button {
@@ -743,8 +744,10 @@ md-radio-button.md-default-theme.md-checked .md-off, md-radio-button.md-checked 
 }
 
 .xs-icon-button md-icon {
-    font-size: 12px;
-    margin: 1px;
+    font-size: 11px;
+    margin: auto;
+    height: 11px;
+    min-height: 10px;
 }
 
 .xs-delete-icon-justify md-icon {


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> Fix the position of the like and reply buttons that are decentralized in the comments screen.</p>

![screenshot from 2018-02-05 09-40-07](https://user-images.githubusercontent.com/18005317/35805256-e2cbf3c4-0a59-11e8-9b74-5ca870da19b8.png)

<p><b>Solution:</b> I changed the CSS of the buttons so that they were centralized.</p>

![screenshot from 2018-02-05 09-35-27](https://user-images.githubusercontent.com/18005317/35805268-edd2932c-0a59-11e8-84cf-a1afebf160d8.png)

<p><b>TODO/FIXME:</b> n/a</p>
