### PR TITLE
Add current institution to delete members notifications

### DIFF
--- a/backend/handlers/institution_members_handler.py
+++ b/backend/handlers/institution_members_handler.py
@@ -51,7 +51,9 @@ class InstitutionMembersHandler(BaseHandler):
                 member.key.urlsafe(),
                 user.key.urlsafe(),
                 entity_type,
-                institution.key.urlsafe())
+                institution.key.urlsafe(),
+                user.current_institution
+            )
 
         subject = "Remoção de vínculo"
         message = """Lamentamos informar que seu vínculo com a instituição %s


### PR DESCRIPTION


<p><b>Feature/Bug description:</b> The current institution name was not being send on delete members notifications</p>

<p><b>Solution:</b> It was added the user current institution to send_message_notification call and the related tests were updated</p>

<p><b>TODO/FIXME:</b> n/a</p>
