### PR TITLE
Fix alignment of edit institution page

### DIFF
--- a/frontend/institution/management_institution_page.html
+++ b/frontend/institution/management_institution_page.html
@@ -1,6 +1,6 @@
 <div layout="row" flex md-colors="{background: 'grey-200'}" layout-align="center">
   <!-- CONTENT -->
-  <div flex-lg="90" flex-gt-lg="70" flex layout="row" layout-align="space-between"
+  <div flex-lg="90" flex-gt-lg="70" flex layout="row" layout-align="space-around"
   md-colors="{background: 'grey-50'}">
 
   <!-- LEFT SIDE PANEL -->


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> The alignment of the institution's edit information page is right and not centered as it should be.</p>

![screenshot from 2018-02-22 10-29-42](https://user-images.githubusercontent.com/18005317/36541410-9422fd2e-17bc-11e8-96bb-4b48f0fab2d2.png)

<p><b>Solution:</b> Change the layout of the edit institution information page (from space-between to space-around).</p>

![screenshot from 2018-02-22 10-30-12](https://user-images.githubusercontent.com/18005317/36541415-97da2b54-17bc-11e8-863b-0f110e65ce8f.png)

<p><b>TODO/FIXME:</b> n/a</p>
