### PR TITLE
Fix the comment button color in deleted post

### DIFF
--- a/frontend/post/postDetailsDirective.js
+++ b/frontend/post/postDetailsDirective.js
@@ -442,7 +442,8 @@
         };
 
         postDetailsCtrl.getButtonColor = function getButtonColor(condition=true) {
-            var color = condition && !postDetailsCtrl.isDeleted() ? 'light-green' : 'grey';
+            var isNotDeletedOrHasComments = !postDetailsCtrl.isDeleted() || postDetailsCtrl.post.number_of_comments > 0;
+            var color = condition && isNotDeletedOrHasComments ? 'light-green' : 'grey';
             return {background: color};
         };
 

--- a/frontend/post/postDetailsDirective.js
+++ b/frontend/post/postDetailsDirective.js
@@ -441,8 +441,9 @@
             postDetailsCtrl.post.number_of_comments : "+99";
         };
 
-        postDetailsCtrl.getButtonColor = function getButtonColor(condition=true) {
-            var isNotDeletedOrHasComments = !postDetailsCtrl.isDeleted() || postDetailsCtrl.post.number_of_comments > 0;
+        postDetailsCtrl.getButtonColor = function getButtonColor(condition=true, isCommentButton) {
+            var hasComments = (postDetailsCtrl.post.number_of_comments > 0 && isCommentButton);
+            var isNotDeletedOrHasComments = !postDetailsCtrl.isDeleted() || hasComments;
             var color = condition && isNotDeletedOrHasComments ? 'light-green' : 'grey';
             return {background: color};
         };

--- a/frontend/post/post_details.html
+++ b/frontend/post/post_details.html
@@ -194,7 +194,7 @@
       <div style="margin-left: auto; margin-right: 10px;" ng-if="!postDetailsCtrl.showSurvey()">
         <md-button class="sm-icon-button" aria-label="Favorite" ng-click="postDetailsCtrl.likeOrDislikePost()"
             ng-disabled="postDetailsCtrl.disableButton()" title="{{(postDetailsCtrl.isLikedByUser()) ? 'Descurtir' : 'Curtir'}}"
-            md-colors="{{ postDetailsCtrl.getButtonColor(postDetailsCtrl.isLikedByUser()) }}">
+            md-colors="{{ postDetailsCtrl.getButtonColor(postDetailsCtrl.isLikedByUser(), false) }}">
           <md-icon>grade</md-icon>
         </md-button>
         <span style="margin-left: -16px;" class="counter-likes-comments" data-badge="{{postDetailsCtrl.number_of_likes()}}"></span>

--- a/frontend/post/post_details.html
+++ b/frontend/post/post_details.html
@@ -202,7 +202,7 @@
         <md-button class="sm-icon-button" aria-label="Comments"
             ng-click="postDetailsCtrl.isPostPage ? 'null' : postDetailsCtrl.getComments()"
             title="Mostrar comentários"
-            md-colors="{{ postDetailsCtrl.getButtonColor() }}">
+            md-colors="{{ postDetailsCtrl.getButtonColor(true, true) }}">
           <md-icon>comments</md-icon>
         </md-button>
         <span style="margin-left: -10px;" class="counter-likes-comments" data-badge="{{postDetailsCtrl.number_of_comments()}}"></span>

--- a/frontend/test/specs/postDetailsControllerSpec.js
+++ b/frontend/test/specs/postDetailsControllerSpec.js
@@ -416,4 +416,27 @@
             expect(postService.getPost).toHaveBeenCalledWith(posts[0].key);
         });
     })
+
+    describe('getButtonColor()', function () {
+        it('should return light-green', function () {
+            spyOn(postDetailsCtrl, 'isDeleted').and.callThrough();
+            postDetailsCtrl.post = posts[2];
+            var result = postDetailsCtrl.getButtonColor();
+            expect(postDetailsCtrl.isDeleted).toHaveBeenCalled();
+            expect(result.background).toEqual('light-green');
+            postDetailsCtrl.post.state = 'deleted';
+            var result = postDetailsCtrl.getButtonColor();
+            expect(postDetailsCtrl.isDeleted).toHaveBeenCalled();
+            expect(result.background).toEqual('light-green');
+        });
+
+        it('should return grey', function () {
+            spyOn(postDetailsCtrl, 'isDeleted').and.callThrough();
+            postDetailsCtrl.post = posts[0];
+            postDetailsCtrl.post.state = 'deleted';
+            var result = postDetailsCtrl.getButtonColor();
+            expect(postDetailsCtrl.isDeleted).toHaveBeenCalled();
+            expect(result.background).toEqual('grey');
+        })
+    });
 }));

--- a/frontend/test/specs/postDetailsControllerSpec.js
+++ b/frontend/test/specs/postDetailsControllerSpec.js
@@ -425,7 +425,7 @@
             expect(postDetailsCtrl.isDeleted).toHaveBeenCalled();
             expect(result.background).toEqual('light-green');
             postDetailsCtrl.post.state = 'deleted';
-            var result = postDetailsCtrl.getButtonColor();
+            var result = postDetailsCtrl.getButtonColor(true, true);
             expect(postDetailsCtrl.isDeleted).toHaveBeenCalled();
             expect(result.background).toEqual('light-green');
         });
@@ -434,7 +434,7 @@
             spyOn(postDetailsCtrl, 'isDeleted').and.callThrough();
             postDetailsCtrl.post = posts[0];
             postDetailsCtrl.post.state = 'deleted';
-            var result = postDetailsCtrl.getButtonColor();
+            var result = postDetailsCtrl.getButtonColor(true, true);
             expect(postDetailsCtrl.isDeleted).toHaveBeenCalled();
             expect(result.background).toEqual('grey');
         })


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
The comment button wasn't looking like clickable in a deleted post when the post had comments.
</p>

<p><b>Solution:</b>
I've fixed the verification in getButtonColor method.

![screenshot from 2018-02-20 08-39-40](https://user-images.githubusercontent.com/23387866/36422433-b582d938-161a-11e8-9a83-1058b4669fa9.png)


</p>

<p><b>TODO/FIXME:</b> n/a</p>
