### PR TITLE
Fix posibility of return step when saving event

### DIFF
--- a/frontend/event/eventController.js
+++ b/frontend/event/eventController.js
@@ -316,7 +316,7 @@
 
         dialogCtrl.nextStepOrSave = function nextStepOrSave() {
             if (dialogCtrl.getStep(3)) {
-                dialogCtrl.blockPublishButton = true;
+                dialogCtrl.blockReturnButton = true;
                 dialogCtrl.save();
             } else {
                 dialogCtrl.nextStep();
@@ -376,6 +376,8 @@
                     dialogCtrl.events.push(response.data);
                     MessageService.showToast('Evento criado com sucesso!');
                 }, function error(response) {
+                    dialogCtrl.loading = false;
+                    dialogCtrl.blockReturnButton = false;
                     MessageService.showToast(response.data.msg);
                     $state.go("app.user.events");
                 });

--- a/frontend/event/event_dialog.html
+++ b/frontend/event/event_dialog.html
@@ -39,7 +39,7 @@
   </div>
   <div layout="row" layout-align="start center" style="padding: 0;">
     <div flex="0" ng-if="controller.getStep(2) || controller.getStep(3)">
-        <md-button class="md-fab md-primary" style="margin-left: -28px;" ng-click="controller.previousStep()"
+        <md-button class="md-fab md-primary" style="margin-left: -28px;" ng-click="controller.previousStep()" ng-disabled="controller.blockReturnButton"
           md-colors="{background: 'default-teal-500'}" hide-xs>
             <md-icon >keyboard_arrow_left</md-icon>
         </md-button>
@@ -158,8 +158,7 @@
             </div>
           </md-dialog-content>
           <md-dialog-content ng-if="controller.getStep(3)" layout-padding class="custom-scrollbar">
-            <load-circle flex ng-if="controller.loading"></load-circle>
-            <div ng-if="!controller.loading" layout="row" layout-align="center center">
+            <div layout="row" layout-align="center center">
               <div flex="95" layout="column">
                 <div layout-margin>
                   <p class="md-subheader">Vídeos</p>
@@ -200,17 +199,18 @@
               </div>
             </div>
           </md-dialog-content>
-          <md-dialog-actions ng-if="!controller.loading" style="border:0px" layout="row">
-              <md-button class="md-raised" md-colors="{background: 'default-teal-500'}" ng-click="controller.closeDialog()">
+          <md-dialog-actions style="border:0px" layout="row">
+              <md-button ng-if="!controller.loading" class="md-raised" md-colors="{background: 'default-teal-500'}" ng-click="controller.closeDialog()">
                   <span style="color: white;">cancelar</span>
               </md-button>
               <md-button class="md-raised" md-colors="{background: 'default-teal-500'}" ng-click="controller.previousStep()"
-                hide-gt-xs ng-if="controller.getStep(2) || controller.getStep(3)">
+                hide-gt-xs ng-if="(controller.getStep(2) || controller.getStep(3)) && !controller.loading">
                   <span style="color: white;">voltar</span>
               </md-button>
-              <md-button class="md-raised" type="submit" md-colors="{background: 'default-teal-500'}" ng-disabled="controller.blockPublishButton">
+              <md-button ng-if="!controller.loading" class="md-raised" type="submit" md-colors="{background: 'default-teal-500'}">
                   <span style="color: white;">{{controller.getStep(3) ? "publicar" : "avançar"}}</span>
               </md-button>
+              <load-circle flex ng-if="controller.loading"></load-circle>
           </md-dialog-actions>
         </form>
       </md-dialog>


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> When clicking the button to publish the event, the button to return to the previous step is still enabled giving the user the possibility to go back to the previous step and if an error occurs in the publication, it is prevented from proceeding to the next step because the buttons forward and cancel no longer appear.</p>

![screenshot from 2018-02-27 09-43-09](https://user-images.githubusercontent.com/18005317/36729555-5bb09e0c-1ba3-11e8-9bd4-9a9e7113e81d.png)

<p><b>Solution:</b> I disabled the back button when the event is being published so that the user can not return to the previous step, and if an error occurs, the buttons are activated again so that the user will try to publish again.</p>

![screenshot from 2018-02-27 09-41-05](https://user-images.githubusercontent.com/18005317/36729485-1805ced4-1ba3-11e8-81a5-64748c792e6f.png)

<p><b>TODO/FIXME:</b> n/a</p>
