### PR TITLE
Fixing bug in edit of event

### DIFF
--- a/frontend/event/eventController.js
+++ b/frontend/event/eventController.js
@@ -162,7 +162,7 @@
             if(event.isValid()) {
                 var patch = formatPatch(generatePatch(jsonpatch.generate(dialogCtrl.observer), event));
                 EventService.editEvent(dialogCtrl.event.key, patch).then(function success() {
-                    dialogCtrl.closeDialog();
+                    $mdDialog.hide();
                     MessageService.showToast('Evento editado com sucesso.');
                 }, function error(response) {
                     MessageService.showToast(response.data.msg);
@@ -206,6 +206,7 @@
         };
 
         dialogCtrl.closeDialog = function closeDialog() {
+            dialogCtrl.resetEvent(dialogCtrl.oldEvent);
             $mdDialog.hide();
         };
 
@@ -370,7 +371,7 @@
             addLinks(event);
             if (event.isValid()) {
                 EventService.createEvent(event).then(function success(response) {
-                    dialogCtrl.closeDialog();
+                    $mdDialog.hide();
                     dialogCtrl.events.push(response.data);
                     MessageService.showToast('Evento criado com sucesso!');
                 }, function error(response) {
@@ -439,6 +440,7 @@
                 loadSelectedState();
                 initPatchObserver();
                 loadEventDates();
+                dialogCtrl.oldEvent = _.cloneDeep(dialogCtrl.event);
             } else {
                 dialogCtrl.event = {
                                     address: address

--- a/frontend/event/eventDetailsDirective.js
+++ b/frontend/event/eventDetailsDirective.js
@@ -77,7 +77,8 @@
                 clickOutsideToClose: true,
                 locals: {
                     event: event,
-                    isEditing: true
+                    isEditing: true,
+                    resetEvent: resetEvent
                 },
                 bindToController: true
             });
@@ -110,6 +111,10 @@
         function isInstitutionAdmin(event) {
             return _.includes(_.map(eventCtrl.user.institutions_admin, Utils.getKeyFromUrl),
                 Utils.getKeyFromUrl(event.institution_key));
+        }
+
+        function resetEvent(oldEvent) {
+            eventCtrl.event = _.cloneDeep(oldEvent);
         }
 
     });


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> When the edition of event is canceled, the edited informations keep in event page.</p>

<p><b>Solution:</b> Passing function to dialog to reset event object of event_page.</p>

<p><b>TODO/FIXME:</b> n/a</p>
