### PR TITLE
Fix design of event's date in firefox.

### DIFF
--- a/frontend/event/event_details.html
+++ b/frontend/event/event_details.html
@@ -6,7 +6,7 @@
     <div layout="row" layout-xs="column">
       <md-card-content style="max-height: 150px" md-colors="{background: 'default-grey-200'}">
         <div style="max-height: 100px;" layout="column">
-          <div layout="row" md-colors="{background: 'default-grey-200'}">
+          <div style="max-height: 50px;" layout="row" md-colors="{background: 'default-grey-200'}">
             <h1 class="md-display-1" md-colors="{color:'default-teal-400'}" style="font-weight: bold; margin-top: auto;">
               {{eventDetailsCtrl.event.start_time | amUtc | amLocal | amDateFormat:'DD'}}
               A {{eventDetailsCtrl.event.end_time | amUtc | amLocal | amDateFormat:'DD' | uppercase}}</h1>


### PR DESCRIPTION
<p><b>Feature/Bug description:</b> The date square was out of card.</p>

<p><b>Solution:</b> Set the max heigth of square.</p>

<p><b>TODO/FIXME:</b> n/a</p>

![screenshot from 2018-02-27 11-35-25](https://user-images.githubusercontent.com/18709274/36734684-06a42e3c-1bb3-11e8-96ce-f5aae340b7ef.png)
![screenshot from 2018-02-27 11-35-01](https://user-images.githubusercontent.com/18709274/36734685-06c4de7a-1bb3-11e8-933b-4e55398e0633.png)
