### PR TITLE
Fix save post card visualization when the post isn't filled

### DIFF
--- a/frontend/post/save_post.html
+++ b/frontend/post/save_post.html
@@ -106,12 +106,12 @@
       </div>
     </md-card-content>
     <md-card-actions style="text-align: right; margin-right: 20px; margin-bottom: 20px;"
-      layout="row" layout-align="end center">
+      layout="row" layout-align="end center" ng-show="postCtrl.showButton()">
       <load-circle flex ng-if="postCtrl.loadingPost"></load-circle>
-      <md-button ng-show="postCtrl.showButton()" style="color: #009688" ng-click="postCtrl.cancelDialog()">
+      <md-button style="color: #009688" ng-click="postCtrl.cancelDialog()">
         Cancelar
       </md-button>
-      <md-button  ng-show="postCtrl.showButton()" class="md-raised" md-colors="{background: 'default-teal-500'}" title="Enviar"
+      <md-button class="md-raised" md-colors="{background: 'default-teal-500'}" title="Enviar"
         type="submit">
         Postar
       </md-button>


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> Card-actions are appearing on the create post card even if the post is empty, making the post card larger than necessary.</p>

![screenshot from 2018-02-22 09-14-38](https://user-images.githubusercontent.com/18005317/36538357-dad79de8-17b1-11e8-8d20-c8a78c8b40f2.png)

<p><b>Solution:</b> I added a ng-show in the card-action directive that checks whether the post was populated or not, if yes, displays the buttons.</p>

![screenshot from 2018-02-22 09-14-12](https://user-images.githubusercontent.com/18005317/36538359-debc26ea-17b1-11e8-9cab-c6eb1545a7d5.png)

<p><b>TODO/FIXME:</b> n/a</p>
