### PR TITLE
Fix post layout in small screens

### DIFF
--- a/frontend/post/post_details.html
+++ b/frontend/post/post_details.html
@@ -19,22 +19,28 @@
         <img ng-src="{{ postDetailsCtrl.post.institution_image }}" role="button" class="md-user-avatar img-post-shadow"/>
       </a>
     </md-card-avatar>
-    <md-card-header-text>
-      <div>
-        <a href class="md-title hyperlink" ng-click="postDetailsCtrl.goToInstitution(postDetailsCtrl.post.institution_key)">
-          {{ postDetailsCtrl.post.institution_name }}
-        </a>
-      </div>
-      <span layout="row" class="md-subhead">
-        por {{ postDetailsCtrl.post.author }} <b class="xs-bullet">&bull;</b>
-        {{ postDetailsCtrl.post.publication_date | amUtc | amLocal | amCalendar:referenceTime:formats }}
-        <md-button ng-if="postDetailsCtrl.showButtonEdit()" class="sm-icon-button xs-icon-button xs-edit-icon-justify"
-        ng-click="postDetailsCtrl.editPost()" md-colors="{background: 'light-green'}"
-        style="margin-top: 4px; margin-left: 4px;">
-          <md-icon>edit</md-icon>
-        </md-button>
-      </span>
-    </md-card-header-text>
+    <md-card-title style="padding: 0">
+      <md-card-title-text>
+        <div>
+          <a style="font-size: 14px" href class="md-title hyperlink" ng-click="postDetailsCtrl.goToInstitution(postDetailsCtrl.post.institution_key)">
+            {{ postDetailsCtrl.post.institution_name }}
+          </a>
+        </div>
+        <span layout="row" layout-xs="column" class="md-subhead" style="padding: 0;" md-colors="{color: 'grey-600'}">
+          <p style="margin: 0">
+            por {{ postDetailsCtrl.post.author }} <b class="xs-bullet">&bull;</b>
+          </p>
+          <p style="margin: 0">
+            {{ postDetailsCtrl.post.publication_date | amUtc | amLocal | amCalendar:referenceTime:formats }}
+            <md-button ng-if="postDetailsCtrl.showButtonEdit()" class="sm-icon-button xs-icon-button xs-edit-icon-justify"
+            ng-click="postDetailsCtrl.editPost()" md-colors="{background: 'light-green'}"
+            style="margin-top: 4px; margin-left: 4px;">
+              <md-icon>edit</md-icon>
+            </md-button>
+          </p>
+        </span>
+      </md-card-title-text>
+    </md-card-title>
     <md-menu md-offset="-200 45">
       <md-button class="md-icon-button" style="margin-right: -20px; margin-top: -15px" ng-click="$mdMenu.open(ev)">
         <md-icon>more_vert</md-icon>
@@ -100,7 +106,7 @@
   <md-card md-colors="{background: 'default-grey-100'}" ng-if="postDetailsCtrl.showSharedPost()">
     <md-card-header>
       <md-card-avatar>
-        <img ng-src="{{ postDetailsCtrl.post.shared_post.institution_image }}" class="md-card-image"/>
+        <img ng-src="{{ postDetailsCtrl.post.shared_post.institution_image }}" class="md-user-avatar img-post-shadow"/>
       </md-card-avatar>
       <md-card-header-text>
         <a href class="md-title hyperlink" ng-click="postDetailsCtrl.goToInstitution(postDetailsCtrl.post.shared_post.institution_key)">

--- a/frontend/styles/custom.css
+++ b/frontend/styles/custom.css
@@ -906,6 +906,8 @@ md-radio-button.md-default-theme.md-checked .md-off, md-radio-button.md-checked 
 }
 
 .img-post-shadow {
+    height: 40px;
+    width:40px;
     box-shadow:0 0 12px #9E9E9E;
 }
 


### PR DESCRIPTION
**Feature/Bug description:** In small displays, the name of the institution and the author were superimposed.

**Solution:** Changed the directive to card-title and it is not overwritten.

**TODO/FIXME:** n/a

![screenshot from 2018-03-06 13-41-26](https://user-images.githubusercontent.com/18709274/37045961-f2832e56-2145-11e8-8d55-9a6765839bcb.png)

![screenshot from 2018-03-06 14-03-00](https://user-images.githubusercontent.com/18709274/37046449-27fc413e-2147-11e8-9aa3-bb8d361f6a84.png)
