### PR TITLE
Fix confirm dialog when changes profile institution

### DIFF
--- a/frontend/auth/configProfileController.js
+++ b/frontend/auth/configProfileController.js
@@ -12,7 +12,7 @@
         var observer;
 
         configProfileCtrl.user = AuthService.getCurrentUser();
-        configProfileCtrl.newUser = _.clone(configProfileCtrl.user);
+        configProfileCtrl.newUser = _.cloneDeep(configProfileCtrl.user);
         configProfileCtrl.loading = false;
         configProfileCtrl.cpfRegex = /^\d{3}\.\d{3}\.\d{3}\-\d{2}$/;
         configProfileCtrl.photo_url = configProfileCtrl.newUser.photo_url;
@@ -134,7 +134,7 @@
                     institution: inst
                 },
                 targetEvent: ev,
-                clickOutsideToClose: true
+                clickOutsideToClose: false
             });
         };
 


### PR DESCRIPTION
**Feature/Bug description:** When a user changes any institution profile and exits the page, is show the confirm dialog.
**Solution:** Cloned user object using cloneDeep, so when changed profile in the user not changed in the new User object.

**TODO/FIXME:** n/a