### PR TITLE
Fix background image of an event when using PNG format

### DIFF
--- a/frontend/event/event_details.html
+++ b/frontend/event/event_details.html
@@ -2,7 +2,7 @@
 <div layout="column" ng-if="!eventDetailsCtrl.isDeleted(eventDetailsCtrl.event)">
   <md-card layout="column" md-colors="{background: 'default-teal-400'}">
       <img class="md-card-image" ng-if="eventDetailsCtrl.showImage"
-      ng-src="{{ eventDetailsCtrl.event.photo_url }}"/>
+      style="background-color: white;" ng-src="{{ eventDetailsCtrl.event.photo_url }}"/>
     <div layout="row" layout-xs="column">
       <md-card-content style="max-height: 150px" md-colors="{background: 'default-grey-200'}">
         <div style="max-height: 100px;" layout="column">


### PR DESCRIPTION
**Feature/Bug description:** When the event image is PNG, the background color of the image was green.
**Solution:** Set color to white.

**TODO/FIXME:** n/a

![screenshot from 2018-03-13 15-52-32](https://user-images.githubusercontent.com/18709274/37363412-a4b20d32-26d6-11e8-8ffd-7478748f6fe5.png)
