### PR TITLE
Fix the invite by csv of user already invited

### DIFF
--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -436,7 +436,7 @@
                 if(!_.isEmpty(emails)) {
                     selectEmailsCtrl.manageMemberCtrl.sendUserInvite(emails);
                 } else {
-                    MessageService.showToast("Todos os e-mails selecionados já foram convidados ou pertencem a algum membro da instituição.")
+                    MessageService.showToast("E-mails selecionados já foram convidados ou pertencem a algum membro da instituição.")
                 }
                 selectEmailsCtrl.closeDialog();
             } else if(selectEmailsCtrl.selectedEmails > MAX_EMAILS_QUANTITY) {

--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -413,9 +413,21 @@
             $mdDialog.cancel();
         };
 
+        function removeSentInvitations() {
+            if(selectEmailsCtrl.manageMemberCtrl.sent_invitations.length > 0) {
+                var invitedEmails = selectEmailsCtrl.manageMemberCtrl.sent_invitations.
+                    map(invite => {
+                        return invite.invitee;
+                    });
+                return selectEmailsCtrl.selectedEmails.filter(email => !invitedEmails.includes(email));
+            }
+            return selectEmailsCtrl.selectedEmails;
+        }
+
         selectEmailsCtrl.sendInvite = function sendInvite() {
             if(selectEmailsCtrl.selectedEmails.length > 0 && selectEmailsCtrl.selectedEmails.length <= MAX_EMAILS_QUANTITY) {
-                selectEmailsCtrl.manageMemberCtrl.sendUserInvite(selectEmailsCtrl.selectedEmails);
+                var emails = removeSentInvitations();
+                selectEmailsCtrl.manageMemberCtrl.sendUserInvite(emails);
                 selectEmailsCtrl.closeDialog();
             } else if(selectEmailsCtrl.selectedEmails > MAX_EMAILS_QUANTITY) {
                 MessageService.showToast("Limite máximo de " + MAX_EMAILS_QUANTITY + " e-mails selecionados excedido.");

--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -281,7 +281,7 @@
                 controller: "SelectEmailsController",
                 controllerAs: "selectEmailsCtrl",
                 locals: {
-                    emails: emails,
+                    emails: _.uniq(emails),
                     manageMemberCtrl: manageMemberCtrl
                 },
                 bindToController: true,
@@ -414,8 +414,14 @@
         };
 
         selectEmailsCtrl.removePendingAndMembersEmails = function removePendingAndMembersEmails() {
-            var invitedEmails = selectEmailsCtrl.manageMemberCtrl.sent_invitations.
-                map(invite => {
+
+            var requestedEmails = selectEmailsCtrl.manageMemberCtrl.requests
+                .map(request => {
+                    return request.institutional_email;
+                });
+
+            var invitedEmails = selectEmailsCtrl.manageMemberCtrl.sent_invitations
+                .map(invite => {
                     return invite.invitee;
                 });
 
@@ -424,8 +430,9 @@
                     return member.email;
                 }));
 
-            var emailsNotMembersAndNotInvited = selectEmailsCtrl.selectedEmails.
-                filter(email => !invitedEmails.includes(email) && !membersEmails.includes(email));
+            var emailsNotMembersAndNotInvited = selectEmailsCtrl.selectedEmails
+                .filter(email =>
+                    !invitedEmails.includes(email) && !membersEmails.includes(email) && !requestedEmails.includes(email));
 
             return emailsNotMembersAndNotInvited;
         }
@@ -436,7 +443,7 @@
                 if(!_.isEmpty(emails)) {
                     selectEmailsCtrl.manageMemberCtrl.sendUserInvite(emails);
                 } else {
-                    MessageService.showToast("E-mails selecionados já foram convidados ou pertencem a algum membro da instituição.")
+                    MessageService.showToast("E-mails selecionados já foram convidados, requisitaram ser membro ou pertencem a algum membro da instituição.");
                 }
                 selectEmailsCtrl.closeDialog();
             } else if(selectEmailsCtrl.selectedEmails > MAX_EMAILS_QUANTITY) {

--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -413,7 +413,7 @@
             $mdDialog.cancel();
         };
 
-        function removePendingAndMembersEmails() {
+        selectEmailsCtrl.removePendingAndMembersEmails = function removePendingAndMembersEmails() {
             var invitedEmails = selectEmailsCtrl.manageMemberCtrl.sent_invitations.
                 map(invite => {
                     return invite.invitee;
@@ -432,7 +432,7 @@
 
         selectEmailsCtrl.sendInvite = function sendInvite() {
             if(!_.isEmpty(selectEmailsCtrl.selectedEmails) && _.size(selectEmailsCtrl.selectedEmails) <= MAX_EMAILS_QUANTITY) {
-                var emails = removePendingAndMembersEmails();
+                var emails = selectEmailsCtrl.removePendingAndMembersEmails();
                 if(!_.isEmpty(emails)) {
                     selectEmailsCtrl.manageMemberCtrl.sendUserInvite(emails);
                 } else {

--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -413,21 +413,31 @@
             $mdDialog.cancel();
         };
 
-        function removeSentInvitations() {
-            if(!_.isEmpty(selectEmailsCtrl.manageMemberCtrl.sent_invitations)) {
-                var invitedEmails = selectEmailsCtrl.manageMemberCtrl.sent_invitations.
-                    map(invite => {
-                        return invite.invitee;
-                    });
-                return selectEmailsCtrl.selectedEmails.filter(email => !invitedEmails.includes(email));
-            }
-            return selectEmailsCtrl.selectedEmails;
+        function removePendingAndMembersEmails() {
+            var invitedEmails = selectEmailsCtrl.manageMemberCtrl.sent_invitations.
+                map(invite => {
+                    return invite.invitee;
+                });
+
+            var membersEmails = [].concat.apply([], selectEmailsCtrl.manageMemberCtrl.members
+                .map(member => {
+                    return member.email;
+                }));
+
+            var emailsNotMembersAndNotInvited = selectEmailsCtrl.selectedEmails.
+                filter(email => !invitedEmails.includes(email) && !membersEmails.includes(email));
+
+            return emailsNotMembersAndNotInvited;
         }
 
         selectEmailsCtrl.sendInvite = function sendInvite() {
-            if(selectEmailsCtrl.selectedEmails.length > 0 && selectEmailsCtrl.selectedEmails.length <= MAX_EMAILS_QUANTITY) {
-                var emails = removeSentInvitations();
-                selectEmailsCtrl.manageMemberCtrl.sendUserInvite(emails);
+            if(!_.isEmpty(selectEmailsCtrl.selectedEmails) && _.size(selectEmailsCtrl.selectedEmails) <= MAX_EMAILS_QUANTITY) {
+                var emails = removePendingAndMembersEmails();
+                if(!_.isEmpty(emails)) {
+                    selectEmailsCtrl.manageMemberCtrl.sendUserInvite(emails);
+                } else {
+                    MessageService.showToast("Todos os e-mails selecionados já foram convidados ou pertencem a algum membro da instituição.")
+                }
                 selectEmailsCtrl.closeDialog();
             } else if(selectEmailsCtrl.selectedEmails > MAX_EMAILS_QUANTITY) {
                 MessageService.showToast("Limite máximo de " + MAX_EMAILS_QUANTITY + " e-mails selecionados excedido.");

--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -414,7 +414,7 @@
         };
 
         function removeSentInvitations() {
-            if(selectEmailsCtrl.manageMemberCtrl.sent_invitations.length > 0) {
+            if(!_.isEmpty(selectEmailsCtrl.manageMemberCtrl.sent_invitations)) {
                 var invitedEmails = selectEmailsCtrl.manageMemberCtrl.sent_invitations.
                     map(invite => {
                         return invite.invitee;

--- a/frontend/test/specs/selectEmailsControllerSpec.js
+++ b/frontend/test/specs/selectEmailsControllerSpec.js
@@ -12,7 +12,8 @@
     };
 
     var emails = ["test1@example.com", "test2@example.com", "test3@example.com"];
-    var members = ["member1@example.com", "member2@example.com"];
+    var members = [{name: "Member 1", email: ["member1@example.com"]},{name: "Member 2", email: ["member2@example.com"]}];
+    var sentInvitations = [{invitee: "test4@example.com"}, {invitee: "test5@example.com"}];
 
     beforeEach(module('app'));
 
@@ -29,6 +30,7 @@
                     institutionService: InstitutionService
         });
         manageMemberCtrl.members = members;
+        manageMemberCtrl.sent_invitations = sentInvitations;
         selectEmailsCtrl = newCtrl('SelectEmailsController', {
             scope: scope,
         }, {
@@ -133,6 +135,14 @@
 
         it('Should return true if is a valid email', function() {
             expect(selectEmailsCtrl.validateEmail(emails[0])).toBeTruthy();
+        });
+    });
+
+    describe('removePendingAndMembersEmails()', function() {
+        it('Should return emails that not belongs to members or has been not invited', function() {
+            selectEmailsCtrl.selectedEmails = ["test1@example.com", "test4@example.com", "member1@example.com"];
+            var filteredEmails = selectEmailsCtrl.removePendingAndMembersEmails();
+            expect(filteredEmails).toEqual(["test1@example.com"]);
         });
     });
 }));

--- a/frontend/test/specs/selectEmailsControllerSpec.js
+++ b/frontend/test/specs/selectEmailsControllerSpec.js
@@ -14,7 +14,7 @@
     var emails = ["test1@example.com", "test2@example.com", "test3@example.com"];
     var members = [{name: "Member 1", email: ["member1@example.com"]},{name: "Member 2", email: ["member2@example.com"]}];
     var sentInvitations = [{invitee: "test4@example.com"}];
-    var requestedMembers = [{institutional_email: "test5@example.com"}]
+    var requestedMembers = [{institutional_email: "test5@example.com"}];
     beforeEach(module('app'));
 
     beforeEach(inject(function($controller, $state, $rootScope, $mdDialog, AuthService, InstitutionService, InviteService) {

--- a/frontend/test/specs/selectEmailsControllerSpec.js
+++ b/frontend/test/specs/selectEmailsControllerSpec.js
@@ -12,6 +12,7 @@
     };
 
     var emails = ["test1@example.com", "test2@example.com", "test3@example.com"];
+    var members = ["member1@example.com", "member2@example.com"];
 
     beforeEach(module('app'));
 
@@ -27,7 +28,7 @@
                     inviteService: InviteService,
                     institutionService: InstitutionService
         });
-
+        manageMemberCtrl.members = members;
         selectEmailsCtrl = newCtrl('SelectEmailsController', {
             scope: scope,
         }, {

--- a/frontend/test/specs/selectEmailsControllerSpec.js
+++ b/frontend/test/specs/selectEmailsControllerSpec.js
@@ -13,8 +13,8 @@
 
     var emails = ["test1@example.com", "test2@example.com", "test3@example.com"];
     var members = [{name: "Member 1", email: ["member1@example.com"]},{name: "Member 2", email: ["member2@example.com"]}];
-    var sentInvitations = [{invitee: "test4@example.com"}, {invitee: "test5@example.com"}];
-
+    var sentInvitations = [{invitee: "test4@example.com"}];
+    var requestedMembers = [{institutional_email: "test5@example.com"}]
     beforeEach(module('app'));
 
     beforeEach(inject(function($controller, $state, $rootScope, $mdDialog, AuthService, InstitutionService, InviteService) {
@@ -31,6 +31,7 @@
         });
         manageMemberCtrl.members = members;
         manageMemberCtrl.sent_invitations = sentInvitations;
+        manageMemberCtrl.requests = requestedMembers;
         selectEmailsCtrl = newCtrl('SelectEmailsController', {
             scope: scope,
         }, {
@@ -140,7 +141,7 @@
 
     describe('removePendingAndMembersEmails()', function() {
         it('Should return emails that not belongs to members or has been not invited', function() {
-            selectEmailsCtrl.selectedEmails = ["test1@example.com", "test4@example.com", "member1@example.com"];
+            selectEmailsCtrl.selectedEmails = ["test1@example.com", "member1@example.com", "test4@example.com", "test5@example.com"];
             var filteredEmails = selectEmailsCtrl.removePendingAndMembersEmails();
             expect(filteredEmails).toEqual(["test1@example.com"]);
         });


### PR DESCRIPTION
**Feature/Bug description:** When members are invited by csv file and at least one member already been invited, the others are not invited.

**Solution:** Filtering the final list of emails to a list that don't match with the emails of 'sent_invitations' list.

**TODO/FIXME:** n/a