### PR TITLE
Adding verification before return

### DIFF
--- a/frontend/event/eventDetailsDirective.js
+++ b/frontend/event/eventDetailsDirective.js
@@ -118,7 +118,8 @@
         };
 
         eventCtrl.getOfficialSite = function getOfficialSite() {
-           return Utils.limitString(eventCtrl.event.official_site, 80);
+            if(eventCtrl.event)
+                return Utils.limitString(eventCtrl.event.official_site, 80);
         };
 
         function isInstitutionAdmin(event) {


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> The console show following error in event page: "TypeError: Cannot read property 'official_site' of null".</p>

<p><b>Solution:</b> Adding verification if the property exists before return.</p>

<p><b>TODO/FIXME:</b> n/a</p>
