### PR TITLE
fix bug on event image after editing

### DIFF
--- a/frontend/event/eventController.js
+++ b/frontend/event/eventController.js
@@ -232,10 +232,10 @@
         };
 
         dialogCtrl.cleanImage = function() {
-           dialogCtrl.photoUrl = "";
-           dialogCtrl.photoBase64Data = null;
-           dialogCtrl.deletePreviousImage = true;
-           delete dialogCtrl.event.photo_url;
+            dialogCtrl.photoUrl = "";
+            dialogCtrl.photoBase64Data = null;
+            dialogCtrl.deletePreviousImage = true;
+            delete dialogCtrl.event.photo_url;
         };
 
         dialogCtrl.getCitiesByState = function getCitiesByState() {

--- a/frontend/event/eventDetailsDirective.js
+++ b/frontend/event/eventDetailsDirective.js
@@ -13,6 +13,7 @@
 
         eventCtrl.user = AuthService.getCurrentUser();
         eventCtrl.isLoadingEvents = true;
+        eventCtrl.showImage = true;
 
         eventCtrl.share = function share(ev, event) {
             $mdDialog.show({
@@ -80,8 +81,16 @@
                     isEditing: true
                 },
                 bindToController: true
-            });
+            }).then(function(){
+                eventCtrl.showImage = hasImage(event);
+            })
         };
+
+        function hasImage(event) {
+            var emptyPhoto = event && event.photo_url == "";
+            var nullPhoto = event && event.photo_url == null;
+            return !(emptyPhoto || nullPhoto);
+        }
 
         eventCtrl.isEventAuthor = function isEventAuthor(event) {
             if (event) return Utils.getKeyFromUrl(event.author_key) === eventCtrl.user.key;
@@ -113,7 +122,7 @@
         }
 
     });
-
+    
     app.directive("eventDetails", function () {
         return {
             restrict: 'E',

--- a/frontend/event/event_details.html
+++ b/frontend/event/event_details.html
@@ -1,7 +1,7 @@
 
 <div layout="column" ng-if="!eventDetailsCtrl.isDeleted(eventDetailsCtrl.event)">
   <md-card layout="column" md-colors="{background: 'default-teal-400'}">
-      <img class="md-card-image"
+      <img class="md-card-image" ng-if="eventDetailsCtrl.showImage"
       ng-src="{{ eventDetailsCtrl.event.photo_url }}"/>
     <div layout="row">
       <md-card-content style="max-height: 150px" md-colors="{background: 'default-grey-200'}">

--- a/frontend/test/specs/eventDetailsControllerSpec.js
+++ b/frontend/test/specs/eventDetailsControllerSpec.js
@@ -59,6 +59,8 @@
             mdDialog: mdDialog
         });
 
+        eventCtrl.showImage = true;
+
         httpBackend.when('GET', 'main/main.html').respond(200);
         httpBackend.when('GET', 'home/home.html').respond(200);
         httpBackend.when('GET', 'auth/login.html').respond(200);
@@ -106,7 +108,7 @@
     describe('editEvent', function () {
 
         it('should call $mdDialog.show', function () {
-            spyOn(mdDialog, 'show');
+            spyOn(mdDialog, 'show').and.returnValue(deffered.promise);
             eventCtrl.editEvent('$event', event);
             expect(mdDialog.show).toHaveBeenCalled();
         });


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>When an event has an image, and that one is removed through the edit event dialog, the image is still shown on the event details view.</p>

<p><b>Solution:</b>It was created a function to verify if the edited event has image. If don't, the image is hidden from the view. </p>

<p><b>TODO/FIXME:</b> n/a</p>
