### PR TITLE
Script to add an App Version to be displayed on Frontend and Support apps 

### DIFF
--- a/ecis
+++ b/ecis
@@ -19,10 +19,6 @@ SUPPORT_CONFIG_FILE="support/config.js"
 
 PY_ENV=backend/py_env
 
-APP_VERSION=$(git branch | grep '* ' | tr -d '* ')
-sed -i "6s|.*|    APP_VERSION: '$APP_VERSION'|" $FRONTEND_CONFIG_FILE
-sed -i "6s|.*|    APP_VERSION: '$APP_VERSION'|" $SUPPORT_CONFIG_FILE
-
 function set_backend_url {
     if [ -z $1 ]; then
         url="http://$BACKEND_DOMAIN"
@@ -49,6 +45,10 @@ function set_landingpage_url {
 
 case "$1" in
     run)
+        APP_VERSION=$(git branch | grep '* ' | tr -d '* ')
+        sed -i "6s|.*|    APP_VERSION: '$APP_VERSION'|" $FRONTEND_CONFIG_FILE
+        sed -i "6s|.*|    APP_VERSION: '$APP_VERSION'|" $SUPPORT_CONFIG_FILE
+
         echo "=========== Cleaning Environment ==========="
         rm -rf $PY_ENV
         rm -rf frontend/test/node_modules frontend/test/bower_components

--- a/ecis
+++ b/ecis
@@ -19,6 +19,10 @@ SUPPORT_CONFIG_FILE="support/config.js"
 
 PY_ENV=backend/py_env
 
+APP_VERSION=$(git branch | grep '* ' | tr -d '* ')
+sed -i "6s|.*|    APP_VERSION: '$APP_VERSION'|" $FRONTEND_CONFIG_FILE
+sed -i "6s|.*|    APP_VERSION: '$APP_VERSION'|" $SUPPORT_CONFIG_FILE
+
 function set_backend_url {
     if [ -z $1 ]; then
         url="http://$BACKEND_DOMAIN"
@@ -37,9 +41,9 @@ function set_landingpage_url {
     else
         url="http://"$1
     fi
-    sed -i "5s|.*|    LANDINGPAGE_URL: '$url'|" $FRONTEND_CONFIG_FILE
+    sed -i "5s|.*|    LANDINGPAGE_URL: '$url',|" $FRONTEND_CONFIG_FILE
     echo ">> Frontend will use ${bold}$url${_bold} as landing page."
-    sed -i "5s|.*|    LANDINGPAGE_URL: '$url'|" $SUPPORT_CONFIG_FILE
+    sed -i "5s|.*|    LANDINGPAGE_URL: '$url',|" $SUPPORT_CONFIG_FILE
     echo ">> Support will use ${bold}$url${_bold} as landing page."
 }
 
@@ -114,6 +118,12 @@ case "$1" in
     ;;
 
     deploy)
+        APP_VERSION=$(git tag | tail -1)
+        read -p ">> The ${bold}Latest${_bold} APP VERSION ${bold}$APP_VERSION${_bold} will be deployed, ok?"
+        git checkout tags/"$APP_VERSION"
+        sed -i "6s|.*|    APP_VERSION: '$APP_VERSION'|" $FRONTEND_CONFIG_FILE
+        sed -i "6s|.*|    APP_VERSION: '$APP_VERSION'|" $SUPPORT_CONFIG_FILE
+
         read -p "${bold}>> Type the app name:${_bold} " APP_NAME
 
         gcloud config set project $APP_NAME

--- a/ecis
+++ b/ecis
@@ -45,7 +45,7 @@ function set_landingpage_url {
 
 case "$1" in
     run)
-        APP_VERSION=$(git branch | grep '* ' | tr -d '* ')
+        APP_VERSION=$(git branch | grep "*" | tr -d "()*" | cut -c2-)
         sed -i "6s|.*|    APP_VERSION: '$APP_VERSION'|" $FRONTEND_CONFIG_FILE
         sed -i "6s|.*|    APP_VERSION: '$APP_VERSION'|" $SUPPORT_CONFIG_FILE
 

--- a/frontend/config.js
+++ b/frontend/config.js
@@ -3,5 +3,5 @@
 var Config = {
     BACKEND_URL: 'http://localhost:8082',
     LANDINGPAGE_URL: 'http://localhost:8080',
-    APP_VERSION: 'v1.3.15-alpha'
+    APP_VERSION: 'master'
 };

--- a/frontend/config.js
+++ b/frontend/config.js
@@ -2,5 +2,6 @@
 
 var Config = {
     BACKEND_URL: 'http://localhost:8082',
-    LANDINGPAGE_URL: 'http://localhost:8080'
+    LANDINGPAGE_URL: 'http://localhost:8080',
+    APP_VERSION: 'v1.3.15-alpha'
 };

--- a/frontend/main/main.html
+++ b/frontend/main/main.html
@@ -44,6 +44,10 @@
   </md-button>
 </div>
 
+<h4 class="md-caption app-version">
+    {{mainCtrl.APP_VERSION}}
+</h4>
+
 <md-toolbar class="md-warn" ng-if="!mainCtrl.userEmailVerified()" ng-hide="hideEmailVerification">
   <div class="md-toolbar-tools" layout-align="end center">
     <h2 class="md-flex">Verifique seu email para confirmar sua conta.</h2>

--- a/frontend/main/mainController.js
+++ b/frontend/main/mainController.js
@@ -14,6 +14,8 @@
         mainCtrl.pending_manager_member = 0;
         mainCtrl.pending_inst_invitations = 0;
 
+        mainCtrl.APP_VERSION = Config.APP_VERSION;
+
         mainCtrl.search = function search() {
             if(mainCtrl.search_keyword) {
                 var search = mainCtrl.search_keyword;

--- a/frontend/styles/custom.css
+++ b/frontend/styles/custom.css
@@ -934,3 +934,17 @@ md-radio-button.md-default-theme.md-checked .md-off, md-radio-button.md-checked 
     margin-top: 4px; 
     border-radius: 50%;
 }
+
+.app-version {
+    position: fixed;
+    left: 10%;
+    bottom: -2%;
+    z-index: 100;
+    padding: 5px 10px 8px 10px;
+    -webkit-box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+       -moz-box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+    background-color: #f5f5f5;
+    text-align: center;
+    font-size: 10px;
+  }

--- a/support/config.js
+++ b/support/config.js
@@ -3,5 +3,5 @@
 var Config = {
     BACKEND_URL: 'http://localhost:8082',
     LANDINGPAGE_URL: 'http://localhost:8080',
-    APP_VERSION: 'v1.3.15-alpha'
+    APP_VERSION: 'master'
 };

--- a/support/config.js
+++ b/support/config.js
@@ -2,5 +2,6 @@
 
 var Config = {
     BACKEND_URL: 'http://localhost:8082',
-    LANDINGPAGE_URL: 'http://localhost:8080'
+    LANDINGPAGE_URL: 'http://localhost:8080',
+    APP_VERSION: 'v1.3.15-alpha'
 };

--- a/support/report/reportController.js
+++ b/support/report/reportController.js
@@ -126,6 +126,7 @@
             controller.report.userKey = user.key;
             controller.report.timestamp = new Date().toISOString();
             controller.report.userInfo = getUserInfo();
+            controller.report.appVersion = Config.APP_VERSION;
             FirebaseService.createReport(controller.report).then(function () {
                 MessageService.showToast("Obrigado! Recebemos seu Relatório.");
                 $state.go("support.home");

--- a/support/support/support.html
+++ b/support/support/support.html
@@ -46,6 +46,10 @@
         </md-menu-item>
       </md-menu-content>
     </md-content>
+    <span flex md-truncate></span>
+    <div layout="row" layout-align="center">
+        <h1 class="md-caption">{{controller.APP_VERSION}}</h1>
+    </div>
   </md-sidenav>
 
   <div layout="column" flex>

--- a/support/support/supportController.js
+++ b/support/support/supportController.js
@@ -9,6 +9,8 @@
 
         controller.user = AuthService.getCurrentUser();
 
+        controller.APP_VERSION = Config.APP_VERSION;
+
         controller.sideNavOptions = [
             {
                 label: "Início",


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> The platform needs to display which version is running on the browser, to be able to track bugs and new versions available.</p>

<p><b>Solution:</b> Add to the config.js files (on support and frontend) a variable that stores the versions of the app. That variable is controlled by the script, setting up the version right after execute **run** or **deploy** commands. The version will appear on the left lower side of the screen.</p>

![screenshot from 2018-02-23 14-55-52](https://user-images.githubusercontent.com/2967288/36608885-f09880ae-18a9-11e8-9acc-cbd8e83b3525.png)
![screenshot from 2018-02-23 14-54-52](https://user-images.githubusercontent.com/2967288/36608888-f1cbe5ce-18a9-11e8-956b-dbbc3b1fcf01.png)

<p><b>TODO/FIXME:</b> n/a</p>
