### PR TITLE
Making the name of institution clickable in config_profile page

### DIFF
--- a/frontend/auth/configProfileController.js
+++ b/frontend/auth/configProfileController.js
@@ -193,6 +193,11 @@
             }
         };
 
+        configProfileCtrl.goToInstitution = function goToInstitution(institutionKey) {
+            const url = $state.href('app.institution.timeline', {institutionKey: institutionKey});
+            window.open(url, '_blank');
+        };
+
         function deleteUser() {
             var patch = jsonpatch.generate(observer);
             var promise = UserService.save(patch);

--- a/frontend/auth/config_profile.html
+++ b/frontend/auth/config_profile.html
@@ -64,9 +64,13 @@
                   <md-subheader class="md-no-sticky">Seus vínculos institucionais:</md-subheader>
                   <md-list-item class="md-3-line" ng-repeat="institution in configProfileCtrl.newUser.institutions track by institution.key">
                     <img style="border-radius: 50%; " ng-src="{{ institution.photo_url }}" width="50px" height="50px" />
-                    <div style="margin-left: 10px;" class="md-list-item-text" layout="column">
-                      <h3>{{ institution.acronym }}</h3>
-                      <h4>{{ institution.name }}</h4>
+                    <div style="margin-left: 10px; margin-top: 9px;" class="md-list-item-text" layout="column">
+                      <a href class="hyperlink" target="_blank" ng-click="configProfileCtrl.goToInstitution(institution.key)">
+                          {{ institution.acronym }}
+                      </a>
+                      <a href class="hyperlink" target="_blank" ng-click="configProfileCtrl.goToInstitution(institution.key)">
+                          {{ institution.name }}
+                      </a>
                     </div>
                     <div layout="row">
                       <md-button class="md-secondary sm-icon-button" title="Editar perfil institucional"


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> The name and acronym of institutions in config_profile page is not clickable.</p>

<p><b>Solution:</b> Adding href in html to make name and acronym of institutions clickable and opening the institution page in a new window of browser.</p>

<p><b>TODO/FIXME:</b> n/a</p>
