### PR TITLE
Fix word break of post title

### DIFF
--- a/frontend/post/postDetailsDirective.js
+++ b/frontend/post/postDetailsDirective.js
@@ -257,7 +257,7 @@
         };
 
         postDetailsCtrl.getResponsiveTitleClass = function getResponsiveTitleClass() {
-            return Utils.isBiggerToScreen(postDetailsCtrl.post.title) ? 'break' : 'no-break';
+            return Utils.isLargerThanTheScreen(postDetailsCtrl.post.title) ? 'break' : 'no-break';
         };
 
         function getOriginalPost(post){

--- a/frontend/post/postDetailsDirective.js
+++ b/frontend/post/postDetailsDirective.js
@@ -256,6 +256,10 @@
             }
         };
 
+        postDetailsCtrl.getResponsiveTitleClass = function getResponsiveTitleClass() {
+            return Utils.isBiggerToScreen(postDetailsCtrl.post.title) ? 'break' : 'no-break';
+        };
+
         function getOriginalPost(post){
             if(post.shared_post){
                 return post.shared_post;

--- a/frontend/post/post_details.html
+++ b/frontend/post/post_details.html
@@ -165,7 +165,7 @@
   <md-card-title ng-if="postDetailsCtrl.isShowTitle(postDetailsCtrl.post)">
     <md-card-title-text>
       <a href class="md-title hyperlink" ng-click="postDetailsCtrl.goToPost(postDetailsCtrl.post)">
-        <span class="md-headline break">{{postDetailsCtrl.post.title}}</span>
+        <span class="md-headline" ng-class="postDetailsCtrl.getResponsiveTitleClass()">{{postDetailsCtrl.post.title}}</span>
       </a>
     </md-card-title-text>
   </md-card-title>

--- a/frontend/post/post_details.html
+++ b/frontend/post/post_details.html
@@ -164,8 +164,9 @@
   </pdf-view>
   <md-card-title ng-if="postDetailsCtrl.isShowTitle(postDetailsCtrl.post)">
     <md-card-title-text>
-      <a href class="md-title hyperlink" ng-click="postDetailsCtrl.goToPost(postDetailsCtrl.post)">
-        <span class="md-headline" ng-class="postDetailsCtrl.getResponsiveTitleClass()">{{postDetailsCtrl.post.title}}</span>
+      <a href class="md-title hyperlink" ng-click="postDetailsCtrl.goToPost(postDetailsCtrl.post)"
+      ng-class="postDetailsCtrl.getResponsiveTitleClass()">
+        <span class="md-headline">{{postDetailsCtrl.post.title}}</span>
       </a>
     </md-card-title-text>
   </md-card-title>

--- a/frontend/styles/custom.css
+++ b/frontend/styles/custom.css
@@ -394,6 +394,10 @@ a:active {
     word-break: break-all;
 }
 
+.no-break {
+    word-break: keep-all;
+}
+
 .align-top {
     margin-top: 13px;
 }

--- a/frontend/utils/utils.js
+++ b/frontend/utils/utils.js
@@ -122,7 +122,7 @@ var Utils = {
      * @param {string} string the string that will be analized.
      * @returns {boolean} True if string has a word bigger to the screen width proportion. False in otherwise.
      */
-    isBiggerToScreen: function isBiggerToScreen(string) {
+    isLargerThanTheScreen: function isLargerThanTheScreen(string) {
         var words = string.split(" ");
         var greatestWordLength = words
             .reduce((acumulator, word) => {
@@ -130,24 +130,26 @@ var Utils = {
             }, 0);
 
         /* The values references to the width of screen */
-        var smallScreen = 360;
+        var smallScreen = 380;
         var mediumScreen = 640;
-        var bigScreen = 840;
-        var XBigScreen = 940;
+        var largeScreen = 840;
+        var extraLargeScreen = 940;
 
         /* Max length of a word supported by screen width */
-        var maxLengthWordToSmallScreen = 21;
-        var maxLengthToMediumScreen = 42;
-        var maxLengthToBigScreen = 58;
-        var maxLengthWordToXBigScreen = 64;
-        var maxLengthWordToLargerScreen = 60;
+        var maxLengthWordToSmallScreen = 20;
+        var maxLengthToMediumScreen = 41;
+        var maxLengthToLargeScreen = 57;
+        var maxLengthWordToExtraLargeScreen = 63;
+        var maxLengthWordToGtExtraLargeScreen = 59;
 
         var screenWidth = screen.width;
 
-        return (screenWidth <= smallScreen && greatestWordLength >= maxLengthWordToSmallScreen)
-            || (screenWidth > smallScreen && screenWidth <= mediumScreen && greatestWordLength >= maxLengthToMediumScreen)
-            || (screenWidth > mediumScreen && screenWidth <= bigScreen && greatestWordLength >= maxLengthToBigScreen)
-            || (screenWidth > bigScreen && screenWidth <= XBigScreen && greatestWordLength >= maxLengthWordToXBigScreen)
-            || (greatestWordLength >= maxLengthWordToLargerScreen);
+        var supportSmallScreen = screenWidth <= smallScreen && greatestWordLength >= maxLengthWordToSmallScreen;
+        var supportMediumScreen = screenWidth > smallScreen && screenWidth <= mediumScreen && greatestWordLength >= maxLengthToMediumScreen;
+        var supportLargeScreen = screenWidth > mediumScreen && screenWidth <= largeScreen && greatestWordLength >= maxLengthToLargeScreen;
+        var supportExtraLargeScreen = screenWidth > largeScreen && screenWidth <= extraLargeScreen && greatestWordLength >= maxLengthWordToExtraLargeScreen;
+        var supportGtExtraLargeScreen = screenWidth > extraLargeScreen && greatestWordLength >= maxLengthWordToGtExtraLargeScreen
+
+        return supportSmallScreen || supportMediumScreen || supportLargeScreen || supportExtraLargeScreen || supportExtraLargeScreen || supportGtExtraLargeScreen;
     }
 };

--- a/frontend/utils/utils.js
+++ b/frontend/utils/utils.js
@@ -114,5 +114,40 @@ var Utils = {
      */
     normalizeString: function normalizeString(string) {
         return string.normalize('NFD').replace(/[\u0300-\u036f]/g, "").toLowerCase();
+    },
+
+    /**
+     * This function return a boolean to indicate if a string has a word
+     * bigger that screen width proportion.
+     * @param {string} string the string that will be analized.
+     * @returns {boolean} True if string has a word bigger to the screen width proportion. False in otherwise.
+     */
+    isBiggerToScreen: function isBiggerToScreen(string) {
+        var words = string.split(" ");
+        var greatestWordLength = words
+            .reduce((acumulator, word) => {
+                return acumulator > word.length ? acumulator : word.length;
+            }, 0);
+
+        /* The values references to the width of screen */
+        var smallScreen = 360;
+        var mediumScreen = 640;
+        var bigScreen = 840;
+        var XBigScreen = 940;
+
+        /* Max length of a word supported by screen width */
+        var maxLengthWordToSmallScreen = 21;
+        var maxLengthToMediumScreen = 42;
+        var maxLengthToBigScreen = 58;
+        var maxLengthWordToXBigScreen = 64;
+        var maxLengthWordToLargerScreen = 60;
+
+        var screenWidth = screen.width;
+
+        return (screenWidth <= smallScreen && greatestWordLength >= maxLengthWordToSmallScreen)
+            || (screenWidth > smallScreen && screenWidth <= mediumScreen && greatestWordLength >= maxLengthToMediumScreen)
+            || (screenWidth > mediumScreen && screenWidth <= bigScreen && greatestWordLength >= maxLengthToBigScreen)
+            || (screenWidth > bigScreen && screenWidth <= XBigScreen && greatestWordLength >= maxLengthWordToXBigScreen)
+            || (greatestWordLength >= maxLengthWordToLargerScreen);
     }
 };


### PR DESCRIPTION
**Feature/Bug description:** When has a long word in the title of a post the visualization looks strange.

**Solution:** Added a function in Utils to verify if any string is bigger to screen width proportion and calling the correct CSS class to the context.

**TODO/FIXME:** n/a