### PR TITLE
Fix management members cards height

### DIFF
--- a/frontend/institution/management_members.html
+++ b/frontend/institution/management_members.html
@@ -123,7 +123,7 @@
         </div>
       </md-toolbar>
       <md-card-content ng-show="manageMemberCtrl.showInvites" 
-          ng-style="manageMemberCtrl.calculateHeight(manageMemberCtrl.sent_invitations)" ng-scrollbars>
+           style="overflow: auto; max-height: 270px;" class="custom-scrollbar">
         <md-list>
           <md-list-item class="md-2-line" ng-repeat="invite in manageMemberCtrl.sent_invitations" ng-click="null">
             <md-icon class="md-avatar-icon" style="margin-top: 2px"

--- a/frontend/institution/management_members.html
+++ b/frontend/institution/management_members.html
@@ -123,7 +123,7 @@
         </div>
       </md-toolbar>
       <md-card-content ng-show="manageMemberCtrl.showInvites" 
-           style="overflow: auto; max-height: 270px;" class="custom-scrollbar">
+           style="overflow: auto; max-height: 220px;" class="custom-scrollbar">
         <md-list>
           <md-list-item class="md-2-line" ng-repeat="invite in manageMemberCtrl.sent_invitations" ng-click="null">
             <md-icon class="md-avatar-icon" style="margin-top: 2px"
@@ -168,7 +168,7 @@
               <p>Email institucional: {{ request.institutional_email}}</p>
             </div>
             <md-icon class="md-secondary md-hue-3" title="Rejeitar" ng-click="manageMemberCtrl.rejectRequest(request, $event)">close</md-icon>
-            <md-icon class="md-secondary" title="Aceitar membro" ng-click="manageMemberCtrl.acceptRequest(request)" style="margin-left: 30%">send</md-icon>
+            <md-icon class="md-secondary" title="Aceitar membro" ng-click="manageMemberCtrl.acceptRequest(request)">send</md-icon>
           </md-list-item>
         </md-list>
       </md-card-content>

--- a/frontend/institution/management_members.html
+++ b/frontend/institution/management_members.html
@@ -157,7 +157,7 @@
         </div>
       </md-toolbar>
       <md-card-content ng-show="manageMemberCtrl.showRequests"
-          ng-style="manageMemberCtrl.calculateHeight(manageMemberCtrl.requests, 5.5)" ng-scrollbars>
+          style="overflow: auto; max-height: 270px;" class="custom-scrollbar">
         <md-list flex>
           <md-list-item ng-repeat="request in manageMemberCtrl.requests" ng-click="null" class="md-3-line">
             <md-icon class="md-avatar-icon"


### PR DESCRIPTION
**Feature/Bug description:**
The calculateHeight method could cause a very strange bug. The screen was shaking when the admin accept the last request.

**Solution:**
I've removed the calculateHeight call and the ng-scrollbar replacing them by a custom-scrollbar class with a auto overflow and a max-height property

![screenshot from 2018-03-14 14-23-50](https://user-images.githubusercontent.com/23387866/37419908-4aff608c-2794-11e8-998a-1483e7ee7e6f.png)

![screenshot from 2018-03-14 14-24-14](https://user-images.githubusercontent.com/23387866/37419919-50520300-2794-11e8-87dd-21a406b53b1f.png)


![screenshot from 2018-03-14 14-24-45](https://user-images.githubusercontent.com/23387866/37419923-52c8257e-2794-11e8-9ab8-1b2b89279ed5.png)

![screenshot from 2018-03-14 14-25-12](https://user-images.githubusercontent.com/23387866/37419927-56b1647a-2794-11e8-8582-5ae355058e8d.png)


**TODO/FIXME:** n/a