### PR TITLE
Fix missing of broke lines in shared post

### DIFF
--- a/frontend/post/post_details.html
+++ b/frontend/post/post_details.html
@@ -124,7 +124,7 @@
       href class="md-text hyperlink" ng-click="postDetailsCtrl.goToPost(postDetailsCtrl.post.shared_post)">
         <span>{{ postDetailsCtrl.post.shared_post.title }}</span>
       </a>
-      <p class="break" ng-if="!postDetailsCtrl.isDeleted(postDetailsCtrl.post.shared_post)"
+      <p class="text" ng-if="!postDetailsCtrl.isDeleted(postDetailsCtrl.post.shared_post)"
         ng-bind-html="postDetailsCtrl.postToURL(postDetailsCtrl.post.shared_post).text" ></p>
       <div layout="row" layout-align="end-center">
         <a href class="md-text hyperlink" ng-click="postDetailsCtrl.goToPost(postDetailsCtrl.post.shared_post)"


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
The shared post wasn't showing the line's break.

![screenshot from 2018-02-06 08-56-35](https://user-images.githubusercontent.com/23387866/35858814-9323d97c-0b1c-11e8-8907-1719086c33dc.png)


</p>

<p><b>Solution:</b>
Change the css' class in p tag

![screenshot from 2018-02-06 08-56-10](https://user-images.githubusercontent.com/23387866/35858832-a37c8878-0b1c-11e8-834f-d54d6edbdc4e.png)


</p>

<p><b>TODO/FIXME:</b> n/a</p>
