### PR TITLE
Fix missing feedback when editing user profile

### DIFF
--- a/frontend/auth/configProfileController.js
+++ b/frontend/auth/configProfileController.js
@@ -16,6 +16,7 @@
         configProfileCtrl.loading = false;
         configProfileCtrl.cpfRegex = /^\d{3}\.\d{3}\.\d{3}\-\d{2}$/;
         configProfileCtrl.photo_url = configProfileCtrl.newUser.photo_url;
+        configProfileCtrl.loadingSubmission = false;
 
         var HAS_ONLY_ONE_INSTITUTION_MSG = "Esta é a única instituição ao qual você é vinculado." +
             " Ao remover o vínculo você não poderá mais acessar o sistema," +
@@ -56,6 +57,7 @@
         };
 
         configProfileCtrl.finish = function finish() {
+            configProfileCtrl.loadingSubmission = true;
             if (configProfileCtrl.photo_user) {
                 configProfileCtrl.loading = true;
                 ImageService.saveImage(configProfileCtrl.photo_user).then(function (data) {
@@ -63,6 +65,7 @@
                     configProfileCtrl.user.uploaded_images.push(data.url);
                     saveUser();
                     configProfileCtrl.loading = false;
+                    configProfileCtrl.loadingSubmission = false;
                 });
             } else {
                 return saveUser();
@@ -76,6 +79,8 @@
                 var patch = jsonpatch.generate(observer);
                 UserService.save(patch).then(function success() {
                     AuthService.save();
+                    configProfileCtrl.loadingSubmission = false;
+                    MessageService.showToast("Edição concluída com sucesso");
                     $state.go("app.user.home");
                     deffered.resolve();
                 });

--- a/frontend/auth/config_profile.html
+++ b/frontend/auth/config_profile.html
@@ -41,7 +41,8 @@
                 </md-input-container>
               </div>
             </div>
-            <section layout="row" layout="column" layout-align="end center" layout-wrap>
+            <load-circle layout="row" layout-align="center center" ng-if="configProfileCtrl.loadingSubmission"></load-circle>
+            <section layout="row" layout="column" layout-align="end center" layout-wrap ng-if="!configProfileCtrl.loadingSubmission">
               <md-button ng-click="configProfileCtrl.deleteAccount($event)" md-colors="{background: 'red-500'}">Excluir conta</md-button>
               <md-button ng-click="configProfileCtrl.finish()" md-colors="{background: 'teal-500'}">Concluir edição</md-button>
             </section>


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
The system wasn't giving a feedback of user edition. No message, no loading progress.
</p>

<p><b>Solution:</b>
I've added the loading-cicle directive and called showToast to shows up when the editing is done.

![screenshot from 2018-02-27 08-41-44](https://user-images.githubusercontent.com/23387866/36727221-3fd0368c-1b9b-11e8-9e3e-f5a6bed4abb7.png)

![screenshot from 2018-02-27 08-42-05](https://user-images.githubusercontent.com/23387866/36727227-44c422fc-1b9b-11e8-8345-33c558090a98.png)


</p>

<p><b>TODO/FIXME:</b> n/a</p>
