### PR TITLE
Fix bug in opening of institution website without http(s).

### DIFF
--- a/frontend/institution/institutionController.js
+++ b/frontend/institution/institutionController.js
@@ -221,7 +221,8 @@
 
         institutionCtrl.openWebsite = function openWebsite() {
             var website = institutionCtrl.institution.website_url;
-            $window.open(website);
+            website = Utils.addHttpsToUrl(website, [website]);
+            $window.open(website, '_blank');
         };
 
         institutionCtrl.getFullAddress = function getFullAddress() {


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> When the website of institution don't has http or https the page opened after click is the home page of cis.</p>

<p><b>Solution:</b> Reusing function in Utils.js to add https in url of website of institution.</p>

<p><b>TODO/FIXME:</b> n/a</p>
