### PR TITLE
add current institution to user requests

### DIFF
--- a/backend/handlers/institution_request_collection_handler.py
+++ b/backend/handlers/institution_request_collection_handler.py
@@ -54,7 +54,8 @@ class InstitutionRequestCollectionHandler(BaseHandler):
     @json_response
     def post(self, user, institution_key):
         """Handler of post requests."""
-        data = json.loads(self.request.body)
+        body = json.loads(self.request.body)
+        data = body['data']
         host = self.request.host
         inst_request_type = 'REQUEST_INSTITUTION'
 
@@ -77,6 +78,6 @@ class InstitutionRequestCollectionHandler(BaseHandler):
         request = InviteFactory.create(data, type_of_invite)
         request.put()
 
-        request.send_invite(host)
+        request.send_invite(host, user.current_institution)
 
         self.response.write(json.dumps(request.make()))

--- a/backend/handlers/request_handler.py
+++ b/backend/handlers/request_handler.py
@@ -76,7 +76,9 @@ class RequestHandler(BaseHandler):
             request.sender_key.urlsafe(),
             user.key.urlsafe(),
             entity_type,
-            institution.key.urlsafe())
+            institution.key.urlsafe(),
+            user.current_institution
+        )
 
         self.response.write(json.dumps(makeUser(sender, self.request)))
 

--- a/backend/handlers/user_request_collection_handler.py
+++ b/backend/handlers/user_request_collection_handler.py
@@ -31,7 +31,8 @@ class UserRequestCollectionHandler(BaseHandler):
     @json_response
     def post(self, user, institution_key):
         """Handler of post requests."""
-        data = json.loads(self.request.body)
+        body = json.loads(self.request.body)
+        data = body['data']
         host = self.request.host
         user_request_type = 'REQUEST_USER'
 

--- a/backend/service_messages.py
+++ b/backend/service_messages.py
@@ -33,14 +33,18 @@ def create_entity(entity_key):
     """Create a short entity with only key and name."""
     entity_obj = ndb.Key(urlsafe=entity_key).get()
     class_name = entity_obj.__class__.__name__
+    is_post = class_name == 'Post'
+    is_institution = class_name == 'Institution'
+    is_invite = 'Invite' in class_name
+    is_request = 'Request' in class_name
     name = ''
 
-    if class_name == 'Post':
+    if is_post:
         institution = entity_obj.institution.get()
         name = institution.name
-    elif class_name == 'Institution':
+    elif is_institution:
         name = entity_obj.name
-    elif 'Invite' in class_name:
+    elif is_invite or is_request:
         institution = entity_obj.institution_key.get()
         name = institution.name
     

--- a/backend/test/institution_request_collection_handler_test.py
+++ b/backend/test/institution_request_collection_handler_test.py
@@ -4,6 +4,7 @@
 import json
 from test_base_handler import TestBaseHandler
 from handlers.institution_request_collection_handler import InstitutionRequestCollectionHandler
+from models.invite import Invite
 
 from mock import patch
 import mocks
@@ -23,8 +24,9 @@ class InstitutionRequestCollectionHandlerTest(TestBaseHandler):
              ], debug=True)
         cls.testapp = cls.webtest.TestApp(app)
 
+    @patch.object(Invite, 'send_invite')
     @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
-    def test_post(self, verify_token):
+    def test_post(self, verify_token, send_invite):
         """Test handler post."""
         # Initialize objects
         self.other_user = mocks.create_user()
@@ -46,8 +48,9 @@ class InstitutionRequestCollectionHandlerTest(TestBaseHandler):
             },
             'type_of_invite': 'REQUEST_INSTITUTION'
         }
+        body = {"data": data}
 
-        response = self.testapp.post_json(InstitutionRequestCollectionHandlerTest.REQUEST_URI, data)
+        response = self.testapp.post_json(InstitutionRequestCollectionHandlerTest.REQUEST_URI, body)
         request = json.loads(response._app_iter[0])
 
         self.assertEqual(
@@ -79,3 +82,5 @@ class InstitutionRequestCollectionHandlerTest(TestBaseHandler):
             request['requested_inst_name'],
             "Complexo Industrial da Saude",
             "Expected institution_requested be new inst")
+
+        send_invite.assert_called_with('localhost:80', None)

--- a/frontend/requests/requestInvitationService.js
+++ b/frontend/requests/requestInvitationService.js
@@ -8,7 +8,8 @@
         var REQUESTS_URI = "/api/institutions/";
 
         service.sendRequest = function sendRequest(request, institution_key) {
-            return HttpService.post(REQUESTS_URI + institution_key + "/requests/user", request);
+            var body = {data: request};
+            return HttpService.post(REQUESTS_URI + institution_key + "/requests/user", body);
         };
 
         service.sendRequestInst = function sendRequestInst(request) {


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> The user current Institution was not being passed to the appropriate methods to create the notifications for user requests</p>

<p><b>Solution:</b> On institution request collection handler and on request handler, it was added the current institution to the methods send_invites and send_message_notification, respectively. Besides that, it was changed the way the data is sent on user requests </p>

<p><b>TODO/FIXME:</b> n/a</p>
