### PR TITLE
Fix remove institution from the user

### DIFF
--- a/frontend/auth/configProfileController.js
+++ b/frontend/auth/configProfileController.js
@@ -159,9 +159,7 @@
         function removeConection(institution_key) {
             if (_.size(configProfileCtrl.user.institutions) > 1) {
                 configProfileCtrl.user.removeInstitution(institution_key);
-                _.remove(configProfileCtrl.user.institution_profiles, function(profile) {
-                    return profile.institution_key === institution_key;
-                });
+                configProfileCtrl.user.removeProfile(institution_key);
                 AuthService.save();
             } else {
                 AuthService.logout();

--- a/frontend/auth/configProfileController.js
+++ b/frontend/auth/configProfileController.js
@@ -158,9 +158,7 @@
 
         function removeConection(institution_key) {
             if (_.size(configProfileCtrl.user.institutions) > 1) {
-                _.remove(configProfileCtrl.user.institutions, function(institution) {
-                    return institution.key === institution_key;
-                });
+                configProfileCtrl.user.removeInstitution(institution_key);
                 _.remove(configProfileCtrl.user.institution_profiles, function(profile) {
                     return profile.institution_key === institution_key;
                 });


### PR DESCRIPTION
**Feature/Bug description:** 
When the user remove an institution his current_institution wasn't changing what could create a bug.
**Solution:**
I've called removeInstitution and removeProfile in the removeConection method. Thus, the current_institution is changed once the removeInstitution method call changeInstitution().

**TODO/FIXME:** n/a