### PR TITLE
Fix bug of create profile in request user

### DIFF
--- a/backend/handlers/request_handler.py
+++ b/backend/handlers/request_handler.py
@@ -62,11 +62,22 @@ class RequestHandler(BaseHandler):
         sender.add_institution(institution_key)
         sender.follow(institution_key)
         sender.change_state('active')
-        sender.put()
 
         institution.add_member(sender)
         institution.follow(sender.key)
         institution.put()
+        import pdb
+        pdb.set_trace()
+
+        data_profile = {
+            'office': request.office,
+            'email': request.institutional_email,
+            'institution_key': institution_key.urlsafe(),
+            'institution_name': institution.name,
+            'institution_photo_url': institution.photo_url
+        }
+        sender.create_and_add_profile(data_profile)
+        sender.put()
 
         host = self.request.host
         request.send_response_email(host, "ACCEPT")

--- a/backend/handlers/request_handler.py
+++ b/backend/handlers/request_handler.py
@@ -75,7 +75,6 @@ class RequestHandler(BaseHandler):
             'institution_photo_url': institution.photo_url
         }
         sender.create_and_add_profile(data_profile)
-        sender.put()
 
         host = self.request.host
         request.send_response_email(host, "ACCEPT")

--- a/backend/handlers/request_handler.py
+++ b/backend/handlers/request_handler.py
@@ -66,8 +66,6 @@ class RequestHandler(BaseHandler):
         institution.add_member(sender)
         institution.follow(sender.key)
         institution.put()
-        import pdb
-        pdb.set_trace()
 
         data_profile = {
             'office': request.office,

--- a/backend/handlers/user_request_collection_handler.py
+++ b/backend/handlers/user_request_collection_handler.py
@@ -44,18 +44,8 @@ class UserRequestCollectionHandler(BaseHandler):
 
         request = InviteFactory.create(data, type_of_invite)
         request.put()
-
-        institution = ndb.Key(urlsafe=institution_key).get()
+        
         user.name = data.get('sender_name')
-
-        # data_profile = {
-        #     'office': request.office,
-        #     'email': request.institutional_email,
-        #     'institution_key': institution_key,
-        #     'institution_name': institution.name,
-        #     'institution_photo_url': institution.photo_url
-        # }
-        # user.create_and_add_profile(data_profile)
 
         if(request.stub_institution_key):
             request.stub_institution_key.get().addInvite(request)

--- a/backend/handlers/user_request_collection_handler.py
+++ b/backend/handlers/user_request_collection_handler.py
@@ -48,14 +48,14 @@ class UserRequestCollectionHandler(BaseHandler):
         institution = ndb.Key(urlsafe=institution_key).get()
         user.name = data.get('sender_name')
 
-        data_profile = {
-            'office': request.office,
-            'email': request.institutional_email,
-            'institution_key': institution_key,
-            'institution_name': institution.name,
-            'institution_photo_url': institution.photo_url
-        }
-        user.create_and_add_profile(data_profile)
+        # data_profile = {
+        #     'office': request.office,
+        #     'email': request.institutional_email,
+        #     'institution_key': institution_key,
+        #     'institution_name': institution.name,
+        #     'institution_photo_url': institution.photo_url
+        # }
+        # user.create_and_add_profile(data_profile)
 
         if(request.stub_institution_key):
             request.stub_institution_key.get().addInvite(request)

--- a/backend/handlers/user_request_collection_handler.py
+++ b/backend/handlers/user_request_collection_handler.py
@@ -46,6 +46,7 @@ class UserRequestCollectionHandler(BaseHandler):
         request.put()
         
         user.name = data.get('sender_name')
+        user.put()
 
         if(request.stub_institution_key):
             request.stub_institution_key.get().addInvite(request)

--- a/backend/test/request_handler_test.py
+++ b/backend/test/request_handler_test.py
@@ -81,6 +81,7 @@ class RequestHandlerTest(TestBaseHandler):
         admin = mocks.create_user(ADMIN['email'])
         institution = mocks.create_institution()		 
         institution.admin = admin.key
+        institution.photo_url = 'tst.jpg'
         institution.put()
         admin.institutions_admin = [institution.key]
         admin.add_permission("answer_user_request", institution.key.urlsafe())
@@ -92,6 +93,7 @@ class RequestHandlerTest(TestBaseHandler):
         'is_request': True,
         'admin_key': admin.key.urlsafe(),
         'institution_key': institution.key.urlsafe(),
+        'office': 'Dev',
         'type_of_invite': 'REQUEST_USER'
         }
         request = RequestUser.create(data)
@@ -131,6 +133,7 @@ class RequestHandlerTest(TestBaseHandler):
         admin = mocks.create_user(ADMIN['email'])
         institution = mocks.create_institution()		 
         institution.admin = admin.key
+        institution.photo_url = 'tst.jpg'
         institution.put()
         admin.institutions_admin = [institution.key]
         admin.add_permission("answer_user_request", institution.key.urlsafe())
@@ -141,6 +144,7 @@ class RequestHandlerTest(TestBaseHandler):
         'is_request': True,
         'admin_key': admin.key.urlsafe(),
         'institution_key': institution.key.urlsafe(),
+        'office': 'Dev',
         'type_of_invite': 'REQUEST_USER'
         }
         request = RequestUser.create(data)

--- a/backend/test/user_request_collection_handler_test.py
+++ b/backend/test/user_request_collection_handler_test.py
@@ -76,9 +76,6 @@ class UserRequestCollectionHandlerTest(TestBaseHandler):
             self.user_admin.name,
             'Expected sender admin_name is User Admin')
         self.assertEqual(
-            len(user_updated.institution_profiles),
-            1, 'Expected one profile in user profiles')
-        self.assertEqual(
             user_updated.name, 'user name updated',
             'Expected new user name is user name updated')
 


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> When making a request to be a member of an institution the profile of the user is already created before the request is accepted, which causes a bug when selecting the current institution, since the requested institution already appears even without the request being accepted.</p>

<p><b>Solution:</b> I moved the user profile creation of the user request collection handler to the request handler, so that the profile is created only if the request is accepted.</p>

<p><b>TODO/FIXME:</b> n/a</p>
