### PR TITLE
Fix tutorial dialog in small screens

### DIFF
--- a/frontend/invites/welcome_dialog.html
+++ b/frontend/invites/welcome_dialog.html
@@ -20,10 +20,10 @@
     </div>
 </md-dialog>
 
-<div flex="50" flex-gt-md="30" ng-if="controller.next" style="position: relative; left: 10%; top: 35%;">
+<div flex="50" flex-gt-md="30" ng-if="controller.next" style="margin-bottom: -40%;">
     <md-card>
         <md-card-content layout="column">
-            <p class="md-subhead" layout-margin>
+            <p layout-margin>
                 Clique nesse botão na página em que você gostaria de sugerir ou relatar um problema.
             </p>
         </md-card-content >

--- a/frontend/invites/welcome_dialog.html
+++ b/frontend/invites/welcome_dialog.html
@@ -1,4 +1,4 @@
-<md-dialog layout="row" flex-gt-md="40" style="box-shadow: none;">
+<md-dialog layout="row" flex-gt-md="40" style="box-shadow: none; position: relative;">
     <div flex ng-if="!controller.next">
         <md-dialog-content class="md-dialog-content" layout="column">
             <h3 class="md-title" md-colors="{color: 'default-grey-800'}">Bem vindo a versão de testes da Plataforma CIS</h3>
@@ -20,7 +20,7 @@
     </div>
 </md-dialog>
 
-<div flex="50" flex-gt-md="30" ng-if="controller.next" style="margin-bottom: -40%;">
+<div flex="50" flex-gt-md="30" ng-if="controller.next" style="position: absolute; bottom: 30px; right: 4.5%;">
     <md-card>
         <md-card-content layout="column">
             <p layout-margin>


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
The tutorial's dialog was broken in small screens

![screenshot from 2018-02-16 13-03-52](https://user-images.githubusercontent.com/23387866/36317040-beae79d4-131a-11e8-8f56-97fd6827a677.png)


</p>

<p><b>Solution:</b>
I've tried to find a position that works in both small and large screens.

![screenshot from 2018-02-16 13-02-03](https://user-images.githubusercontent.com/23387866/36317066-cdf9e694-131a-11e8-8cc5-41bbebb919de.png)


![screenshot from 2018-02-16 13-02-19](https://user-images.githubusercontent.com/23387866/36317054-c7549df2-131a-11e8-88df-7645f909d9c8.png)


</p>

<p><b>TODO/FIXME:</b> n/a</p>
