### PR TITLE
Refact reply comment notification's message

### DIFF
--- a/backend/handlers/reply_comment_handler.py
+++ b/backend/handlers/reply_comment_handler.py
@@ -69,6 +69,7 @@ class ReplyCommentHandler(BaseHandler):
             )
 
         comment = post.get_comment(comment_id)
+        entity_type = "REPLY_COMMENT"
 
         if (comment.get('author_key') != user.key.urlsafe()):
             send_message_notification(

--- a/backend/test/reply_comment_handler_test.py
+++ b/backend/test/reply_comment_handler_test.py
@@ -104,7 +104,7 @@ class ReplyCommentHandlerTest(TestBaseHandler):
             call(
                 self.other_user.key.urlsafe(),
                 self.third_user.key.urlsafe(),
-                "COMMENT",
+                "REPLY_COMMENT",
                 self.user_post.key.urlsafe(),
                 self.institution.key
             )

--- a/frontend/notification/notificationDirective.js
+++ b/frontend/notification/notificationDirective.js
@@ -137,7 +137,11 @@
                          key: ""
                      }
                 }
-            }
+            },
+            "REPLY_COMMENT": {
+                icon: "comment",
+                state: "app.post"
+            },
         };
 
         notificationCtrl.markAsRead = function markAsRead(notification) {

--- a/frontend/notification/notificationService.js
+++ b/frontend/notification/notificationService.js
@@ -38,7 +38,8 @@
             'REJECT_INVITE_INSTITUTION': messageCreator('Rejeitou o seu convite para ser administrador', NO_INST),
             'ACCEPT_INVITE_INSTITUTION': messageCreator('Aceitou o seu convite para ser administrador', NO_INST),
             'DELETE_MEMBER': messageCreator('Removeu você de ', SINGLE_INST),
-            'ACCEPTED_LINK': messageCreator('Aceitou sua solicitação de vínculo com ', SINGLE_INST)
+            'ACCEPTED_LINK': messageCreator('Aceitou sua solicitação de vínculo com ', SINGLE_INST),
+            'REPLY_COMMENT': messageCreator('Respondeu um comentário seu')
         };
 
         var POST_NOTIFICATION = 'POST';


### PR DESCRIPTION
<p><b>Feature/Bug description:</b>
To differ reply comment from comment notification's message.
</p>

<p><b>Solution:</b>
Change the entity_type in the notification and handle this type in the notification's directive.

![screenshot from 2018-02-28 15-27-18](https://user-images.githubusercontent.com/23387866/36805607-9c72284e-1c9c-11e8-91e3-93ba5edabe9e.png)

</p>

<p><b>TODO/FIXME:</b> n/a</p>
