### PR TITLE
Fix create survey button when editing post

### DIFF
--- a/frontend/post/save_post.html
+++ b/frontend/post/save_post.html
@@ -34,7 +34,7 @@
               </md-input-container>
           </div>
             <!-- SURVEY -->
-          <survey-directive ng-if="postCtrl.typePost === 'Survey'" post="postCtrl.post" posts="posts" user="postCtrl.user" callback="postCtrl.choiceCommon"
+          <survey-directive ng-if="postCtrl.typePost === 'Survey' && !isEditing" post="postCtrl.post" posts="posts" user="postCtrl.user" callback="postCtrl.choiceCommon"
               options="postCtrl.options"></survey-directive>
         </div>
       </div>
@@ -76,7 +76,7 @@
                   {{!postCtrl.showFiles() ? 'Anexar PDF' : 'Trocar PDF'}}
                 </md-button>
               </md-menu-item>
-              <md-menu-item>
+              <md-menu-item ng-if="!isEditing">
                 <md-button ng-click="postCtrl.setTypeOfPost()" aria-label="Tipo do Post">
                   <div ng-if="postCtrl.typePost === 'Common'">
                     <md-icon>poll</md-icon>


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
Create survey's button was appearing in edit post's modal.
</p>

<p><b>Solution:</b>
I've added a ng-if in the button making it to get hidden when the modal is to edit the post.

![screenshot from 2018-02-27 17-29-44](https://user-images.githubusercontent.com/23387866/36753410-d573130a-1be4-11e8-9314-c64b1bce7649.png)

</p>

<p><b>TODO/FIXME:</b> n/a</p>
