### PR TITLE
Fix alignment of management institution page

### DIFF
--- a/frontend/institution/management_institution_page.html
+++ b/frontend/institution/management_institution_page.html
@@ -1,6 +1,6 @@
 <div layout="row" flex md-colors="{background: 'grey-200'}" layout-align="center">
   <!-- CONTENT -->
-  <div flex-lg="90" flex-gt-lg="70" flex layout="row" layout-align="space-around"
+  <div flex-lg="90" flex-gt-lg="70" flex layout="row" layout-align="space-between"
   md-colors="{background: 'grey-50'}">
 
   <!-- LEFT SIDE PANEL -->
@@ -64,8 +64,10 @@
     </md-sidenav>
 
     <!-- CONTENT -->
-    <md-content id="content" flex-gt-md="70" flex class="body custom-scrollbar">
-      <div ui-view="content_manage_institution" flex layout="column"></div>
-    </md-content>
+    <div flex layout="row" layout-align="center">
+      <md-content id="content" flex-gt-md="95" flex flex class="body custom-scrollbar">
+        <div ui-view="content_manage_institution" flex layout="column"></div>
+      </md-content>
+    </div>
   </div>
 </div>

--- a/frontend/institution/management_institution_page.html
+++ b/frontend/institution/management_institution_page.html
@@ -65,7 +65,7 @@
 
     <!-- CONTENT -->
     <div flex layout="row" layout-align="center">
-      <md-content id="content" flex-gt-md="95" flex flex class="body custom-scrollbar">
+      <md-content id="content" flex-gt-md="95" flex class="body custom-scrollbar">
         <div ui-view="content_manage_institution" flex layout="column"></div>
       </md-content>
     </div>


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> The left menu alignment of the institution management screen is different from the home page menu (far right).</p>

![screenshot from 2018-02-26 08-38-53](https://user-images.githubusercontent.com/18005317/36668881-7b3c3344-1ad1-11e8-86f9-52dacbdbe08d.png)

<p><b>Solution:</b> I changed the layout-align from space-around to space-between and centralized the cards of edit institution and manage members.</p>

![screenshot from 2018-02-26 08-35-49](https://user-images.githubusercontent.com/18005317/36668884-80ad4b6a-1ad1-11e8-81be-e2cf2a1b4a8d.png)

<p><b>TODO/FIXME:</b> n/a</p>
