### PR TITLE
Fix comment in post page

### DIFF
--- a/frontend/post/postDetailsDirective.js
+++ b/frontend/post/postDetailsDirective.js
@@ -302,10 +302,6 @@
             $state.go('app.user.event', {eventKey: event.key});
         };
 
-        postDetailsCtrl.getValues = function getValues(object) {
-            return _.values(object);
-        };
-
         postDetailsCtrl.reloadPost = function reloadPost() {
             var promise = PostService.getPost(postDetailsCtrl.post.key);
             promise.then(function success(response) {

--- a/frontend/post/postDetailsDirective.js
+++ b/frontend/post/postDetailsDirective.js
@@ -321,7 +321,7 @@
         postDetailsCtrl.loadComments = function refreshComments() {
             var promise  =  CommentService.getComments(postDetailsCtrl.post.comments);
             promise.then(function success(response) {
-                postDetailsCtrl.post.data_comments = response.data;
+                postDetailsCtrl.post.data_comments = _.values(response.data);
                 postDetailsCtrl.post.number_of_comments = _.size(postDetailsCtrl.post.data_comments);
                 postDetailsCtrl.isLoadingComments = false;
             }, function error(response) {
@@ -358,7 +358,7 @@
 
         function addComment(post, comment) {
             var postComments = postDetailsCtrl.post.data_comments;
-            postComments[comment.id] = comment;
+            postComments.push(comment);
             post.number_of_comments += 1;
         }
 

--- a/frontend/post/post_details.html
+++ b/frontend/post/post_details.html
@@ -228,7 +228,7 @@
     <load-circle flex ng-if="postDetailsCtrl.isLoadingComments && !postDetailsCtrl.isPostPage"></load-circle>
     <md-divider style="margin-top: 15px;"></md-divider>
     <comment ng-if="!postDetailsCtrl.isLoadingComments || postDetailsCtrl.isPostPage"
-      ng-repeat="comment in postDetailsCtrl.getValues(postDetailsCtrl.post.data_comments) | orderBy:'publication_date'"
+      ng-repeat="comment in postDetailsCtrl.post.data_comments | orderBy:'publication_date'"
       comment="comment" user="postDetailsCtrl.user" post="postDetailsCtrl.post"></comment>
   </div>
   


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> When the user open the post page and try to submit a comment, the application hangs. This problem was caused by inconsistency in the handling of comments coming from the backend, in the timeline, they are treated as a comment object and in the post page as a list. This inconsistency made the method of adding comments not work as expected, since the addition was being done using the comment id as the index of the object, for example, comments [id] = comment. When the comments were in the form of the list (On the post page) the addition did not work as expected because the comment id is a very large number, and this causes a very high index to be added to the list, causing an infinite loop in the ng-repeat of comments.</p>

<p><b>Solution:</b> Treat the comments of the posts in the timeline and the post page in the same way (Treating as lists) and modify the method of adding comments to push the list instead of accessing the index directly.</p>

<p><b>TODO/FIXME:</b> n/a</p>
