### PR TITLE
Fix border of admin photo

### DIFF
--- a/frontend/institution/members.html
+++ b/frontend/institution/members.html
@@ -18,7 +18,8 @@
 	            <h3>ADMINISTRADOR</h3>
 	            <div layout="row" style="margin-top: 2%; margin-bottom: 5%" 
 	                md-colors="{background: 'grey-300'}" ng-click="membersCtrl.showUserProfile(membersCtrl.institution.admin.key, $event)">  
-	                <img title="{{membersCtrl.institution.admin.name}}" ng-src="{{membersCtrl.institution.admin.photo_url}}" class="md-avatar" style="width: 60px; height: 60px; margin-right: 2%"/>
+					<img title="{{membersCtrl.institution.admin.name}}" ng-src="{{membersCtrl.institution.admin.photo_url}}" class="md-avatar"
+					style="width: 60px; height: 60px; margin-right: 2%; border-radius: 50%;"/>
 	                <div layout="column" layout-align="center" 
 	                	ng-click="membersCtrl.showUserProfile(membersCtrl.institution.admin.key, $event)">
 	                    <b>{{ membersCtrl.institution.admin.name }}</b>


### PR DESCRIPTION
**Feature/Bug description:** The border of admin photo, in section "membros" in institution page, is different from the pattern to photos of the CIS.


![screenshot from 2018-03-08 11-09-58](https://user-images.githubusercontent.com/20300259/37155370-9406617c-22c1-11e8-9447-c63f00854493.png)

**Solution:** Adding border-radius in admin photo.

![screenshot from 2018-03-08 11-10-44](https://user-images.githubusercontent.com/20300259/37155373-997c8852-22c1-11e8-9e96-1f1b997d8924.png)



**TODO/FIXME:** n/a