### PR TITLE
Adding a new regex to accept more youtube url types and match to get id of video

### DIFF
--- a/frontend/post/post.js
+++ b/frontend/post/post.js
@@ -24,8 +24,8 @@ Post.prototype.isValid = function isValid() {
 
 Post.prototype.getVideoUrl = function getVideoUrl() {
     if(this.video_url) {
-        var params = _.split(this.video_url, '=');
-        var id = params[params.length - 1];
+        const match = this.video_url.match(/(?:youtube\.com\/(?:[^\/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?\/ ]{11})/i);
+        const id = match[1];
         return 'https://www.youtube.com/embed/' + id;
     }
 };

--- a/frontend/post/postDirective.js
+++ b/frontend/post/postDirective.js
@@ -18,7 +18,7 @@
         postCtrl.pdfFiles = [];
         postCtrl.deletedFiles = [];
         postCtrl.hasVideo = false;
-        postCtrl.videoRegex = '(?:http(s)?:\/\/)?(www\.)?youtube\.com\/watch\\?v=.+';
+        postCtrl.videoRegex = '(https?\:\/\/)?((www\.)?youtube\.com|youtu\.?be)\/.+';
         postCtrl.options = [];
         var option_empty = {'text': '',
                             'number_votes': 0,


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> If in youtube url has properties like start time of video (ex.: #t=2m10s), feature like "youtu.be", mobile (m.youtube.com...) and other types of youtube url links, the post doesn't recognize the video and don't plays the video.</p>

<p><b>Solution:</b> Adding a new regex to recognize more youtube url types and adding a match to get only video id to make embed link to plays the video in post.</p>

<p><b>TODO/FIXME:</b> n/a</p>
