### PR TITLE
Fix visulization of likes in post page

### DIFF
--- a/frontend/post/postDetailsDirective.js
+++ b/frontend/post/postDetailsDirective.js
@@ -10,7 +10,6 @@
 
         var LIMIT_POST_CHARACTERS = 1000;
 
-        postDetailsCtrl.showLikes = false;
         postDetailsCtrl.showComments = false;
         postDetailsCtrl.savingComment = false;
         postDetailsCtrl.savingLike = false;
@@ -331,8 +330,7 @@
 
         postDetailsCtrl.getLikes = function getLikes() {
             var likesUri = postDetailsCtrl.post.likes;
-            postDetailsCtrl.showLikes = !postDetailsCtrl.showLikes;
-            if(postDetailsCtrl.showLikes) {
+            if(postDetailsCtrl.isPostPage) {
                 var promise = PostService.getLikes(likesUri);
                 promise.then(function success(response) {
                     postDetailsCtrl.post.data_likes = response.data;

--- a/frontend/test/specs/postDetailsControllerSpec.js
+++ b/frontend/test/specs/postDetailsControllerSpec.js
@@ -58,6 +58,8 @@
             $rootScope: rootscope,
             $scope: scope
         });
+
+        postDetailsCtrl.isPostPage = true;
     }));
 
     afterEach(function() {
@@ -141,14 +143,12 @@
             httpBackend.expect('POST', POSTS_URI + '/' + posts[0].key + '/likes').respond();
             httpBackend.expect('GET', "/api/posts/123456/likes").respond();
             postDetailsCtrl.user.liked_posts = [];
-            expect(postDetailsCtrl.showLikes).toEqual(false);
             postDetailsCtrl.likeOrDislikePost(posts[0]).then(function() {
                 expect(posts[0].number_of_likes).toEqual(1);
             });
             httpBackend.flush();
             expect(postDetailsCtrl.isLikedByUser).toHaveBeenCalledWith();
             expect(postDetailsCtrl.getLikes).toHaveBeenCalledWith(posts[0]);
-            expect(postDetailsCtrl.showLikes).toEqual(true);
             expect(postService.likePost).toHaveBeenCalledWith(posts[0]);
         });
 


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> Fix view of the user they like in the post on the post details page.</p>

<p><b>Solution:</b> I removed the variable showLikes that was preventing the likes from being viewed in the post.</p>

<p><b>TODO/FIXME:</b> n/a</p>
