### PR TITLE
Fix sender_name in invite member

### DIFF
--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -62,8 +62,8 @@
             manageMemberCtrl.invite.institution_key = currentInstitutionKey;
             manageMemberCtrl.invite.admin_key = manageMemberCtrl.user.key;
             manageMemberCtrl.invite.type_of_invite = 'USER';
+            manageMemberCtrl.invite.sender_name = manageMemberCtrl.user.name;
             invite = new Invite(manageMemberCtrl.invite);
-            invite.sender_name = manageMemberCtrl.user.name;
 
             var emails = getEmails(loadedEmails);
             var requestBody = {


### PR DESCRIPTION
**Feature/Bug description:**
The "Convidado por" field was appearing only when the page was refreshed

![screenshot from 2018-03-05 15-09-57](https://user-images.githubusercontent.com/23387866/36991734-5e8ba426-2087-11e8-9725-dfa6821e26aa.png)


**Solution:** 
I've added the sender_name into the invite before its creation

![screenshot from 2018-03-05 15-06-38](https://user-images.githubusercontent.com/23387866/36991640-17bd9a22-2087-11e8-8f1f-c891253b8294.png)


**TODO/FIXME:** n/a