### PR TITLE
 Fix possible multiple click to open PDF dialog 

### DIFF
--- a/frontend/post/pdfDialog.html
+++ b/frontend/post/pdfDialog.html
@@ -1,3 +1,6 @@
-<md-dialog layout-fill flex="80" aria-label="portfólio">
-    <embed layout="column" ng-src="{{ctrl.pdfUrl}}" flex="100" type='application/pdf'></embed>
+<md-dialog layout-fill flex="80" aria-label="portfólio" layout="row" layout-align="center">
+    <div ng-if="ctrl.isLoadingPdf" layout="row" layout-align="center center">
+        <load-circle></load-circle>
+    </div>
+    <embed ng-if="!ctrl.isLoadingPdf" layout="column" ng-src="{{ctrl.pdfUrl}}" flex="100" type='application/pdf'></embed>
 </md-dialog>

--- a/frontend/post/pdfViewDirective.js
+++ b/frontend/post/pdfViewDirective.js
@@ -3,7 +3,7 @@
 
     var app = angular.module('app');
 
-    app.controller('PdfController', function PdfController(PdfService, $mdDialog, $sce) {
+    app.controller('PdfController', function PdfController($mdDialog) {
         var pdfCtrl = this;     
 
         pdfCtrl.showFiles = function() {
@@ -12,20 +12,21 @@
         };
 
         pdfCtrl.pdfDialog = function(ev, pdf) {
-            var readablePdf = {};
+            /*var readablePdf = {};
             PdfService.getReadableURL(pdf.url, setPdfURL, readablePdf).then(
                 function success() {
-                    $mdDialog.show({
-                        templateUrl: 'app/post/pdfDialog.html',
-                        targetEvent: ev,
-                        clickOutsideToClose:true,
-                        locals: {
-                            pdfUrl: readablePdf.url
-                        },
-                        controller: DialogController,
-                        controllerAs: 'ctrl'
-                    });
-                });
+                });*/
+            
+            $mdDialog.show({
+                templateUrl: 'app/post/pdfDialog.html',
+                targetEvent: ev,
+                clickOutsideToClose:true,
+                locals: {
+                    pdf: pdf
+                },
+                controller: DialogController,
+                controllerAs: 'ctrl'
+            });
         };
 
         pdfCtrl.hideFile = function(index) {
@@ -39,10 +40,23 @@
             pdf.url = url;
         }
 
-        function DialogController($mdDialog, pdfUrl) {
+        function DialogController($mdDialog, PdfService, $sce, pdf) {
             var ctrl = this;
-            var trustedUrl = $sce.trustAsResourceUrl(pdfUrl);
-            ctrl.pdfUrl = trustedUrl;
+            ctrl.pdfUrl = "";
+            ctrl.isLoadingPdf = true;
+
+            function readPdf() {
+                var readablePdf = {};
+                PdfService.getReadableURL(pdf.url, setPdfURL, readablePdf).then(function success() {
+                    var trustedUrl = $sce.trustAsResourceUrl(readablePdf.url);
+                    ctrl.pdfUrl = trustedUrl;
+                    ctrl.isLoadingPdf = false;
+                });
+            }
+
+            (function main() {
+                readPdf();
+            })();
         }
     });
 


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> The PDF view dialog is taking a long time to open, allowing the user to click several times to open it.</p>

<p><b>Solution:</b> I added a circular load that allows the modal to open as soon as the user clicks and it waits until the pdf is fully loaded.</p>

![screenshot from 2018-02-22 14-45-06](https://user-images.githubusercontent.com/18005317/36555146-f15e5a1a-17df-11e8-8fc5-3a2a2beaa3c1.png)

<p><b>TODO/FIXME:</b> n/a</p>
