### PR TITLE
Create new layout of reset password modal

### DIFF
--- a/frontend/auth/loginController.js
+++ b/frontend/auth/loginController.js
@@ -38,18 +38,26 @@
         };
 
         loginCtrl.resetPassword = function resetPassword(ev) {
-            var confirm = $mdDialog.prompt()
-                .title('Esqueceu sua senha?')
-                .textContent('Digite seu email e enviaremos um link para criar uma nova senha.')
-                .placeholder('Digite seu email')
-                .ariaLabel('Digite seu emai')
-                .targetEvent(ev)
-                .required(true)
-                .ok("Redefinir Senha")
-                .cancel("Cancelar");
+            // var confirm = $mdDialog.prompt()
+            //     .title('Esqueceu sua senha?')
+            //     .textContent('Digite seu email e enviaremos um link para criar uma nova senha.')
+            //     .placeholder('Digite seu email')
+            //     .ariaLabel('Digite seu emai')
+            //     .targetEvent(ev)
+            //     .required(true)
+            //     .ok("Redefinir Senha")
+            //     .cancel("Cancelar");
 
-            $mdDialog.show(confirm).then(function(email) {
-                AuthService.resetPassword(email);
+            // $mdDialog.show(confirm).then(function(email) {
+            //     AuthService.resetPassword(email);
+            // });
+            $mdDialog.show({
+                controller: "ResetPasswordController",
+                controllerAs: "resetCtrl",
+                templateUrl: '/app/auth/reset_password_dialog.html',
+                parent: angular.element(document.body),
+                targetEvent: ev,
+                clickOutsideToClose:true
             });
         };
 
@@ -74,5 +82,21 @@
                 $state.go("app.user.home");
             }
         })();
+    });
+
+    app.controller('ResetPasswordController', function(AuthService, $mdDialog) {
+        var resetCtrl = this;
+
+        resetCtrl.email = '';
+        resetCtrl.showNextScreen = false;
+
+        resetCtrl.resetPassword = function resetPassword() {
+            AuthService.resetPassword(resetCtrl.email);
+            resetCtrl.showNextScreen = true;
+        };
+
+        resetCtrl.closeResetDialog = function closeResetDialog() {
+            $mdDialog.hide();
+        };
     });
 })();

--- a/frontend/auth/loginController.js
+++ b/frontend/auth/loginController.js
@@ -38,19 +38,6 @@
         };
 
         loginCtrl.resetPassword = function resetPassword(ev) {
-            // var confirm = $mdDialog.prompt()
-            //     .title('Esqueceu sua senha?')
-            //     .textContent('Digite seu email e enviaremos um link para criar uma nova senha.')
-            //     .placeholder('Digite seu email')
-            //     .ariaLabel('Digite seu emai')
-            //     .targetEvent(ev)
-            //     .required(true)
-            //     .ok("Redefinir Senha")
-            //     .cancel("Cancelar");
-
-            // $mdDialog.show(confirm).then(function(email) {
-            //     AuthService.resetPassword(email);
-            // });
             $mdDialog.show({
                 controller: "ResetPasswordController",
                 controllerAs: "resetCtrl",
@@ -88,11 +75,11 @@
         var resetCtrl = this;
 
         resetCtrl.email = '';
-        resetCtrl.showNextScreen = false;
+        resetCtrl.showConfirmedRest = false;
 
         resetCtrl.resetPassword = function resetPassword() {
             AuthService.resetPassword(resetCtrl.email);
-            resetCtrl.showNextScreen = true;
+            resetCtrl.showConfirmedRest = true;
         };
 
         resetCtrl.closeResetDialog = function closeResetDialog() {

--- a/frontend/auth/reset_password_dialog.html
+++ b/frontend/auth/reset_password_dialog.html
@@ -6,7 +6,7 @@
                     <div layout="row" layout-align="center center">
                         <img src="/app/images/logowithname.png" style="margin-bottom: 20px; width: 70%;"/>
                     </div>
-                    <div ng-if="!resetCtrl.showNextScreen">
+                    <div ng-if="!resetCtrl.showConfirmedRest">
                         <form name="resetPassword" ng-submit="resetCtrl.resetPassword()" layout="column">
                             <b style="margin-bottom: 20px;">Redefinir sua senha</b>
                             <md-input-container>
@@ -23,7 +23,7 @@
                             </div>
                         </form>
                     </div>
-                    <div ng-if="resetCtrl.showNextScreen" layout="column">
+                    <div ng-if="resetCtrl.showConfirmedRest" layout="column">
                         <p>Você receberá dentro de instantes no e-mail {{resetCtrl.email}} um link para redefinição da senha.</p>
                         <div layout="row" layout-align="end center" style="padding: 0;">
                             <md-button class="md-raised" ng-click="resetCtrl.closeResetDialog()" md-colors="{background: 'default-teal-500'}">

--- a/frontend/auth/reset_password_dialog.html
+++ b/frontend/auth/reset_password_dialog.html
@@ -1,0 +1,39 @@
+<md-dialog flex-gt-md="30" flex-xs="95" flex-sm="65" flex-md="40">
+    <md-dialog-content>
+        <div layout="column" layout-align="space-between">
+            <div layout="row" layout-align="center center">
+                <div layout="column" flex="90" layout-padding>
+                    <div layout="row" layout-align="center center">
+                        <img src="/app/images/logowithname.png" style="margin-bottom: 20px; width: 70%;"/>
+                    </div>
+                    <div ng-if="!resetCtrl.showNextScreen">
+                        <form name="resetPassword" ng-submit="resetCtrl.resetPassword()" layout="column">
+                            <b style="margin-bottom: 20px;">Redefinir sua senha</b>
+                            <md-input-container>
+                                <label>E-mail</label>
+                                <input type="email" name="email" ng-model="resetCtrl.email" required/>
+                                <div ng-messages="resetPassword.email.$error">
+                                    <div ng-message="required">Insira um email válido</div>
+                                </div>
+                            </md-input-container>
+                            <div layout="row" layout-align="end center" style="padding: 0;">
+                                <md-button class="md-raised" type="submit" md-colors="{background: 'default-teal-500'}">
+                                    <span>enviar</span>
+                                </md-button>
+                            </div>
+                        </form>
+                    </div>
+                    <div ng-if="resetCtrl.showNextScreen" layout="column">
+                        <p>Você receberá dentro de instantes no e-mail {{resetCtrl.email}} um link para redefinição da senha.</p>
+                        <div layout="row" layout-align="end center" style="padding: 0;">
+                            <md-button class="md-raised" ng-click="resetCtrl.closeResetDialog()" md-colors="{background: 'default-teal-500'}">
+                                <span>inicial</span>
+                            </md-button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div style="height: 30px;" md-colors="{background: 'default-grey-300'}"></div>
+        </div>
+    </md-dialog-content>
+</md-dialog>


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> Create new layout for modal reset password.</p>

![screenshot from 2018-02-21 11-27-47](https://user-images.githubusercontent.com/18005317/36485427-f8582714-16fa-11e8-8a99-3aa7672586e8.png)

<p><b>Solution:</b> Using the angular directives, I created the new layout for the dialog of password reset according to what was passed by the design.</p>

![screenshot from 2018-02-21 11-25-35](https://user-images.githubusercontent.com/18005317/36485443-00a081fa-16fb-11e8-810c-ea646aaf422d.png)
![screenshot from 2018-02-21 11-25-51](https://user-images.githubusercontent.com/18005317/36485453-05c0d0f4-16fb-11e8-8cb9-640408f480a5.png)
![screenshot from 2018-02-21 11-26-13](https://user-images.githubusercontent.com/18005317/36485458-088c8c10-16fb-11e8-86c3-f2a82ca563c7.png)
![screenshot from 2018-02-21 11-26-53](https://user-images.githubusercontent.com/18005317/36485462-0a8046ba-16fb-11e8-8357-130aa3dde924.png)
![screenshot from 2018-02-21 11-27-13](https://user-images.githubusercontent.com/18005317/36485469-0f2e45d6-16fb-11e8-82b8-d267010c3f3e.png)
![screenshot from 2018-02-21 11-27-25](https://user-images.githubusercontent.com/18005317/36485473-112bbf44-16fb-11e8-914a-97f2489f6919.png)

<p><b>TODO/FIXME:</b> n/a</p>
