### PR TITLE
Fix color picker visualization in large screen

### DIFF
--- a/frontend/home/color_picker.html
+++ b/frontend/home/color_picker.html
@@ -1,4 +1,4 @@
-<md-dialog flex-gt-md="20" flex-md="25" layout="row">
+<md-dialog flex-lg="25" flex-md="25" flex-xl="20" layout="row">
     <div flex>
         <md-content layout-padding>
             <h3>Selecione uma cor:</h3>

--- a/frontend/home/color_picker.html
+++ b/frontend/home/color_picker.html
@@ -1,4 +1,4 @@
-<md-dialog flex-lg="25" flex-md="25" flex-xl="20" layout="row">
+<md-dialog flex-lg="25" flex-md="25" flex-gt-lg="20" flex layout="row">
     <div flex>
         <md-content layout-padding>
             <h3>Selecione uma cor:</h3>


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> Give more spacing between the colors of the user's color picker.</p>

![screenshot from 2018-02-05 10-53-01](https://user-images.githubusercontent.com/18005317/35808096-87139d2a-0a63-11e8-86bf-021bd4900c8f.png)

<p><b>Solution:</b> Using the flex-lg and flex-xl directives I added more space in the user's color picker on large screens.</p>

![screenshot from 2018-02-05 10-52-37](https://user-images.githubusercontent.com/18005317/35808103-8ad17914-0a63-11e8-9a91-37173339994d.png)

<p><b>TODO/FIXME:</b> n/a</p>
