### PR TITLE
fix bug on side menu

### DIFF
--- a/frontend/home/homeController.js
+++ b/frontend/home/homeController.js
@@ -29,6 +29,7 @@
         }
  
         homeCtrl.getSelectedItemClass = function getSelectedItemClass(state){
+            loadStateView();
              return (state === homeCtrl.stateView) ? "option-selected-left-bar":"";
          };
 


### PR DESCRIPTION


<p><b>Feature/Bug description:</b>When the user is on home view and click on 'Meu Perfil' or 'Eventos' and then click on home button on toobar, the sidebar selected option does not update to 'Inicio'</p>

<p><b>Solution:</b> it was called the loadStateView function to update the stateView variable before use it in getSelectedItemClass function</p>

<p><b>TODO/FIXME:</b> n/a</p>
