### PR TITLE
Fix query handler to find only active institutions

### DIFF
--- a/backend/handlers/institution_collection_handler.py
+++ b/backend/handlers/institution_collection_handler.py
@@ -23,6 +23,7 @@ class InstitutionCollectionHandler(BaseHandler):
         """Get all institutions."""
 
         INSTITUTION_ATTRIBUTES = ['name', 'key', 'acronym', 'address', 'photo_url', 'description']
+        ACTIVE_STATE = "active"
 
         page = to_int(
             self.request.get('page', Utils.DEFAULT_PAGINATION_OFFSET),
@@ -33,7 +34,7 @@ class InstitutionCollectionHandler(BaseHandler):
             QueryException,
             "Query param limit must be an integer")
 
-        queryInstitutions = Institution.query()
+        queryInstitutions = Institution.query(Institution.state == ACTIVE_STATE)
 
         queryInstitutions, more = offset_pagination(
             page,

--- a/backend/test/institution_collection_handler_test.py
+++ b/backend/test/institution_collection_handler_test.py
@@ -31,8 +31,14 @@ class InstitutionCollectionHandlerTest(TestBaseHandler):
         user = mocks.create_user('user@example.com')
         # new Institution FIRST INST
         first_inst = mocks.create_institution('FIRST INST')
-        # new Institution SECOND INST
+        first_inst.state = "active"
+        first_inst.put()
+        # new Institution SECOND INST with pending state default 
         second_inst = mocks.create_institution('SECOND INST')
+        # new Institution THIRD INST
+        third_inst = mocks.create_institution('THIRD INST')
+        third_inst.state = "active"
+        third_inst.put()
 
         # Call the get method
         all_institutions = self.testapp.get("/api/institutions?page=0&&limit=2").json
@@ -43,5 +49,5 @@ class InstitutionCollectionHandlerTest(TestBaseHandler):
         self.assertEqual(all_institutions['institutions'][0]['name'], first_inst.name,
                          "The name of institituion should be equal to the first_inst name")
 
-        self.assertEqual(all_institutions['institutions'][1]['name'], second_inst.name,
-                         "The name of institution should be equal to the second_inst name")
+        self.assertEqual(all_institutions['institutions'][1]['name'], third_inst.name,
+                         "The name of institution should be equal to the third_inst name")


### PR DESCRIPTION
**Feature/Bug description:** The GET of Institution Collection Handler, has a query to get all institutions in datastore, including the stubs.

**Solution:** Change query to find only active institutions.

**TODO/FIXME:** n/a