### PR TITLE
Fix patch of institution

### DIFF
--- a/frontend/institution/configInstDirective.js
+++ b/frontend/institution/configInstDirective.js
@@ -401,9 +401,9 @@
                 configInstCtrl.newInstitution = response.data;
                 configInstCtrl.suggestedName = configInstCtrl.newInstitution.name;
                 currentPortfoliourl = configInstCtrl.newInstitution.portfolio_url;
+                observer = jsonpatch.observe(configInstCtrl.newInstitution);
                 loadAddress(); 
                 setDefaultPhotoUrl();
-                observer = jsonpatch.observe(configInstCtrl.newInstitution);
                 configInstCtrl.loading = false;
             }, function error(response) {
                 MessageService.showToast(response.data.msg);


### PR DESCRIPTION
**Feature/Bug description:** In the creation or edition of an institution the property "country" is not captured by the observer.

**Solution:** Initialize observer before loading the address of the institution.

**TODO/FIXME:** n/a