### PR TITLE
Fix post notification with unknown key

### DIFF
--- a/backend/worker.py
+++ b/backend/worker.py
@@ -151,9 +151,10 @@ class NotifyFollowersHandler(BaseHandler):
         """Send notifications to institution followers."""
         sender_key = self.request.get('sender_key')
         entity_type = self.request.get('entity_type')
-        inst_key = self.request.get('institution_key')
+        entity_key = self.request.get('entity_key')
         current_institution = ndb.Key(urlsafe=self.request.get('current_institution'))
         
+        inst_key = self.request.get('institution_key')
         institution = ndb.Key(urlsafe=inst_key).get()
 
         for follower_key in institution.followers:
@@ -164,7 +165,7 @@ class NotifyFollowersHandler(BaseHandler):
                     follower.key.urlsafe(),
                     sender_key,
                     entity_type,
-                    inst_key,
+                    entity_key,
                     current_institution
                 )
 


### PR DESCRIPTION
**Feature/Bug description:** When a post is created, a notification is sent to all the post's institution's followers. However, the institution key was being used as entity_key, instead of the post key. So, the follower was unable to access the post page via its notification. 

**Solution:**  The variable inst_key was replaced by entity_key on send_message_notification call, at NotifyFollowersHandler

**TODO/FIXME:** n/a

![post_not](https://user-images.githubusercontent.com/13683704/36979413-2e84c99a-2066-11e8-92ab-4d28b60633b5.gif)
