### PR TITLE
Add load circle in timeline

### DIFF
--- a/frontend/post/timeline.html
+++ b/frontend/post/timeline.html
@@ -9,4 +9,5 @@
     <post-details posts="timelineCtrl.posts" post="post" is-post-page=false add-post="addPost"></post-details>
   </div>
   <!-- LOADING CIRCLE -->
+  <load-circle ng-if="timelineCtrl.isLoadingPosts"></load-circle>
 </div>


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> Add load circle in the timeline if load more posts.</p>

<p><b>Solution:</b> I added load circle in the timeline using load-circle directive.</p>

![screenshot from 2018-02-16 11-45-03](https://user-images.githubusercontent.com/18005317/36313285-d2f9789a-130f-11e8-8fdb-6092157cbafe.png)

<p><b>TODO/FIXME:</b> n/a</p>
