### PR TITLE
Add current institution to delete institution notification

### DIFF
--- a/backend/handlers/institution_handler.py
+++ b/backend/handlers/institution_handler.py
@@ -215,6 +215,7 @@ class InstitutionHandler(BaseHandler):
         notification_params = {
             "sender_key": user.key.urlsafe(),
             "entity_type": "DELETED_INSTITUTION",
-            "institution_key": institution_key
+            "institution_key": institution_key,
+            "current_institution": user.current_institution.urlsafe()
         }
         enqueue_task('notify-followers', notification_params)

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -149,7 +149,8 @@ class NotifyFollowersHandler(BaseHandler):
         sender_key = self.request.get('sender_key')
         entity_type = self.request.get('entity_type')
         inst_key = self.request.get('institution_key')
-
+        current_institution = ndb.Key(urlsafe=self.request.get('current_institution'))
+        
         institution = ndb.Key(urlsafe=inst_key).get()
 
         for follower_key in institution.followers:
@@ -160,7 +161,8 @@ class NotifyFollowersHandler(BaseHandler):
                     follower.key.urlsafe(),
                     sender_key,
                     entity_type,
-                    inst_key
+                    inst_key,
+                    current_institution
                 )
 
 


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> The current institution name is not present on delete institution notification</p>

<p><b>Solution:</b> It was added current institution to notification params at institution handler delete method</p>

<p><b>TODO/FIXME:</b> n/a</p>
