### PR TITLE
Fix edit event: City verification

### DIFF
--- a/frontend/event/event_dialog.html
+++ b/frontend/event/event_dialog.html
@@ -120,7 +120,7 @@
                         <md-option ng-repeat="city in controller.cities" ng-value="city">{{city}}</md-option>
                       </md-select>
                       <div ng-messages>
-                          <div ng-show="createEvent.state.$pristine && !controller.isAnotherCountry"
+                          <div ng-show="createEvent.state.$pristine && !controller.isAnotherCountry && !controller.selectedFederalState"
                               style="opacity: 0.9; margin-top: 2px; font-size: 0.8em;">
                               Primeiro selecione um estado
                           </div>

--- a/frontend/event/event_dialog.html
+++ b/frontend/event/event_dialog.html
@@ -2,7 +2,7 @@
   <div style="padding:0;">
     <md-card style="max-width: 100%; margin:0;">
       <md-card-content style="padding: 8px;">
-        <div layout="row" layout-align="space-between center" class="custom-scrollbar" style="overflow-y: auto;">
+        <div layout="row" layout-align="space-between center" class="hide-scrollbar" style="overflow-y: auto;">
           <div layout="row" layout-align="center center">
             <span class="green-circle" style="color: #FFFFFF; width: 20px; height: 20px;">
               <span layout="row" layout-algin="center">


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
Even if a state was selected the message "Escolha um estado primeiro" in the city field was showing.

![screenshot from 2018-02-08 09-10-30](https://user-images.githubusercontent.com/23387866/35974508-2af9a5a0-0cb8-11e8-82f5-e7e41c38894e.png)


</p>

<p><b>Solution:</b>
I've added a missing verification.
</p>

<p><b>TODO/FIXME:</b> n/a</p>
