### PR TITLE
Send multiple user invites

### DIFF
--- a/backend/handlers/invite_collection_handler.py
+++ b/backend/handlers/invite_collection_handler.py
@@ -69,7 +69,7 @@ class InviteCollectionHandler(BaseHandler):
                 invites_keys.append(current_invite.key.urlsafe())
 
             enqueue_task('send-invite', {'invites_keys': json.dumps(invites_keys), 'host': host,
-                                        'current_institution': current_institution_key.urlsafe()})
+                                         'current_institution': current_institution_key.urlsafe()})
 
         process_invites(data['emails'], invite, user.current_institution)
 

--- a/backend/handlers/invite_collection_handler.py
+++ b/backend/handlers/invite_collection_handler.py
@@ -10,6 +10,7 @@ from custom_exceptions.notAuthorizedException import NotAuthorizedException
 from handlers.base_handler import BaseHandler
 from models.invite_institution import InviteInstitution
 from models.factory_invites import InviteFactory
+from service_entities import enqueue_task
 
 
 class InviteCollectionHandler(BaseHandler):
@@ -34,36 +35,43 @@ class InviteCollectionHandler(BaseHandler):
         body = json.loads(self.request.body)
         data = body['data']
         host = self.request.host
-        type_of_invite = data.get('type_of_invite')
+        invites_keys = []
+        invite = data['invite_body']
+        type_of_invite = invite.get('type_of_invite')
+        for email in data['emails']:
+            invite['invitee'] = email
+            Utils._assert(type_of_invite == 'INSTITUTION',
+                          "invitation type not allowed", NotAuthorizedException)
 
-        Utils._assert(type_of_invite == 'INSTITUTION',
-                      "invitation type not allowed", NotAuthorizedException)
-        
-        """TODO: Remove the assert bellow when the hierarchical invitations can be available
-        @author: Mayza Nunes 11/01/2018
-        """
-        Utils._assert(type_of_invite != 'USER',
-                      "Hierarchical invitations is not available in this version", NotAuthorizedException)
+            """TODO: Remove the assert bellow when the hierarchical invitations can be available
+            @author: Mayza Nunes 11/01/2018
+            """
+            Utils._assert(type_of_invite != 'USER',
+                          "Hierarchical invitations is not available in this version", NotAuthorizedException)
 
-        invite = InviteFactory.create(data, type_of_invite)
+            current_invite = InviteFactory.create(invite, type_of_invite)
 
-        can_invite_inst = user.has_permission("send_link_inst_invite", invite.institution_key.urlsafe())
-        can_invite_members = user.has_permission("invite_members", invite.institution_key.urlsafe())
-    
-        if(can_invite_inst or can_invite_members):
-            institution = invite.institution_key.get()
+            can_invite_inst = user.has_permission(
+                "send_link_inst_invite", current_invite.institution_key.urlsafe())
+            can_invite_members = user.has_permission(
+                "invite_members", current_invite.institution_key.urlsafe())
+
+            Utils._assert(not can_invite_inst and not can_invite_members,
+                          "User is not allowed to send invites", NotAuthorizedException)
+
+            institution = current_invite.institution_key.get()
             Utils._assert(institution.state == 'inactive',
-                        "The institution has been deleted", NotAuthorizedException)
-            
-            invite.put()
+                          "The institution has been deleted", NotAuthorizedException)
 
-            if(invite.stub_institution_key):
-                invite.stub_institution_key.get().addInvite(invite)
+            current_invite.put()
 
-            invite.send_invite(host, user.current_institution)
+            if(current_invite.stub_institution_key):
+                current_invite.stub_institution_key.get().addInvite(current_invite)
 
-            make_invite = invite.make()
+            invites_keys.append(current_invite.key.urlsafe())
 
-            self.response.write(json.dumps(make_invite)) 
-        else:
-            raise NotAuthorizedException("User is not allowed to send invites")
+        enqueue_task('send-invite', {'invites_keys': json.dumps(invites_keys), 'host': host,
+                                     'current_institution': json.dumps(user.current_institution.urlsafe())})
+
+        self.response.write(json.dumps(
+            {'msg': 'Os convites estão sendo processados.'}))

--- a/backend/handlers/invite_collection_handler.py
+++ b/backend/handlers/invite_collection_handler.py
@@ -63,16 +63,21 @@ class InviteCollectionHandler(BaseHandler):
 
         for email in data['emails']:
             invite['invitee'] = email
-            current_invite = InviteFactory.create(invite, type_of_invite)
-            current_invite.put()
-
-            if(current_invite.stub_institution_key):
-                current_invite.stub_institution_key.get().addInvite(current_invite)
-
+            current_invite = createInvite(invite)
             invites_keys.append(current_invite.key.urlsafe())
 
         enqueue_task('send-invite', {'invites_keys': json.dumps(invites_keys), 'host': host,
                                      'current_institution': json.dumps(user.current_institution.urlsafe())})
 
         self.response.write(json.dumps(
-            {'msg': 'Os convites estão sendo processados.'}))
+            {'msg': 'The invites are being processed.'}))
+
+def createInvite(data):
+    """Create an invite."""
+    invite = InviteFactory.create(data, data['type_of_invite'])
+    invite.put()
+
+    if(invite.stub_institution_key):
+        invite.stub_institution_key.get().addInvite(invite)
+    
+    return invite

--- a/backend/handlers/invite_handler.py
+++ b/backend/handlers/invite_handler.py
@@ -37,12 +37,9 @@ def define_entity(dictionary):
     return InstitutionProfile
 
 
-def check_if_user_is_member(user, institution_key):
+def check_if_user_is_member(user, institution):
     """Check if the user is already a member."""
-    for current_institution in user.institutions:
-        if(current_institution == institution_key):
-            return True
-    return False
+    return institution.has_member(user.key) and user.is_member(institution.key)
 
 
 class InviteHandler(BaseHandler):
@@ -86,7 +83,7 @@ class InviteHandler(BaseHandler):
         institution_key = invite.institution_key
         institution = institution_key.get()
 
-        Utils._assert(check_if_user_is_member(user, institution_key), 
+        Utils._assert(check_if_user_is_member(user, institution), 
             "The user is already a member", NotAuthorizedException)
 
         invite.change_status('accepted')

--- a/backend/handlers/invite_handler.py
+++ b/backend/handlers/invite_handler.py
@@ -37,6 +37,14 @@ def define_entity(dictionary):
     return InstitutionProfile
 
 
+def check_if_user_is_member(user, institution_key):
+    """Check if the user is already a member."""
+    for current_institution in user.institutions:
+        if(current_institution == institution_key):
+            return True
+    return False
+
+
 class InviteHandler(BaseHandler):
     """Invite Handler."""
 
@@ -74,11 +82,14 @@ class InviteHandler(BaseHandler):
         Utils._assert(invite.status == 'accepted', 
             "This invitation has already been accepted", 
             NotAuthorizedException)
-            
-        invite.change_status('accepted')
 
         institution_key = invite.institution_key
         institution = institution_key.get()
+
+        Utils._assert(check_if_user_is_member(user, institution_key), 
+            "The user is already a member", NotAuthorizedException)
+
+        invite.change_status('accepted')
 
         user.add_institution(institution_key)
         user.follow(institution_key)

--- a/backend/models/institution.py
+++ b/backend/models/institution.py
@@ -287,3 +287,7 @@ class Institution(ndb.Model):
         """This method is called after each Institution.put()."""
         search_institution = SearchInstitution()
         search_institution.createDocument(future.get_result().get())
+    
+    def has_member(self, user_key):
+        """Check if the user is member."""
+        return user_key in self.members

--- a/backend/models/invite_user.py
+++ b/backend/models/invite_user.py
@@ -12,43 +12,11 @@ class InviteUser(Invite):
     """Model of invite user."""
 
     @staticmethod
-    def invitee_is_member(inviteeEmail, institution):
-        """Check if the invitee is already a member."""
-        userWithEmail = User.query(User.email == inviteeEmail)
-        if userWithEmail.count() == 1:
-            instmember = Institution.query(Institution.members.IN(
-                [userWithEmail.get().key]),
-                Institution.key == institution.key)
-            return instmember.count() > 0
-        return False
-
-    @staticmethod
-    def invitee_is_invited(invitee, institutionKey):
-        """Check if the invitee has already been invited."""
-        invited = InviteUser.query(
-            InviteUser.institution_key == institutionKey,
-            InviteUser.status == 'sent',
-            InviteUser.invitee == invitee)
-
-        return invited.count() > 0
-
-    @staticmethod
-    def check_is_invite_user_valid(data):
-        """Check if the invite user is valid."""
-        institution = ndb.Key(urlsafe=data.get('institution_key')).get()
-        invitee = data.get('invitee')
-        if InviteUser.invitee_is_member(invitee, institution):
-            raise FieldException("The invitee is already a member")
-        if InviteUser.invitee_is_invited(invitee, institution.key):
-            raise FieldException("The invitee is already invited")
-
-    @staticmethod
     def create(data):
         """Create a post and check required fields."""
         invite = InviteUser()
         invite.invitee = data.get('invitee')
         invite = Invite.create(data, invite)
-        InviteUser.check_is_invite_user_valid(data)
         return invite
 
     def send_email(self, host, body=None):

--- a/backend/test/invite_collection_handler_test.py
+++ b/backend/test/invite_collection_handler_test.py
@@ -159,8 +159,9 @@ class InviteCollectionHandlerTest(TestBaseHandler):
                          was stub")
 
     """
+    @patch('handlers.invite_collection_handler.enqueue_task')
     @patch('utils.verify_token', return_value=ADMIN)
-    def test_post_invite_user(self, verify_token):
+    def test_post_invite_user(self, verify_token, enqueue_task):
         admin = mocks.create_user(ADMIN['email'])
         institution = mocks.create_institution()		 
         admin.institutions_admin = [institution.key]
@@ -175,12 +176,14 @@ class InviteCollectionHandlerTest(TestBaseHandler):
             headers={'institution-authorization': institution.key.urlsafe()})
         # Retrieve the entities
         answer = json.loads(answer._app_iter[0])
+        enqueue_task.assert_called()
 
         self.assertTrue(
             answer == {u'msg': u'Os convites est\xe3o sendo processados.'})
 
+    @patch('handlers.invite_collection_handler.enqueue_task')
     @patch('utils.verify_token', return_value=ADMIN)
-    def test_post_invite_user_member_of_other_institution(self, verify_token):
+    def test_post_invite_user_member_of_other_institution(self, verify_token, enqueue_task):
         admin = mocks.create_user(ADMIN['email'])
         institution = mocks.create_institution()		 
         admin.institutions_admin = [institution.key]
@@ -201,6 +204,7 @@ class InviteCollectionHandlerTest(TestBaseHandler):
 
         self.assertTrue(
             answer == {u'msg': u'Os convites est\xe3o sendo processados.'})
+        enqueue_task.assert_called()
 
     @patch.object(Invite, 'send_invite')
     @patch('utils.verify_token', return_value=ADMIN)
@@ -259,7 +263,7 @@ class InviteCollectionHandlerTest(TestBaseHandler):
     
     @patch('handlers.invite_collection_handler.enqueue_task')
     @patch('utils.verify_token', return_value=ADMIN)
-    def test_post_many_invites_at_once(self, verify_token, mock_method):
+    def test_post_many_invites_at_once(self, verify_token, enqueue_task):
         admin = mocks.create_user(ADMIN['email'])
         institution = mocks.create_institution()
         admin.institutions_admin = [institution.key]
@@ -281,4 +285,4 @@ class InviteCollectionHandlerTest(TestBaseHandler):
 
         self.assertTrue(
             answer == {u'msg': u'Os convites est\xe3o sendo processados.'})
-        mock_method.assert_called()
+        enqueue_task.assert_called()

--- a/backend/test/invite_collection_handler_test.py
+++ b/backend/test/invite_collection_handler_test.py
@@ -15,14 +15,16 @@ ADMIN = {'email': 'user1@gmail.com'}
 USER = {'email': 'otheruser@ccc.ufcg.edu.br'}
 CURRENT_INSTITUTION = {'name': 'currentInstitution'}
 
-def create_body(invitee_email, admin, institution):
+def create_body(invitee_emails, admin, institution):
     """Create a body for the post method."""
     body = {
         'data': {
-            'invitee': invitee_email,
-            'admin_key': admin.key.urlsafe(),
-            'type_of_invite': 'USER',
-            'institution_key': institution.key.urlsafe()
+            'invite_body': {
+                'admin_key': admin.key.urlsafe(),
+                'type_of_invite': 'USER',
+                'institution_key': institution.key.urlsafe()
+            },
+            'emails': invitee_emails
         }
     }
     return body
@@ -157,9 +159,8 @@ class InviteCollectionHandlerTest(TestBaseHandler):
                          was stub")
 
     """
-    @patch.object(Invite, 'send_invite')
     @patch('utils.verify_token', return_value=ADMIN)
-    def test_post_invite_user(self, verify_token, send_invite):
+    def test_post_invite_user(self, verify_token):
         admin = mocks.create_user(ADMIN['email'])
         institution = mocks.create_institution()		 
         admin.institutions_admin = [institution.key]
@@ -168,29 +169,18 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         admin.add_permission("invite_members",institution.key.urlsafe())
         admin.put()
         institution.put()
-        body = create_body('ana@gmail.com', admin, institution)
+        body = create_body(['ana@gmail.com'], admin, institution)
 
-        invite = self.testapp.post_json("/api/invites", body, 
+        answer = self.testapp.post_json("/api/invites", body, 
             headers={'institution-authorization': institution.key.urlsafe()})
         # Retrieve the entities
-        invite = json.loads(invite._app_iter[0])
-        key_invite = ndb.Key(urlsafe=invite['key'])
-        invite_obj = key_invite.get()
+        answer = json.loads(answer._app_iter[0])
 
-        # Check data of invite
-        self.assertEqual(invite_obj.invitee, 'ana@gmail.com',
-                         "The email expected was ana@gmail.com")
-        self.assertEqual(invite_obj.admin_key, admin.key,
-                         "The admin_key expected was first_user")
-        self.assertEqual(invite_obj.institution_key, institution.key,
-                         "The institution key expected was key of institution")
+        self.assertTrue(
+            answer == {u'msg': u'Os convites est\xe3o sendo processados.'})
 
-        # assert the invite was sent
-        send_invite.assert_called_with("localhost:80", institution.key)
-
-    @patch.object(Invite, 'send_invite')
     @patch('utils.verify_token', return_value=ADMIN)
-    def test_post_invite_user_member_of_other_institution(self, verify_token, send_invite):
+    def test_post_invite_user_member_of_other_institution(self, verify_token):
         admin = mocks.create_user(ADMIN['email'])
         institution = mocks.create_institution()		 
         admin.institutions_admin = [institution.key]
@@ -203,25 +193,14 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         otherinst.address = mocks.create_address()
         otherinst.add_member(otheruser)
         institution.put()
-        body = create_body(USER['email'], admin, institution)
+        body = create_body([USER['email']], admin, institution)
 
-        invite = self.testapp.post_json("/api/invites", body, 
+        answer = self.testapp.post_json("/api/invites", body, 
             headers={'institution-authorization': institution.key.urlsafe()})
-        # Retrieve the entities
-        invite = json.loads(invite._app_iter[0])
-        key_invite = ndb.Key(urlsafe=invite['key'])
-        invite_obj = key_invite.get()
+        answer = json.loads(answer._app_iter[0])
 
-        # Check data of invite
-        self.assertEqual(invite_obj.invitee, 'otheruser@ccc.ufcg.edu.br',
-                         "The email expected was otheruser@ccc.ufcg.edu.br")
-        self.assertEqual(invite_obj.admin_key, admin.key,
-                         "The admin_key expected was admin")
-        self.assertEqual(invite_obj.institution_key, institution.key,
-                         "The institution key expected was key of institution")
-
-        # assert the invite was sent
-        send_invite.assert_called_with("localhost:80", institution.key)
+        self.assertTrue(
+            answer == {u'msg': u'Os convites est\xe3o sendo processados.'})
 
     @patch.object(Invite, 'send_invite')
     @patch('utils.verify_token', return_value=ADMIN)
@@ -237,7 +216,7 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         otheruser = mocks.create_user(USER['email'])
         institution.add_member(otheruser)
         institution.put()
-        body = create_body(USER['email'], admin, institution)
+        body = create_body([USER['email']], admin, institution)
 
         with self.assertRaises(Exception) as raises_context:
             self.testapp.post_json("/api/invites", body)
@@ -264,7 +243,7 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         admin.add_permission("invite_members",institution.key.urlsafe())
         admin.put()
         institution.put()
-        body = create_body('ana@gmail.com', admin, institution)
+        body = create_body(['ana@gmail.com'], admin, institution)
         with self.assertRaises(Exception) as raises_context:
             self.testapp.post_json("/api/invites", body)
 
@@ -277,3 +256,29 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         
         # assert the invite was not sent
         send_invite.assert_not_called()
+    
+    @patch('handlers.invite_collection_handler.enqueue_task')
+    @patch('utils.verify_token', return_value=ADMIN)
+    def test_post_many_invites_at_once(self, verify_token, mock_method):
+        admin = mocks.create_user(ADMIN['email'])
+        institution = mocks.create_institution()
+        admin.institutions_admin = [institution.key]
+        admin.add_institution(institution.key)
+        institution.admin = admin.key
+        admin.add_permission("invite_members", institution.key.urlsafe())
+        admin.put()
+        institution.put()
+        body = create_body(
+            ['ana@gmail.com', 'user@hotmail.com', 'test@example.com', 'other@other.com'], 
+            admin, 
+            institution
+        )
+
+        answer = self.testapp.post_json("/api/invites", body,
+                                        headers={'institution-authorization': institution.key.urlsafe()})
+        # Retrieve the entities
+        answer = json.loads(answer._app_iter[0])
+
+        self.assertTrue(
+            answer == {u'msg': u'Os convites est\xe3o sendo processados.'})
+        mock_method.assert_called()

--- a/backend/test/invite_collection_handler_test.py
+++ b/backend/test/invite_collection_handler_test.py
@@ -207,36 +207,6 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         enqueue_task.assert_called()
 
     @patch.object(Invite, 'send_invite')
-    @patch('utils.verify_token', return_value=ADMIN)
-    def test_post_invite_user_already_member(self, verify_token, send_invite):
-        """ Check if raise exception when the invite is
-        for user already member of institution."""
-        admin = mocks.create_user(ADMIN['email'])
-        institution = mocks.create_institution()		 
-        admin.institutions_admin = [institution.key]
-        institution.admin = admin.key
-        admin.add_permission("invite_members",institution.key.urlsafe())
-        admin.put()
-        otheruser = mocks.create_user(USER['email'])
-        institution.add_member(otheruser)
-        institution.put()
-        body = create_body([USER['email']], admin, institution)
-
-        with self.assertRaises(Exception) as raises_context:
-            self.testapp.post_json("/api/invites", body)
-
-        message_exception = self.get_message_exception(str(raises_context.exception))
-
-        self.assertEqual(
-            message_exception,
-            "Error! The invitee is already a member",
-            "Expected exception message must be equal to "
-            "Error! The invitee is already a member")
-        
-        # assert the invite was not sent
-        send_invite.assert_not_called()
-
-    @patch.object(Invite, 'send_invite')
     @patch('utils.verify_token', return_value=USER)
     def test_post_invite_without_admin(self, verify_token, send_invite):
         """ Check if raise exception when the admin_key is not admistrator."""

--- a/backend/test/invite_collection_handler_test.py
+++ b/backend/test/invite_collection_handler_test.py
@@ -179,7 +179,7 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         enqueue_task.assert_called()
 
         self.assertTrue(
-            answer == {u'msg': u'Os convites est\xe3o sendo processados.'})
+            answer == {'msg': 'The invites are being processed.'})
 
     @patch('handlers.invite_collection_handler.enqueue_task')
     @patch('utils.verify_token', return_value=ADMIN)
@@ -203,7 +203,7 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         answer = json.loads(answer._app_iter[0])
 
         self.assertTrue(
-            answer == {u'msg': u'Os convites est\xe3o sendo processados.'})
+            answer == {'msg': 'The invites are being processed.'})
         enqueue_task.assert_called()
 
     @patch.object(Invite, 'send_invite')
@@ -284,5 +284,5 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         answer = json.loads(answer._app_iter[0])
 
         self.assertTrue(
-            answer == {u'msg': u'Os convites est\xe3o sendo processados.'})
+            answer == {'msg': 'The invites are being processed.'})
         enqueue_task.assert_called()

--- a/backend/test/invite_handler_test.py
+++ b/backend/test/invite_handler_test.py
@@ -221,9 +221,11 @@ class InviteHandlerTest(TestBaseHandler):
 
         message_exception = self.get_message_exception(
             str(raises_context.exception))
+        
+        expected_message = "Error! The user is already a member"
 
         self.assertEqual(
             message_exception,
-            "Error! The user is already a member",
-            "Expected exception message must be equal to "
-            "Error! The user is already a member")
+            expected_message,
+            "Expected exception message must be equal to %s" %expected_message
+        )

--- a/backend/test/invite_handler_test.py
+++ b/backend/test/invite_handler_test.py
@@ -206,3 +206,24 @@ class InviteHandlerTest(TestBaseHandler):
         
         # assert the notification was not sent
         send_notification.assert_not_called()
+    
+    @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
+    def test_patch_with_a_user_that_is_already_a_member(self, verify_token):
+        """Test a patch invite_user when the user is already a member."""
+        self.inst_test.add_member(self.other_user)
+        self.other_user.add_institution(self.inst_test.key)
+
+        with self.assertRaises(Exception) as raises_context:
+            self.testapp.patch(
+                '/api/invites/%s'
+                % self.invite.key.urlsafe()
+            )
+
+        message_exception = self.get_message_exception(
+            str(raises_context.exception))
+
+        self.assertEqual(
+            message_exception,
+            "Error! The user is already a member",
+            "Expected exception message must be equal to "
+            "Error! The user is already a member")

--- a/backend/test/model_test/invite_user_test.py
+++ b/backend/test/model_test/invite_user_test.py
@@ -23,61 +23,6 @@ class InviteInstitutionTest(TestBase):
         cls.test.init_memcache_stub()
         initModels(cls)
 
-    def invitee_is_member(self):
-        """Test invitee_is_member method."""
-        is_admin_member = InviteUser.invitee_is_member(
-            self.admin.email[0], self.institution
-        )
-
-        is_user_member = InviteUser.invitee_is_member(
-            self.user.email[0], self.institution
-        )
-
-        self.assertEquals(
-            is_admin_member,
-            True,
-            "The admin should be a member of this institution"
-        )
-
-        self.assertEquals(
-            is_user_member,
-            False,
-            "The user should not be a member of this institution"
-        )
-
-    def test_invitee_is_invited(self):
-        """Test invitee_is_invited method."""
-        is_user_invited = InviteUser.invitee_is_invited(
-            self.user.email[0], self.institution.key
-        )
-
-        is_user_not_invited = InviteUser.invitee_is_invited(
-            "not_invited@email", self.institution.key
-        )
-
-        self.assertEquals(
-            is_user_invited,
-            True,
-            "The user should have been invited"
-        )
-
-        self.assertEquals(
-            is_user_not_invited,
-            False,
-            "The user should not have invites"
-        )
-
-    def test_check_is_invite_user_valid_when_invitee_already_invited(self):
-        """Test check_is_invite_user_valid when invitee has already been invited."""
-        with self.assertRaises(FieldException):
-            InviteUser.check_is_invite_user_valid(self.data)
-
-    def test_check_is_invite_user_valid_when_invitee_already_member(self):
-        """Test check_is_invite_user_valid when the invitee is already a member."""
-        self.data["invitee"] = self.admin.email[0]
-        with self.assertRaises(FieldException):
-            InviteUser.check_is_invite_user_valid(self.data)
-
     def test_create(self):
         """Test create method."""
         self.data["invitee"] = "other_user@email"

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -8,6 +8,7 @@ import logging
 from google.appengine.ext import ndb
 from models.institution import Institution
 from models.post import Post
+from models.invite_user import InviteUser
 from utils import json_response
 from service_messages import send_message_notification
 from service_messages import send_message_email
@@ -222,6 +223,18 @@ class AddPostInInstitution(BaseHandler):
 
         institution.add_post(created_post)
 
+class SendInviteHandler(BaseHandler):
+
+    def post(self):
+        """It iterates in an array of invites creating and sending them."""
+        keys = json.loads(self.request.get('invites_keys'))
+        host = self.request.get('host')
+        current_institution = json.loads(self.request.get('current_institution'))
+        current_institution = ndb.Key(urlsafe=current_institution)
+        for key in keys:
+            invite = ndb.Key(urlsafe=key).get()
+            invite.send_invite(host, current_institution)
+
 app = webapp2.WSGIApplication([
     ('/api/queue/send-notification', SendNotificationHandler),
     ('/api/queue/send-email', SendEmailHandler),
@@ -231,5 +244,6 @@ app = webapp2.WSGIApplication([
     ('/api/queue/notify-followers', NotifyFollowersHandler),
     ('/api/queue/add-admin-permissions', AddAdminPermissionsInInstitutionHierarchy),
     ('/api/queue/remove-admin-permissions', RemoveAdminPermissionsInInstitutionHierarchy),
-    ('/api/queue/add-post-institution', AddPostInInstitution)
+    ('/api/queue/add-post-institution', AddPostInInstitution),
+    ('/api/queue/send-invite', SendInviteHandler)
 ], debug=True)

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -229,7 +229,7 @@ class SendInviteHandler(BaseHandler):
         """It iterates in an array of invites creating and sending them."""
         keys = json.loads(self.request.get('invites_keys'))
         host = self.request.get('host')
-        current_institution = json.loads(self.request.get('current_institution'))
+        current_institution = self.request.get('current_institution')
         current_institution = ndb.Key(urlsafe=current_institution)
         for key in keys:
             invite = ndb.Key(urlsafe=key).get()

--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -7,7 +7,7 @@
         RequestInvitationService, ProfileService) {
         var manageMemberCtrl = this;
 
-        var MAX_EMAILS = 1;
+        var MAX_EMAILS_QUANTITY = 1;
 
         manageMemberCtrl.institution = {};
         manageMemberCtrl.invite = {};
@@ -243,13 +243,13 @@
             return promise;
         };
 
-        manageMemberCtrl.canAddAnotherEmailField = function canAddAnotherEmailField() {
-            if (_.size(manageMemberCtrl.emails) < MAX_EMAILS) {
-                addAnotherField()
+        manageMemberCtrl.canAddEmailField = function canAddEmailField() {
+            if (_.size(manageMemberCtrl.emails) < MAX_EMAILS_QUANTITY) {
+                addField()
             };
         };
 
-        function addAnotherField() {
+        function addField() {
             manageMemberCtrl.emails.push(_.clone(empty_email));
         }
 

--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -74,7 +74,7 @@
                 manageMemberCtrl.isLoadingInvite = true;
                 var promise = InviteService.sendInvite(requestBody);
                 promise.then(function success(response) {
-                    refreshSentInvitations(requestBody.emails, requestBody.invite_body);
+                    refreshSentInvitations(requestBody.emails);
                     manageMemberCtrl.invite = {};
                     manageMemberCtrl.showInvites = true; 
                     manageMemberCtrl.showSendInvite = false;
@@ -88,10 +88,11 @@
             }
         };
 
-        function refreshSentInvitations(emails, invite) {
+        function refreshSentInvitations(emails) {
+            var inviteToAdd = new Invite(manageMemberCtrl.invite);
             _.each(emails, function(email) {
-                invite.invitee = email;
-                manageMemberCtrl.sent_invitations.push(_.clone(invite));
+                inviteToAdd.invitee = email;
+                manageMemberCtrl.sent_invitations.push(_.clone(inviteToAdd));
             });
         }
 

--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -6,7 +6,11 @@
         InviteService, $mdToast, $state, $mdDialog, InstitutionService, AuthService, MessageService,
         RequestInvitationService, ProfileService) {
         var manageMemberCtrl = this;
-
+        /* TODO: FIX the MAX_EMAILS_QUANTITY's value
+        * The current value is one because the view that supports
+        * many invitations at once is not ready yet.
+        * @author: Raoni Smaneoto - 23/02/2018
+        */
         var MAX_EMAILS_QUANTITY = 1;
 
         manageMemberCtrl.institution = {};
@@ -70,7 +74,7 @@
                 manageMemberCtrl.isLoadingInvite = true;
                 var promise = InviteService.sendInvite(requestBody);
                 promise.then(function success(response) {
-                    manageMemberCtrl.sent_invitations.push(invite);
+                    refreshSentInvitations(requestBody.emails, requestBody.invite_body);
                     manageMemberCtrl.invite = {};
                     manageMemberCtrl.showInvites = true; 
                     manageMemberCtrl.showSendInvite = false;
@@ -83,6 +87,13 @@
                 return promise;
             }
         };
+
+        function refreshSentInvitations(emails, invite) {
+            _.each(emails, function(email) {
+                invite.invitee = email;
+                manageMemberCtrl.sent_invitations.push(_.clone(invite));
+            });
+        }
 
         manageMemberCtrl.acceptRequest = function acceptRequest(request) {
             var promise = RequestInvitationService.acceptRequest(request.key);

--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -7,6 +7,8 @@
         RequestInvitationService, ProfileService) {
         var manageMemberCtrl = this;
 
+        var MAX_EMAILS = 1;
+
         manageMemberCtrl.institution = {};
         manageMemberCtrl.invite = {};
         manageMemberCtrl.sent_invitations = [];
@@ -19,6 +21,8 @@
         manageMemberCtrl.showRequests = false;
         manageMemberCtrl.showMembers = false;
         manageMemberCtrl.requests = [];
+        var empty_email = {email: ''};
+        manageMemberCtrl.emails = [_.clone(empty_email)];
 
         var currentInstitutionKey = $state.params.institutionKey;
         var invite;
@@ -56,17 +60,22 @@
             invite = new Invite(manageMemberCtrl.invite);
             invite.sender_name = manageMemberCtrl.user.name;
 
+            var emails = getEmails();
+            var requestBody = {
+                invite_body: invite,
+                emails: emails
+            }
+
             if (manageMemberCtrl.isUserInviteValid(invite)) {
                 manageMemberCtrl.isLoadingInvite = true;
-                var promise = InviteService.sendInvite(invite);
+                var promise = InviteService.sendInvite(requestBody);
                 promise.then(function success(response) {
-                    invite.key = response.data.key;
                     manageMemberCtrl.sent_invitations.push(invite);
                     manageMemberCtrl.invite = {};
                     manageMemberCtrl.showInvites = true; 
                     manageMemberCtrl.showSendInvite = false;
                     manageMemberCtrl.isLoadingInvite = false;
-                    MessageService.showToast('Convite enviado com sucesso!');
+                    MessageService.showToast(response.data.msg);
                 }, function error(response) {
                     manageMemberCtrl.isLoadingInvite = false;
                     MessageService.showToast(response.data.msg);
@@ -233,6 +242,26 @@
             });
             return promise;
         };
+
+        manageMemberCtrl.canAddAnotherEmailField = function canAddAnotherEmailField() {
+            if (_.size(manageMemberCtrl.emails) < MAX_EMAILS) {
+                addAnotherField()
+            };
+        };
+
+        function addAnotherField() {
+            manageMemberCtrl.emails.push(_.clone(empty_email));
+        }
+
+        function getEmails() {
+            var emails = [];
+            _.each(manageMemberCtrl.emails, function (email) {
+                if (!_.isEmpty(email.email)) {
+                    emails.push(email.email);
+                }
+            });
+            return emails;
+        }
 
         function designOptions() {
             var $dialog = angular.element(document.querySelector('md-dialog'));

--- a/frontend/institution/management_members.html
+++ b/frontend/institution/management_members.html
@@ -20,7 +20,7 @@
         <form ng-submit="manageMemberCtrl.sendUserInvite()">
           <md-input-container class="md-block" ng-repeat="currentEmail in manageMemberCtrl.emails">
             <label>Email convite deve ser enviado para:</label>
-            <input ng-model="currentEmail.email" ng-change="manageMemberCtrl.canAddAnotherEmailField()" type="email" name="email" required>
+            <input ng-model="currentEmail.email" ng-change="manageMemberCtrl.canAddEmailField()" type="email" name="email" required>
           </md-input-container>
           <load-circle flex ng-if="manageMemberCtrl.isLoadingInvite"></load-circle>
           <section layout="row" layout="column" layout-align="end center" layout-wrap ng-if="!manageMemberCtrl.isLoadingInvite">

--- a/frontend/institution/management_members.html
+++ b/frontend/institution/management_members.html
@@ -16,7 +16,7 @@
           </md-button>
         </div>
       </md-toolbar>
-      <md-card-content ng-show="manageMemberCtrl.showSendInvite;" style="max-height: 150px;">
+      <md-card-content ng-show="manageMemberCtrl.showSendInvite;">
         <form ng-submit="manageMemberCtrl.sendUserInvite()">
           <md-input-container class="md-block" ng-repeat="currentEmail in manageMemberCtrl.emails">
             <label>Email convite deve ser enviado para:</label>

--- a/frontend/institution/management_members.html
+++ b/frontend/institution/management_members.html
@@ -16,11 +16,11 @@
           </md-button>
         </div>
       </md-toolbar>
-      <md-card-content ng-show="manageMemberCtrl.showSendInvite;">
+      <md-card-content ng-show="manageMemberCtrl.showSendInvite;" style="max-height: 150px;">
         <form ng-submit="manageMemberCtrl.sendUserInvite()">
-          <md-input-container class="md-block">
+          <md-input-container class="md-block" ng-repeat="currentEmail in manageMemberCtrl.emails">
             <label>Email convite deve ser enviado para:</label>
-            <input ng-model="manageMemberCtrl.invite.invitee" type="email" name="email" required>
+            <input ng-model="currentEmail.email" ng-change="manageMemberCtrl.canAddAnotherEmailField()" type="email" name="email" required>
           </md-input-container>
           <load-circle flex ng-if="manageMemberCtrl.isLoadingInvite"></load-circle>
           <section layout="row" layout="column" layout-align="end center" layout-wrap ng-if="!manageMemberCtrl.isLoadingInvite">

--- a/frontend/invites/invite.js
+++ b/frontend/invites/invite.js
@@ -6,10 +6,11 @@ function Invite(data) {
 }
 
 Invite.prototype.isValid = function isValid() {
-    var noHasInvitee = (_.isUndefined(this.invitee) || _.isEmpty(this.invitee)) && this.type_of_invite != 'USER';
-    var noHasType = _.isUndefined(this.type_of_invite) || _.isEmpty(this.type_of_invite);
+    var isInviteeNecessary = this.type_of_invite != 'USER';
+    var HasNoInvitee = (_.isUndefined(this.invitee) || _.isEmpty(this.invitee)) && isInviteeNecessary;
+    var HasNoType = _.isUndefined(this.type_of_invite) || _.isEmpty(this.type_of_invite);
 
-    if (noHasInvitee || noHasType) {
+    if (HasNoInvitee || HasNoType) {
         return false;
     }
     return true;

--- a/frontend/invites/invite.js
+++ b/frontend/invites/invite.js
@@ -7,10 +7,10 @@ function Invite(data) {
 
 Invite.prototype.isValid = function isValid() {
     var isInviteeNecessary = this.type_of_invite != 'USER';
-    var HasNoInvitee = (_.isUndefined(this.invitee) || _.isEmpty(this.invitee)) && isInviteeNecessary;
-    var HasNoType = _.isUndefined(this.type_of_invite) || _.isEmpty(this.type_of_invite);
+    var hasNoInvitee = (_.isUndefined(this.invitee) || _.isEmpty(this.invitee)) && isInviteeNecessary;
+    var hasNoType = _.isUndefined(this.type_of_invite) || _.isEmpty(this.type_of_invite);
 
-    if (HasNoInvitee || HasNoType) {
+    if (hasNoInvitee || hasNoType) {
         return false;
     }
     return true;

--- a/frontend/invites/invite.js
+++ b/frontend/invites/invite.js
@@ -6,7 +6,7 @@ function Invite(data) {
 }
 
 Invite.prototype.isValid = function isValid() {
-    var noHasInvitee = _.isUndefined(this.invitee) || _.isEmpty(this.invitee);
+    var noHasInvitee = (_.isUndefined(this.invitee) || _.isEmpty(this.invitee)) && this.type_of_invite != 'USER';
     var noHasType = _.isUndefined(this.type_of_invite) || _.isEmpty(this.type_of_invite);
 
     if (noHasInvitee || noHasType) {

--- a/frontend/invites/newInviteController.js
+++ b/frontend/invites/newInviteController.js
@@ -30,6 +30,7 @@
                     if (!userIsAMember()) {
                         newInviteCtrl.addInstitution(event);
                     } else {
+                        MessageService.showToast('Você já é membro dessa instituição');
                         newInviteCtrl.deleteInvite();
                     }
                 }
@@ -103,7 +104,7 @@
                     .cancel('Não');
                     var promise = $mdDialog.show(confirm);
                 promise.then(function() {
-                    deleteInviteAndReloadUser();
+                   newInviteCtrl.deleteInvite();
                 }, function() {
                     MessageService.showToast('Cancelado');
                 });
@@ -122,32 +123,20 @@
             return instObj.getFullAddress();
         };
 
-        function deleteInviteAndReloadUser() {
-            var promise = InviteService.deleteInvite(newInviteCtrl.inviteKey);
-            promise.then(function success() {
-                AuthService.reload().then(function() {
-                    if(newInviteCtrl.user.isInactive()) {
-                        $state.go("user_inactive");
-                    } else {
-                        $state.go("app.user.home");
-                    }
-                });
-            }, function error(response) {
-                MessageService.showToast(response.data.msg);
-            });
-            return promise;
-        }
-
-       newInviteCtrl.deleteInvite = function deleteInvite() {
+        newInviteCtrl.deleteInvite = function deleteInvite() {
             var promise = InviteService.deleteInvite(newInviteCtrl.inviteKey);
             promise.then(function success() {
                 newInviteCtrl.user.removeInvite(newInviteCtrl.inviteKey);
                 AuthService.save();
-                MessageService.showToast('Você já é membro dessa instituição');
-                $state.go('app.user.home');
+                if(newInviteCtrl.user.isInactive()) {
+                    $state.go("user_inactive");
+                } else {
+                    $state.go("app.user.home");
+                }
             }, function error(response) {
                 MessageService.showToast(response.data.msg);
-            })
+            });
+            return promise;
         }
 
         function showAlert(event) {

--- a/frontend/invites/newInviteController.js
+++ b/frontend/invites/newInviteController.js
@@ -30,7 +30,7 @@
                     if (!userIsAMember()) {
                         newInviteCtrl.addInstitution(event);
                     } else {
-                        deleteInvite();
+                        newInviteCtrl.deleteInvite();
                     }
                 }
             } else {
@@ -138,7 +138,7 @@
             return promise;
         }
 
-        function deleteInvite() {
+       newInviteCtrl.deleteInvite = function deleteInvite() {
             var promise = InviteService.deleteInvite(newInviteCtrl.inviteKey);
             promise.then(function success() {
                 newInviteCtrl.user.removeInvite(newInviteCtrl.inviteKey);

--- a/frontend/survey/surveyDirective.js
+++ b/frontend/survey/surveyDirective.js
@@ -58,7 +58,7 @@
             getTypeSurvey();
             surveyCtrl.post.deadline && formateDate();
             surveyCtrl.post.options = surveyCtrl.options;
-
+            console.log(surveyCtrl.options);
             return new Post(surveyCtrl.post, surveyCtrl.user.current_institution.key);
         }
 

--- a/frontend/survey/surveyDirective.js
+++ b/frontend/survey/surveyDirective.js
@@ -58,7 +58,6 @@
             getTypeSurvey();
             surveyCtrl.post.deadline && formateDate();
             surveyCtrl.post.options = surveyCtrl.options;
-            console.log(surveyCtrl.options);
             return new Post(surveyCtrl.post, surveyCtrl.user.current_institution.key);
         }
 

--- a/frontend/test/specs/managementMembersControllerSpec.js
+++ b/frontend/test/specs/managementMembersControllerSpec.js
@@ -177,27 +177,26 @@
         describe('isUserInviteValid()', function() {
 
             it('should be true with new invite', function() {
-                var newInvite = new Invite({invitee: "teste@gmail.com",
-                                            type_of_invite: 'USER',
+                var newInvite = new Invite({type_of_invite: 'USER',
                                             institution_key: '987654321',
                                             admin_key: '12345'});
-                expect(manageMemberCtrl.isUserInviteValid(newInvite)).toBe(true);
+                expect(manageMemberCtrl.isUserInvitesValid(newInvite, ["teste@gmail.com"])).toBe(true);
             });
 
             it('should be false when the invitee was already invited', function() {
-                var inviteInvited = new Invite({invitee: "testuser@example.com",
-                                            type_of_invite: 'USER',
+                var inviteInvited = new Invite({type_of_invite: 'USER',
                                             institution_key: '987654321',
                                             admin_key: '12345'});
-                expect(manageMemberCtrl.isUserInviteValid(inviteInvited)).toBe(false);
+                expect(manageMemberCtrl.isUserInvitesValid(inviteInvited, ["testuser@example.com", 
+                    "member@gmail.com"])).toBe(false);
             });
 
             it('should be false when the invitee was already member', function() {
-                var inviteMember = new Invite({invitee: "member@gmail.com",
-                                            type_of_invite: 'USER',
+                var inviteMember = new Invite({type_of_invite: 'USER',
                                             institution_key: '987654321',
                                             admin_key: '12345'});
-                expect(manageMemberCtrl.isUserInviteValid(inviteMember)).toBe(false);
+                expect(manageMemberCtrl.isUserInvitesValid(inviteMember, ["member@gmail.com", 
+                    "testuser@example.com"])).toBe(false);
             });
         });
 

--- a/frontend/test/specs/managementMembersControllerSpec.js
+++ b/frontend/test/specs/managementMembersControllerSpec.js
@@ -137,7 +137,7 @@
                     return {
                         then: function(callback) {
                             return callback(
-                                {data: {key: '123'}}
+                                { data: { 'msg': 'Os convites estão sendo processados.' }}
                             );
                         }
                     };
@@ -146,18 +146,22 @@
 
             it('should call inviteService.sendInvite()', function(done) {
                 manageMemberCtrl.invite = {
-                    invitee: "teste@gmail.com",
                     type_of_invite: 'USER',
                     institution_key: '987654321',
                     admin_key: '54321',
                     sender_name: 'User',
                     key: '123'
                 };
+                manageMemberCtrl.emails = [{ email: "teste@gmail.com" }]
                 var newInvite = new Invite(manageMemberCtrl.invite);
+                var requestBody = {
+                    invite_body: newInvite,
+                    emails: ["teste@gmail.com"]
+                }
                 expect(manageMemberCtrl.sent_invitations.length).toBe(2);
                 var promise = manageMemberCtrl.sendUserInvite();
                 promise.then(function() {
-                    expect(inviteService.sendInvite).toHaveBeenCalledWith(newInvite);
+                    expect(inviteService.sendInvite).toHaveBeenCalledWith(requestBody);
                     expect(manageMemberCtrl.invite).toEqual({});
                     expect(manageMemberCtrl.sent_invitations).toContain(invite);
                     expect(manageMemberCtrl.sent_invitations).toContain(newInvite);

--- a/frontend/test/specs/managementMembersControllerSpec.js
+++ b/frontend/test/specs/managementMembersControllerSpec.js
@@ -161,10 +161,12 @@
                 expect(manageMemberCtrl.sent_invitations.length).toBe(2);
                 var promise = manageMemberCtrl.sendUserInvite();
                 promise.then(function() {
+                    var expectedInvite = _.clone(newInvite);
+                    expectedInvite.invitee = "teste@gmail.com";
                     expect(inviteService.sendInvite).toHaveBeenCalledWith(requestBody);
                     expect(manageMemberCtrl.invite).toEqual({});
                     expect(manageMemberCtrl.sent_invitations).toContain(invite);
-                    expect(manageMemberCtrl.sent_invitations).toContain(newInvite);
+                    expect(manageMemberCtrl.sent_invitations).toContain(expectedInvite);
                     expect(manageMemberCtrl.sent_invitations.length).toBe(3);
                     done();
                 });

--- a/frontend/test/specs/newInviteControllerSpec.js
+++ b/frontend/test/specs/newInviteControllerSpec.js
@@ -232,5 +232,16 @@
                 expect(authService.save).toHaveBeenCalled();
             });
         });
+
+        describe('acceptInvite', function () {
+            it('should call deleteInvite', function () {
+                spyOn(newInviteCtrl, 'deleteInvite');
+                newInviteCtrl.institution = otherInstitution;
+                newInviteCtrl.user = otherUser;
+                newInviteCtrl.office = "developer";
+                newInviteCtrl.acceptInvite("$event");
+                expect(newInviteCtrl.deleteInvite).toHaveBeenCalled();
+            });
+        });
     });
 }));

--- a/frontend/test/specs/newInviteControllerSpec.js
+++ b/frontend/test/specs/newInviteControllerSpec.js
@@ -176,10 +176,10 @@
                         }
                     };
                 });
-                spyOn(authService, 'reload').and.callFake(function() {
+                spyOn(authService, 'save').and.callFake(function() {
                     return {
                         then: function(callback) {
-                            return callback(newInviteCtrl.user = new User(otherUser));
+                            return callback();
                         }
                     };
                 });
@@ -210,7 +210,7 @@
 
             it('should call authService.reload()', function(done) {
                 promise.then(function() {
-                    expect(authService.reload).toHaveBeenCalled();
+                    expect(authService.save).toHaveBeenCalled();
                     done();
                 });
             });
@@ -233,14 +233,27 @@
             });
         });
 
-        describe('acceptInvite', function () {
-            it('should call deleteInvite', function () {
-                spyOn(newInviteCtrl, 'deleteInvite');
+        describe('deleteInvite', function () {
+            it('should call deleteInvite', function (done) {
+                spyOn(inviteService, 'deleteInvite').and.callFake(function () {
+                    return {
+                        then: function (callback) {
+                            return callback();
+                        }
+                    };
+                });
+                spyOn(authService, 'save');
                 newInviteCtrl.institution = otherInstitution;
-                newInviteCtrl.user = otherUser;
+                newInviteCtrl.user = new User(otherUser);
+                spyOn(newInviteCtrl.user, 'removeInvite');
                 newInviteCtrl.office = "developer";
-                newInviteCtrl.acceptInvite("$event");
-                expect(newInviteCtrl.deleteInvite).toHaveBeenCalled();
+                var promise = newInviteCtrl.deleteInvite();
+                promise.then(function success() {
+                    expect(newInviteCtrl.user.removeInvite).toHaveBeenCalled();
+                    expect(authService.save).toHaveBeenCalled();
+                    done();
+                });
+                expect(inviteService.deleteInvite).toHaveBeenCalled();
             });
         });
     });

--- a/frontend/utils/messageService.js
+++ b/frontend/utils/messageService.js
@@ -17,7 +17,7 @@
             "Error! The invite has already been used": "Esse convite já foi utilizado!",
             "Error! This comment has been deleted.": "Esse comentário foi removido!",
             "Error! This post has been deleted": "Esse post foi removido.",
-            "Error! User already liked this comment.": "O usuário já curtiu esse comentário."
+            "Error! User already liked this comment.": "O usuário já curtiu esse comentário.",
             "The invites are being processed.": "Os convites estão sendo processados."
         };
 

--- a/frontend/utils/messageService.js
+++ b/frontend/utils/messageService.js
@@ -15,7 +15,8 @@
             "Error! The end time must be after the current time": "A data final do evento deve ser posterior a data atual!",
             "Error! The end time can not be before the start time": "A data final do evento deve ser posterior a inicial!",
             "Error! The invite has already been used": "Esse convite já foi utilizado!",
-            "Error! This comment has been deleted.": "Esse comentário foi removido!"
+            "Error! This comment has been deleted.": "Esse comentário foi removido!",
+            "The invites are being processed.": "Os convites estão sendo processados."
         };
 
         service.showToast = function showToast(message) {


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
Make it possible to send many user invites at once.
</p>

<p><b>Solution:</b>
Now, the frontend send a list of emails and the invite body to the backend. The backend on the other hand iterates over the list creating an invite for each email and lastly send all the invites' keys to the queue, where the invites are really sent.
</p>

<p><b>TODO/FIXME:</b> n/a</p>
