### PR TITLE
Fix invite status verification

### DIFF
--- a/backend/handlers/institution_request_handler.py
+++ b/backend/handlers/institution_request_handler.py
@@ -8,6 +8,8 @@ from utils import login_required
 from utils import json_response
 from handlers.base_handler import BaseHandler
 from google.appengine.ext import ndb
+from utils import Utils
+from custom_exceptions.notAuthorizedException import NotAuthorizedException
 
 
 def check_permission(user, operation, institution_key):
@@ -36,6 +38,11 @@ class InstitutionRequestHandler(BaseHandler):
     def put(self, user, request_key):
         """Handler PUT Requests."""
         request = ndb.Key(urlsafe=request_key).get()
+
+        Utils._assert(request.status != 'sent',
+                      "This request has already been processed",
+                      NotAuthorizedException)
+
         check_permission(
             user,
             'put',
@@ -74,6 +81,11 @@ class InstitutionRequestHandler(BaseHandler):
         """Change request status from 'sent' to 'rejected'."""
         request_key = ndb.Key(urlsafe=request_key)
         request = request_key.get()
+
+        Utils._assert(request.status != 'sent',
+                      "This request has already been processed",
+                      NotAuthorizedException)
+
         check_permission(
             user,
             'remove',

--- a/backend/handlers/invite_handler.py
+++ b/backend/handlers/invite_handler.py
@@ -60,6 +60,11 @@ class InviteHandler(BaseHandler):
         """Change invite status from 'sent' to 'rejected'."""
         invite_key = ndb.Key(urlsafe=key)
         invite = invite_key.get()
+
+        Utils._assert(invite.status != 'sent',
+                      "This invitation has already been processed",
+                      NotAuthorizedException)
+
         invite.change_status('rejected')
         invite.put()
         invite.send_response_notification(user.current_institution, user.key, 'REJECT')
@@ -76,8 +81,8 @@ class InviteHandler(BaseHandler):
         data = self.request.body
         invite = ndb.Key(urlsafe=invite_key).get()
 
-        Utils._assert(invite.status == 'accepted', 
-            "This invitation has already been accepted", 
+        Utils._assert(invite.status != 'sent', 
+            "This invitation has already been processed", 
             NotAuthorizedException)
 
         institution_key = invite.institution_key

--- a/backend/test/institution_request_handler_test.py
+++ b/backend/test/institution_request_handler_test.py
@@ -102,7 +102,98 @@ class InstitutionRequestHandlerTest(TestBaseHandler):
             new_inst.state,
             'inactive',
             "Expected state must be equal to inactive")
+    
+    @patch('utils.verify_token', return_value={'email': 'useradmin@test.com'})
+    def test_delete_with_an_accepted_request(self, verify_token):
+        """Test delete with an accepted request."""
+        self.request.status = "accepted"
+        self.request.put()
 
+        with self.assertRaises(Exception) as raises_context:
+            self.testapp.delete(
+                '/api/requests/%s/institution'
+                % self.request.key.urlsafe()
+            )
+
+        message_exception = self.get_message_exception(
+            str(raises_context.exception))
+
+        expected_message = "Error! This request has already been processed"
+
+        self.assertEqual(
+            message_exception,
+            expected_message,
+            "Expected exception message must be equal to %s" % expected_message
+        )
+    
+    @patch('utils.verify_token', return_value={'email': 'useradmin@test.com'})
+    def test_delete_with_a_rejected_request(self, verify_token):
+        """Test delete with a rejected request."""
+        self.request.status = "rejected"
+        self.request.put()
+
+        with self.assertRaises(Exception) as raises_context:
+            self.testapp.delete(
+                '/api/requests/%s/institution'
+                % self.request.key.urlsafe()
+            )
+
+        message_exception = self.get_message_exception(
+            str(raises_context.exception))
+
+        expected_message = "Error! This request has already been processed"
+
+        self.assertEqual(
+            message_exception,
+            expected_message,
+            "Expected exception message must be equal to %s" % expected_message
+        )
+
+    @patch('utils.verify_token', return_value={'email': 'useradmin@test.com'})
+    def test_put_with_a_rejected_request(self, verify_token):
+        """Test delete with a rejected request."""
+        self.request.status = "rejected"
+        self.request.put()
+
+        with self.assertRaises(Exception) as raises_context:
+            self.testapp.put(
+                '/api/requests/%s/institution'
+                % self.request.key.urlsafe()
+            )
+
+        message_exception = self.get_message_exception(
+            str(raises_context.exception))
+
+        expected_message = "Error! This request has already been processed"
+
+        self.assertEqual(
+            message_exception,
+            expected_message,
+            "Expected exception message must be equal to %s" % expected_message
+        )
+    
+    @patch('utils.verify_token', return_value={'email': 'useradmin@test.com'})
+    def test_put_with_an_accepted_request(self, verify_token):
+        """Test delete with an accepted request."""
+        self.request.status = "accepted"
+        self.request.put()
+
+        with self.assertRaises(Exception) as raises_context:
+            self.testapp.put(
+                '/api/requests/%s/institution'
+                % self.request.key.urlsafe()
+            )
+
+        message_exception = self.get_message_exception(
+            str(raises_context.exception))
+
+        expected_message = "Error! This request has already been processed"
+
+        self.assertEqual(
+            message_exception,
+            expected_message,
+            "Expected exception message must be equal to %s" % expected_message
+        )
 
 def initModels(cls):
     """Init the models."""

--- a/backend/test/invite_handler_test.py
+++ b/backend/test/invite_handler_test.py
@@ -229,3 +229,95 @@ class InviteHandlerTest(TestBaseHandler):
             expected_message,
             "Expected exception message must be equal to %s" %expected_message
         )
+
+    @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
+    def test_patch_with_an_accepted_invite(self, verify_token):
+        """Test patch with an accepted invite."""
+        self.invite.status = "accepted"
+        self.invite.put()
+
+        with self.assertRaises(Exception) as raises_context:
+            self.testapp.patch(
+                '/api/invites/%s'
+                % self.invite.key.urlsafe()
+            )
+
+        message_exception = self.get_message_exception(
+            str(raises_context.exception))
+
+        expected_message = "Error! This invitation has already been processed"
+
+        self.assertEqual(
+            message_exception,
+            expected_message,
+            "Expected exception message must be equal to %s" % expected_message
+        )
+    
+    @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
+    def test_patch_with_a_rejected_invite(self, verify_token):
+        """Test patch with a rejected invite."""
+        self.invite.status = "rejected"
+        self.invite.put()
+
+        with self.assertRaises(Exception) as raises_context:
+            self.testapp.patch(
+                '/api/invites/%s'
+                % self.invite.key.urlsafe()
+            )
+
+        message_exception = self.get_message_exception(
+            str(raises_context.exception))
+
+        expected_message = "Error! This invitation has already been processed"
+
+        self.assertEqual(
+            message_exception,
+            expected_message,
+            "Expected exception message must be equal to %s" % expected_message
+        )
+    
+    @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
+    def test_delete_with_a_rejected_invite(self, verify_token):
+        """Test delete with a rejected invite."""
+        self.invite.status = "rejected"
+        self.invite.put()
+
+        with self.assertRaises(Exception) as raises_context:
+            self.testapp.delete(
+                '/api/invites/%s'
+                % self.invite.key.urlsafe()
+            )
+
+        message_exception = self.get_message_exception(
+            str(raises_context.exception))
+
+        expected_message = "Error! This invitation has already been processed"
+
+        self.assertEqual(
+            message_exception,
+            expected_message,
+            "Expected exception message must be equal to %s" % expected_message
+        )
+    
+    @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
+    def test_delete_with_an_accepted_invite(self, verify_token):
+        """Test delete with an accepted invite."""
+        self.invite.status = "accepted"
+        self.invite.put()
+
+        with self.assertRaises(Exception) as raises_context:
+            self.testapp.delete(
+                '/api/invites/%s'
+                % self.invite.key.urlsafe()
+            )
+
+        message_exception = self.get_message_exception(
+            str(raises_context.exception))
+
+        expected_message = "Error! This invitation has already been processed"
+
+        self.assertEqual(
+            message_exception,
+            expected_message,
+            "Expected exception message must be equal to %s" % expected_message
+        )


### PR DESCRIPTION
**Feature/Bug description:**
In some handlers the invite's status verification was wrong. It was checking if the invite wasn't accepted but It should check if it was sent.
**Solution:**
Change the verification and add it when it was missing.

**TODO/FIXME:** n/a