### PR TITLE
Fix inconsistency in percentage of the survey

### DIFF
--- a/frontend/post/post_details.html
+++ b/frontend/post/post_details.html
@@ -86,7 +86,7 @@
 
   <!-- SURVEY -->
   <survey-details ng-if="postDetailsCtrl.showSurvey()" post="postDetailsCtrl.post" 
-    posts="postDetailsCtrl.posts" user="postDetailsCtrl.user" isdialog="false" is-post-page="postDetailsCtrl.isPostPage"></survey-details>
+    posts="postDetailsCtrl.posts" user="postDetailsCtrl.user" isdialog="false" is-post-page="postDetailsCtrl.isPostPage" reload-post="postDetailsCtrl.reloadPost"></survey-details>
 
   <!-- BODY SHARED EVENT -->
   <div md-colors="{background: 'teal-500'}" ng-if="postDetailsCtrl.isDeletedEvent(postDetailsCtrl.post) && !postDetailsCtrl.isDeleted(postDetailsCtrl.post)"

--- a/frontend/survey/surveyDetailsDirective.js
+++ b/frontend/survey/surveyDetailsDirective.js
@@ -65,6 +65,7 @@
                 dialog.then(function() {
                     surveyCtrl.voteService().then(function () {
                         syncSharedPosts();
+                        surveyCtrl.reloadPost();
                     });
                 }, function() {
                     MessageService.showToast('Cancelado');
@@ -88,7 +89,8 @@
         * @return {undefined} - Void function returns undefined.
         */
         function syncSharedPosts() {
-            surveyCtrl.posts = surveyCtrl.posts.map(post => updateSharedPost(post, surveyCtrl.post));
+            if(surveyCtrl.posts)
+                surveyCtrl.posts = surveyCtrl.posts.map(post => updateSharedPost(post, surveyCtrl.post));
         }
 
         surveyCtrl.voteService = function(){
@@ -195,7 +197,8 @@
                 posts: '=',
                 user: '=',
                 isdialog: '=',
-                isPostPage: '='
+                isPostPage: '=',
+                reloadPost: '='
             }
         };
     });

--- a/frontend/test/specs/surveyDetailsDirectiveSpec.js
+++ b/frontend/test/specs/surveyDetailsDirectiveSpec.js
@@ -54,6 +54,7 @@
         surveyCtrl.user = user;
         surveyCtrl.post = survey;
         surveyCtrl.posts = [survey,shared_post];
+        surveyCtrl.reloadPost = () => {};
 
         httpBackend.when('GET', 'main/main.html').respond(200);
         httpBackend.when('GET', 'home/home.html').respond(200);


### PR DESCRIPTION
**Feature/Bug description:** When two or more users vote in options of a survey, the percentage displayed does not match with the real percentage counting with votes of the other(s) user(s).

**Solution:** Calling reload of the post immediately after the vote action.

**TODO/FIXME:** n/a