### PR TITLE
Fixing the survey options' max-height

### DIFF
--- a/frontend/survey/save_survey.html
+++ b/frontend/survey/save_survey.html
@@ -5,7 +5,7 @@
   </md-input-container>
   <div ng-if="surveyCtrl.isTyping()">
     <p class="md-subheader"> Alternativas</p>
-    <md-content flex style="max-height: 300px;" class="custom-scrollbar">
+    <md-content flex style="max-height: 150px;" class="custom-scrollbar">
       <md-input-container ng-repeat="option in surveyCtrl.options" md-no-float class="md-block" style="height: 25px;">
         <input class="md-input" ng-model="option.text" ng-change="surveyCtrl.changeOption(option)" placeholder="+ Adicionar uma opção..." maxlength="150" />
       </md-input-container>


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
The survey options' height was higher than It should be.

![screenshot from 2018-02-20 08-18-18](https://user-images.githubusercontent.com/23387866/36421528-84beab9a-1617-11e8-9cc6-51546c6f7843.png)


</p>

<p><b>Solution:</b>
I've decreased the max-height property.

![screenshot from 2018-02-20 08-16-47](https://user-images.githubusercontent.com/23387866/36421539-92967eb4-1617-11e8-91fe-8c96eb2184c5.png)


</p>

<p><b>TODO/FIXME:</b> n/a</p>
