### PR TITLE
Fix reply deleted comment

### DIFF
--- a/backend/models/post.py
+++ b/backend/models/post.py
@@ -4,6 +4,7 @@ from google.appengine.ext import ndb
 from google.appengine.ext.ndb.polymodel import PolyModel
 from custom_exceptions.fieldException import FieldException
 from custom_exceptions.notAuthorizedException import NotAuthorizedException
+from custom_exceptions.entityException import EntityException
 from models.event import Event
 from utils import Utils
 
@@ -252,7 +253,9 @@ class Post(PolyModel):
         self.put()
 
     def reply_comment(self, reply, comment_id):
-        comment = self.comments.get(comment_id)
+        comment = self.get_comment(comment_id)
+        Utils._assert(
+            not comment, "This comment has been deleted.", EntityException)
         replies = comment.get('replies')
         replies[reply.id] = Utils.toJson(reply)
 

--- a/frontend/post/postDetailsDirective.js
+++ b/frontend/post/postDetailsDirective.js
@@ -563,6 +563,8 @@
                     commentCtrl.newReply = null;
                     commentCtrl.saving = false;
                 },function error(error) {
+                    commentCtrl.newReply = null;
+                    commentCtrl.saving = false;
                     MessageService.showToast(error.data.msg);
                 });
             }

--- a/frontend/utils/messageService.js
+++ b/frontend/utils/messageService.js
@@ -14,7 +14,8 @@
             "Error! The user must be interested at his post": "O autor deve ser interessado em seu post.",
             "Error! The end time must be after the current time": "A data final do evento deve ser posterior a data atual!",
             "Error! The end time can not be before the start time": "A data final do evento deve ser posterior a inicial!",
-            "Error! The invite has already been used": "Esse convite já foi utilizado!"
+            "Error! The invite has already been used": "Esse convite já foi utilizado!",
+            "Error! This comment has been deleted.": "Esse comentário foi removido!"
         };
 
         service.showToast = function showToast(message) {


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
The reply_comment method wasn't checking if the comment really exists before add the reply.
</p>

<p><b>Solution:</b>
I've added a verification in the method and sent a message to the user warning him that the comment has been deleted.

![screenshot from 2018-02-19 14-56-18](https://user-images.githubusercontent.com/23387866/36391671-3cf0ab74-1586-11e8-8494-516fe6b1ccb4.png)


</p>

<p><b>TODO/FIXME:</b> n/a</p>
