### PR TITLE
Fix button name in edit institution form

### DIFF
--- a/frontend/institution/submit_form.html
+++ b/frontend/institution/submit_form.html
@@ -12,7 +12,7 @@
                         ng-model="configInstCtrl.file" ngf-pattern="'image/*'"
                         ngf-accept="'image/*'" ngf-max-size="5MB" class="md-raised"
                         ngf-select="configInstCtrl.cropImage(configInstCtrl.file, $event)">
-                        <b>Adicionar imagem</b>
+                        <b>Trocar imagem</b>
                     </md-button>
                 </div>
             </div>


### PR DESCRIPTION
**Feature/Bug description:** 
Change "Adicionar imagem" to "Trocar imagem" in edit institution form.

**Solution:** 

![screenshot from 2018-03-05 14-19-05](https://user-images.githubusercontent.com/23387866/36989427-794876d8-2080-11e8-8835-457a4ef7eb28.png)


**TODO/FIXME:** n/a