### PR TITLE
Fix show message of empty filtered institutions in search page

### DIFF
--- a/frontend/search/search.html
+++ b/frontend/search/search.html
@@ -49,8 +49,8 @@
 
                     <md-list ng-if="searchCtrl.loading">
                         <h4 md-colors="{color:'grey-700'}">Resultados da pesquisa</h4>
-                        <md-list-item class="list-item-dense" ng-repeat="institution in searchCtrl.institutions 
-                        | filter: searchCtrl.searchActuation | filter: searchCtrl.searchNature | filter: searchCtrl.searchState" 
+                        <md-list-item class="list-item-dense" ng-repeat="institution in institutions = (searchCtrl.institutions 
+                        | filter: searchCtrl.searchActuation | filter: searchCtrl.searchNature | filter: searchCtrl.searchState)" 
                             style="margin-bottom: 1%;"
                               md-colors="{background: 'grey-300'}">
                             <div layout="row" ng-click="searchCtrl.goToInstitution(institution.id)">
@@ -66,7 +66,7 @@
                                 </div>
                             </div>
                         </md-list-item>
-                        <md-list-item class="md-3-line" ng-if="searchCtrl.notHasInstitutions()">
+                        <md-list-item class="md-3-line" ng-if="institutions.length === 0">
                             <b>&bull; Nenhuma instituição encontrada</b>
                         </md-list-item>
                     </md-list>

--- a/frontend/search/searchController.js
+++ b/frontend/search/searchController.js
@@ -39,10 +39,6 @@
             }
         };
 
-        searchCtrl.notHasInstitutions = function notHasInstitutions() {
-            return _.isEmpty(searchCtrl.institutions);
-        };
-
         searchCtrl.goToInstitution = function goToInstitution(institutionId) {
             if (institutionId) {
                 InstitutionService.getInstitution(institutionId).then(function success(response) {

--- a/frontend/test/specs/searchControllerSpec.js
+++ b/frontend/test/specs/searchControllerSpec.js
@@ -91,18 +91,6 @@
             });
         });
 
-        describe('notHasInstitution', function() {
-
-            it('Should be true when institutions list is empty', function() {
-                expect(searchCtrl.notHasInstitutions()).toBeTruthy();
-            });
-
-            it('Should be false when instituions list contains some institution', function() {
-                searchCtrl.institutions.push(splab);
-                expect(searchCtrl.notHasInstitutions()).toBeFalsy();
-            });
-        });
-
         describe('search()', function() {
 
             it('Should call makeSearch()', function() {


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> When searching for an institution and the angular filter does not find an institution with the specified characteristics, no message appears to the user, making him believe that the search is still being processed.</p>

![screenshot from 2018-02-23 11-32-06](https://user-images.githubusercontent.com/18005317/36599493-4aa74902-188e-11e8-8b75-957dbd28ebd1.png)

<p><b>Solution:</b> I created a check that checks if the filter result is empty, if yes it displays a message to the user stating that no such institution has been found.</p>

![screenshot from 2018-02-23 11-33-14](https://user-images.githubusercontent.com/18005317/36599497-4f0b4a3e-188e-11e8-8e4f-f7342fbe5928.png)

<p><b>TODO/FIXME:</b> n/a</p>
