### PR TITLE
Fix introdution of institution authorization header only to backend api requests

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -334,7 +334,12 @@
                 if (AuthService.isLoggedIn()) {
                     var token = AuthService.getUserToken();
                     config.headers.Authorization = 'Bearer ' + token;
-                    if (!_.isEmpty(AuthService.getCurrentUser().institutions)) {
+                    
+                    var API_URL = "/api/";
+                    var FIRST_POSITION = 0;
+                    var requestToApi = config.url.indexOf(API_URL) == FIRST_POSITION;
+                    
+                    if (!_.isEmpty(AuthService.getCurrentUser().institutions) && requestToApi) {
                         config.headers['Institution-Authorization'] = AuthService.getCurrentUser().current_institution.key;
                     }
                 }


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> Preview PDF files wasn't working because of CORS error acusing unaccepted Header "Institution-Authorization".</p>

<p><b>Solution:</b> Restrict the inclusion of that header only to requests to backend api.</p>

![screenshot from 2018-02-19 17-59-52](https://user-images.githubusercontent.com/2967288/36396918-1b300ea8-159f-11e8-82ca-8ea6b485788d.png)

<p><b>TODO/FIXME:</b> n/a</p>
