### PR TITLE
Adding filter to correct deletion of a comment by id.

### DIFF
--- a/frontend/post/postDetailsDirective.js
+++ b/frontend/post/postDetailsDirective.js
@@ -586,7 +586,8 @@
         commentCtrl.deleteComment = function deleteComment() {
             CommentService.deleteComment(commentCtrl.post.key, commentCtrl.comment.id).then(
                 function success() {
-                    delete commentCtrl.post.data_comments[commentCtrl.comment.id];
+                    commentCtrl.post.data_comments = commentCtrl.post.data_comments
+                        .filter(comment => comment.id !== commentCtrl.comment.id);
                     commentCtrl.post.number_of_comments--;
                     MessageService.showToast('Comentário excluído com sucesso');
                 }, function error(response) {

--- a/frontend/test/specs/commentControllerSpec.js
+++ b/frontend/test/specs/commentControllerSpec.js
@@ -124,12 +124,12 @@
                 };
             });
             spyOn(commentService, 'deleteComment').and.callThrough();
-            commentCtrl.post.data_comments = {5: comment};
+            commentCtrl.post.data_comments = [comment];
             httpBackend.expect('DELETE', POSTS_URI + '/' + posts[0].key + '/comments/' + "5").respond(comment);
             commentCtrl.confirmCommentDeletion("$event");
             httpBackend.flush();
             expect(commentService.deleteComment).toHaveBeenCalledWith(commentCtrl.post.key, 5);
-            expect(commentCtrl.post.data_comments).toEqual({});
+            expect(commentCtrl.post.data_comments).toEqual([]);
             expect(mdDialog.confirm).toHaveBeenCalled();
             expect(mdDialog.show).toHaveBeenCalled();
         });


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> After deletion of a comment in post page, the comment continue appearing in post page (disappearing after refresh the page).</p>

<p><b>Solution:</b> Changing the delete in array to a filter to the correct deletion of the comment.</p>

<p><b>TODO/FIXME:</b> n/a</p>
