### PR TITLE
Fix responsiveness of event page to small screens.

### DIFF
--- a/frontend/event/event_page.html
+++ b/frontend/event/event_page.html
@@ -1,6 +1,6 @@
 <md-content layout="row" id="content" class="body custom-scrollbar">
-  <div layout="row" flex-gt-xs="95" layout-align="end start">
-    <div flex-gt-xs="95">
+  <div layout="row" flex flex-gt-xs="95" layout-align="end start">
+    <div flex flex-gt-xs="95">
       <event-details event="eventCtrl.event" is-event-page=true></event-details>
     </div>
   </div>

--- a/frontend/event/event_page.html
+++ b/frontend/event/event_page.html
@@ -1,5 +1,7 @@
-<md-content id="content" class="body custom-scrollbar">
-  <div flex="90" flex-gt-xs="95" style="margin-left: 40px; margin-right: 35px;">
-    <event-details event="eventCtrl.event" is-event-page=true></event-details>
+<md-content layout="row" id="content" class="body custom-scrollbar">
+  <div layout="row" flex-gt-xs="95" layout-align="end start">
+    <div flex-gt-xs="95">
+      <event-details event="eventCtrl.event" is-event-page=true></event-details>
+    </div>
   </div>
 </md-content>


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> The event page in small display was big margins.</p>

<p><b>Solution:</b> Removed margins and used responsiviness.</p>

<p><b>TODO/FIXME:</b> n/a</p>

![screenshot from 2018-02-22 11-45-18](https://user-images.githubusercontent.com/18709274/36545352-7be79b06-17c7-11e8-9343-03263ea31a6d.png)
