### PR TITLE
Send notification when the admin delete a post

### DIFF
--- a/backend/handlers/post_handler.py
+++ b/backend/handlers/post_handler.py
@@ -69,7 +69,7 @@ class PostHandler(BaseHandler):
 
         post.delete(user)
 
-        if(is_admin):
+        if(is_admin and not is_author):
             send_message_notification(post.author.urlsafe(), user.key.urlsafe(), 
                 'DELETED_POST', post.key.urlsafe())
 

--- a/backend/handlers/post_handler.py
+++ b/backend/handlers/post_handler.py
@@ -63,7 +63,7 @@ class PostHandler(BaseHandler):
 
         is_admin = user.has_permission("remove_posts", post.institution.urlsafe())
         is_author = user.has_permission("remove_post", key)
-
+        
         Utils._assert(not is_admin and not is_author,
                       "The user can not remove this post", NotAuthorizedException)
 

--- a/frontend/notification/notificationDirective.js
+++ b/frontend/notification/notificationDirective.js
@@ -137,6 +137,9 @@
                          key: ""
                      }
                 }
+            },
+            'DELETED_POST': {
+                icon: "clear"
             }
         };
 

--- a/frontend/notification/notificationService.js
+++ b/frontend/notification/notificationService.js
@@ -38,7 +38,8 @@
             'REJECT_INVITE_INSTITUTION': messageCreator('Rejeitou o seu convite para ser administrador', NO_INST),
             'ACCEPT_INVITE_INSTITUTION': messageCreator('Aceitou o seu convite para ser administrador', NO_INST),
             'DELETE_MEMBER': messageCreator('Removeu você de ', SINGLE_INST),
-            'ACCEPTED_LINK': messageCreator('Aceitou sua solicitação de vínculo com ', SINGLE_INST)
+            'ACCEPTED_LINK': messageCreator('Aceitou sua solicitação de vínculo com ', SINGLE_INST),
+            'DELETED_POST': messageCreator('Deletou o seu post', NO_INST)
         };
 
         var POST_NOTIFICATION = 'POST';

--- a/frontend/notification/notificationService.js
+++ b/frontend/notification/notificationService.js
@@ -39,7 +39,7 @@
             'ACCEPT_INVITE_INSTITUTION': messageCreator('Aceitou o seu convite para ser administrador', NO_INST),
             'DELETE_MEMBER': messageCreator('Removeu você de ', SINGLE_INST),
             'ACCEPTED_LINK': messageCreator('Aceitou sua solicitação de vínculo com ', SINGLE_INST),
-            'DELETED_POST': messageCreator('Deletou o seu post', NO_INST)
+            'DELETED_POST': messageCreator('Deletou o seu post por ', SINGLE_INST)
         };
 
         var POST_NOTIFICATION = 'POST';

--- a/frontend/notification/notificationService.js
+++ b/frontend/notification/notificationService.js
@@ -39,7 +39,7 @@
             'ACCEPT_INVITE_INSTITUTION': messageCreator('Aceitou o seu convite para ser administrador', NO_INST),
             'DELETE_MEMBER': messageCreator('Removeu você de ', SINGLE_INST),
             'ACCEPTED_LINK': messageCreator('Aceitou sua solicitação de vínculo com ', SINGLE_INST),
-            'DELETED_POST': messageCreator('Deletou o seu post por ', SINGLE_INST)
+            'DELETED_POST': messageCreator('Deletou o seu post em ', SINGLE_INST)
         };
 
         var POST_NOTIFICATION = 'POST';


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
Send notification when the admin delete a post from another user.
</p>

<p><b>Solution:</b>
I've called send_message_notification if the user is admin in the post_handler

![screenshot from 2018-03-01 09-59-40](https://user-images.githubusercontent.com/23387866/36846118-1c2aef62-1d38-11e8-9b12-38e8854450ce.png)


</p>

<p><b>TODO/FIXME:</b> n/a</p>
