### PR TITLE
Adding breakline in comments and replies

### DIFF
--- a/frontend/post/comment.html
+++ b/frontend/post/comment.html
@@ -13,7 +13,7 @@
                 {{commentCtrl.comment.publication_date | amUtc | amLocal | amCalendar:referenceTime:formats}}
               </small>
             </div>
-            <p style="margin-top: 4px;">{{commentCtrl.comment.text}}</p>
+            <p style="margin-top: 4px;white-space: pre-line;" ng-bind-html="commentCtrl.comment.text"></p>
           </div>
           <div layout="row" layout-align="start center" style="margin-top: 8px;">
             <div ng-if="commentCtrl.canDeleteComment()">
@@ -74,7 +74,7 @@
                 {{reply.publication_date | amUtc | amLocal | amCalendar:referenceTime:formats}}
               </small>
             </div>
-            <p style="margin-top: 4px;">{{reply.text}}</p>
+            <p style="margin-top: 4px; white-space: pre-line;" ng-bind-html="reply.text"></p>
           </div>
           <div layout="row" layout-align="start center">
             <div ng-if="commentCtrl.canDeleteComment(reply)">


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> Breakline is not displayed in comments and replies.</p>

<p><b>Solution:</b> Adding ng-bind-html to show breakline in comments and replies of post.</p>

<p><b>TODO/FIXME:</b> n/a</p>
