### PR TITLE
Hide "like" and "comment" buttons, when post is shared survey.

### DIFF
--- a/frontend/post/postDetailsDirective.js
+++ b/frontend/post/postDetailsDirective.js
@@ -74,6 +74,11 @@
                 postDetailsCtrl.post.shared_event;
         };
 
+        postDetailsCtrl.isSharedSurvey = function isSharedSurvey() {
+            return postDetailsCtrl.post.shared_post && 
+                postDetailsCtrl.post.shared_post.type_survey;
+        };
+
         postDetailsCtrl.getCSSClassPost = function getCSSClassPost() {
             return (postDetailsCtrl.isDeleted(postDetailsCtrl.post) || 
                     postDetailsCtrl.isDeletedEvent(postDetailsCtrl.post) || 
@@ -105,11 +110,7 @@
         postDetailsCtrl.showPost = function showPost() {
             return !postDetailsCtrl.showSurvey() && !postDetailsCtrl.isShared();
         };
-
-        postDetailsCtrl.showSurvey = function showSurvey() {
-            return postDetailsCtrl.post.type_survey;
-        };
-
+        
         postDetailsCtrl.showTextPost = function showTextPost(){
             return !postDetailsCtrl.isDeleted(postDetailsCtrl.post) &&
                      postDetailsCtrl.showPost();
@@ -119,6 +120,10 @@
             return postDetailsCtrl.isAuthorized() &&
                 !postDetailsCtrl.isDeleted(postDetailsCtrl.post);
         };
+
+        postDetailsCtrl.showActivityButtons = function showActivityButtons() {
+            return !postDetailsCtrl.showSurvey() && !postDetailsCtrl.isSharedSurvey();
+        }
 
         postDetailsCtrl.disableButton = function disableButton() {
             return postDetailsCtrl.savingLike ||

--- a/frontend/post/post_details.html
+++ b/frontend/post/post_details.html
@@ -191,7 +191,7 @@
         </md-button>
         <b style="font-size: 12px;">EXCLUIR POST</b>
       </div>
-      <div style="margin-left: auto; margin-right: 10px;" ng-if="!postDetailsCtrl.showSurvey()">
+      <div style="margin-left: auto; margin-right: 10px;" ng-if="postDetailsCtrl.showActivityButtons()">
         <md-button class="sm-icon-button" aria-label="Favorite" ng-click="postDetailsCtrl.likeOrDislikePost()"
             ng-disabled="postDetailsCtrl.disableButton()" title="{{(postDetailsCtrl.isLikedByUser()) ? 'Descurtir' : 'Curtir'}}"
             md-colors="{{ postDetailsCtrl.getButtonColor(postDetailsCtrl.isLikedByUser()) }}">


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> User shoudn't comment or like posts that are shared surveys.</p>

<p><b>Solution:</b> Hide buttons, using a function.</p>

<p><b>TODO/FIXME:</b> n/a</p>

![screenshot from 2018-02-20 09-01-07](https://user-images.githubusercontent.com/18709274/36423323-44230764-161e-11e8-9043-31ad0ba6fe73.png)
