### PR TITLE
Simplify vote method

### DIFF
--- a/backend/models/survey_post.py
+++ b/backend/models/survey_post.py
@@ -4,19 +4,6 @@ from google.appengine.ext import ndb
 from utils import Utils
 import datetime
 
-@ndb.transactional(retries=10)
-def update_vote(survey_key, user, option_id):
-    """Add a vote to the survey post."""
-    survey = survey_key.get()
-    option = survey.options[option_id]
-
-    option["number_votes"] += 1
-    option["voters"].append(user)
-    survey.number_votes += 1
-    survey.options[option_id] = Utils.toJson(option)
-    survey.put()
-
-    return survey
 
 class SurveyPost(Post):
     """Model of survey post."""
@@ -47,26 +34,32 @@ class SurveyPost(Post):
             data, author_key, institution_key)
         return survey_post
 
-    def is_vote_valid(self, author, option):
+    def is_vote_valid(self, author, option, number_options_selected):
         """Verify if vote is valid."""
         if(self.deadline and datetime.datetime.now() > self.deadline):
             raise Exception("Deadline for receive answers has passed.")
 
         if(author in option["voters"]):
             raise Exception("The user already voted for this option")
+        
+        if(self.type_survey == "binary" and number_options_selected != 1):
+            raise Exception("The binary survey should only receive one option")
 
         return True
 
+    @ndb.transactional(retries=10)
     def vote(self, author, all_options_selected):
         """Added all votes of user from survey post."""
-        if(self.type_survey == "binary" and
-            len(all_options_selected) == 1 and
-            self.is_vote_valid(author, all_options_selected[0])):
-           update_vote(self.key, author, all_options_selected[0]["id"])
-        else:
-            for option in all_options_selected:
-                if(self.is_vote_valid(author, option)):
-                    update_vote(self.key, author, option["id"])
+        for option in all_options_selected:
+            if(self.is_vote_valid(author, option, len(all_options_selected))):
+                survey = self.key.get()
+                option = survey.options[option["id"]]
+
+                option["number_votes"] += 1
+                option["voters"].append(author)
+                survey.number_votes += 1
+                survey.options[option["id"]] = Utils.toJson(option)
+                survey.put()
 
     def make(post, host):
         """Create personalized json of post."""

--- a/backend/test/model_test/survey_post_test.py
+++ b/backend/test/model_test/survey_post_test.py
@@ -52,32 +52,46 @@ class SurveyPostTest(TestBase):
         """Test the is_valid method."""
         frist_vote = self.data_binary["options"][0]
         second_vote = self.data_binary["options"][1]
+        TOTAL_VOTES = 1
         survey_binary = SurveyPost.create(
             self.data_binary, self.user.key, self.institution.key)
         survey_multiple = SurveyPost.create(
             self.data_multiple, self.user.key, self.institution.key)
 
         self.assertEquals(
-            survey_binary.is_vote_valid(self.user.key, frist_vote),
+            survey_binary.is_vote_valid(self.user.key, frist_vote, TOTAL_VOTES),
             True, "It should be True"
         )
         self.assertEquals(
-            survey_multiple.is_vote_valid(self.user.key, second_vote),
+            survey_multiple.is_vote_valid(self.user.key, second_vote, TOTAL_VOTES),
+            True, "It should be True"
+        )
+
+        self.assertEquals(
+            survey_multiple.is_vote_valid(self.user.key, second_vote, TOTAL_VOTES + 1),
             True, "It should be True"
         )
 
         frist_vote['voters'].append(self.user.key)
         with self.assertRaises(Exception) as ex:
-            survey_binary.is_vote_valid(self.user.key, frist_vote)
+            survey_binary.is_vote_valid(self.user.key, frist_vote, TOTAL_VOTES)
 
         self.assertEqual(
             'The user already voted for this option',
             str(ex.exception),
             'The user already voted for this option')
 
+        with self.assertRaises(Exception) as ex:
+            survey_binary.is_vote_valid(self.user.key, second_vote, TOTAL_VOTES + 1)
+
+        self.assertEqual(
+            'The binary survey should only receive one option',
+            str(ex.exception),
+            'The binary survey should only receive one option')
+
         survey_binary.deadline = datetime.datetime(2002, 12, 25)
         with self.assertRaises(Exception) as ex:
-            survey_binary.is_vote_valid(self.user.key, frist_vote)
+            survey_binary.is_vote_valid(self.user.key, frist_vote, TOTAL_VOTES)
 
         self.assertEqual(
             'Deadline for receive answers has passed.',


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>The flow to vote in a survey must pass through two methods in order to vote</p>

<p><b>Solution:</b>Simplify to use only one method, that is generic to binary survey and multiple options survey. In addition, insert a verification to check if the vote for binary survey has only one option selected.</p>

<p><b>TODO/FIXME:</b> n/a</p>
