### PR TITLE
Hide message of required title in save post html

### DIFF
--- a/frontend/post/save_post.html
+++ b/frontend/post/save_post.html
@@ -12,7 +12,7 @@
               <md-input-container md-no-float class="md-block" style="margin: 0px; padding-top: 10px;">
                 <input name="title" style="font-weight: bold; color: #00695C; border: 0;resize:none;"
                 ng-model="postCtrl.post.title" maxlength="100" placeholder="{{postCtrl.showPlaceholderMsg()}}" required>
-                <div ng-messages='saveForm.title.$error'>
+                <div ng-show="postCtrl.isTyping()" ng-messages='saveForm.title.$error'>
                     <div ng-message="required">O post deve conter um título!</div>
                 </div>
               </md-input-container>


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> Hide the message that the post must contain a title when the post is empty.</p>

![screenshot from 2018-02-07 08-36-30](https://user-images.githubusercontent.com/18005317/35914997-166cc376-0be4-11e8-8d34-f4f83a5fda2a.png)

<p><b>Solution:</b> Using the ng-show directive I created a check to know if the post is empty or not if it is, does not show the message that the post should contain a title.</p>

![screenshot from 2018-02-07 08-36-53](https://user-images.githubusercontent.com/18005317/35915009-1c1878b0-0be4-11e8-949c-082d5182ffc1.png)

<p><b>TODO/FIXME:</b> n/a</p>
