### PR TITLE
Removing calculateHeight from the system

### DIFF
--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -244,10 +244,6 @@
             return isValid;
         };
 
-        manageMemberCtrl.calculateHeight = function calculateHeight(list, itemHeight=4.5) {
-            return Utils.calculateHeight(list, itemHeight);
-        };
-
         manageMemberCtrl.resendInvite = function resendInvite(inviteKey, event) {
             var confirm = $mdDialog.confirm({ onComplete: designOptions });
             confirm

--- a/frontend/invites/inviteInstitutionController.js
+++ b/frontend/invites/inviteInstitutionController.js
@@ -26,10 +26,6 @@
             inviteInstCtrl[flagName] = !inviteInstCtrl[flagName];
         };
 
-        inviteInstCtrl.calculateHeight = function calculateHeight(list, itemHeight) {
-            return Utils.calculateHeight(list, itemHeight);
-        };
-
         inviteInstCtrl.cancelInvite = function cancelInvite() {
             inviteInstCtrl.invite = {};
         };

--- a/frontend/invites/invite_institution.html
+++ b/frontend/invites/invite_institution.html
@@ -51,7 +51,7 @@
             </div>
           </md-toolbar>
           <md-card-content ng-show="inviteInstCtrl.showInvites" 
-            ng-style="inviteInstCtrl.calculateHeight(inviteInstCtrl.sent_invitations)" ng-scrollbars>
+             style="overflow: auto; max-height: 235px;" class="custom-scrollbar">
             <md-list class="md-dense" flex>
               <md-list-item class="md-3-line" ng-click="null" ng-repeat="invite in inviteInstCtrl.sent_invitations">
                 <md-icon class="md-avatar-icon" 
@@ -86,7 +86,7 @@
             </div>
           </md-toolbar>
           <md-card-content ng-show="inviteInstCtrl.showRequests" 
-            ng-style="inviteInstCtrl.calculateHeight(inviteInstCtrl.sent_requests)" ng-scrollbars>
+             style="overflow: auto; max-height: 240px;" class="custom-scrollbar">
             <div flex >
               <md-list class="md-dense" flex>
                 <md-list-item class="md-3-line" ng-repeat="request in inviteInstCtrl.sent_requests"
@@ -122,7 +122,7 @@
             </div>
           </md-toolbar>
           <md-card-content  ng-show="inviteInstCtrl.showSentInvitations"
-            ng-style="inviteInstCtrl.calculateHeight(inviteInstCtrl.accepted_invitations)" ng-scrollbars>
+             style="overflow: auto; max-height: 235px;" class="custom-scrollbar">
             <md-list class="md-dense" flex>
               <md-list-item class="md-3-line" ng-repeat="invite in inviteInstCtrl.accepted_invitations">
                 <md-icon class="md-avatar-icon" 

--- a/frontend/test/specs/UtilsSpec.js
+++ b/frontend/test/specs/UtilsSpec.js
@@ -31,29 +31,6 @@
 	        .toEqual("Access: <a href='http://www.google.com' target='_blank'>http://www.google.com</a>");
 	    });
 	});
-
-	describe('calculateHeight()', function() {
-		it('should set the height to 20em', function() {
-			var requests = ['req01', 'req02', 'req03', 'req05', 'req06'];
-			var calculatedHeigh = Utils.calculateHeight(requests);
-			var expectedHeight = {height: '20em'};
-			expect(calculatedHeigh).toEqual(expectedHeight);
-		});
-
-		it('should set height to less than 20em', function() {
-			var requests = ['req01', 'req02', 'req03'];
-			var calculatedHeigh = Utils.calculateHeight(requests);
-			var expectedHeight = {height: '15em'};
-			expect(calculatedHeigh).toEqual(expectedHeight);
-		});
-
-		it('should set height to 30em', function() {
-			var requests = ['req01', 'req02', 'req03', 'req05', 'req06'];
-			var calculatedHeigh = Utils.calculateHeight(requests, 10, 3);
-			var expectedHeight = {height: '30em'};
-			expect(calculatedHeigh).toEqual(expectedHeight);
-		});
-	});
 }));
 
 

--- a/frontend/utils/utils.js
+++ b/frontend/utils/utils.js
@@ -60,21 +60,6 @@ var Utils = {
     generateLink : function generateLink(url){
         return window.location.host + url;
     },
-
-    /**
-     * Create an object with a calculated property height, to be used with 
-     * the directive ng-style on a html element that has a list of itens in it.
-     * @param  {array} list=[] A list of itens.
-     * @param  {number} itemHeight=5 The css estimated height of one item.
-     * @param  {number} maxItensNumber=4 The max number of itens to be shown in the element per scroll.
-     * @returns {object} The object with the property height.   
-     */
-    calculateHeight : function calculateHeight(list=[], itemHeight=5, maxItensNumber=4) {
-        var maxHeight = itemHeight * maxItensNumber + 'em';
-        var actualHeight = list.length * itemHeight + 'em';
-        var calculedHeight = list.length < maxItensNumber ? actualHeight : maxHeight;
-        return {height: calculedHeight};
-    },
     
     setScrollListener: function setScrollListener(content, callback) {
         var alreadyRequested = false;

--- a/support/auth/utils.js
+++ b/support/auth/utils.js
@@ -56,21 +56,6 @@ var Utils = {
             return string && string.length > limit ?  
                 string.substring(0, limit+1) + "..." : string;
     },
-
-    /**
-     * Create an object with a calculated property height, to be used with 
-     * the directive ng-style on a html element that has a list of itens in it.
-     * @param  {array} list=[] A list of itens.
-     * @param  {number} itemHeight=5 The css estimated height of one item.
-     * @param  {number} maxItensNumber=4 The max number of itens to be shown in the element per scroll.
-     * @returns {object} The object with the property height.   
-     */
-    calculateHeight : function calculateHeight(list=[], itemHeight=5, maxItensNumber=4) {
-        var maxHeight = itemHeight * maxItensNumber + 'em';
-        var actualHeight = list.length * itemHeight + 'em';
-        var calculedHeight = list.length < maxItensNumber ? actualHeight : maxHeight;
-        return {height: calculedHeight};
-    },
     
     setScrollListener: function setScrollListener(content, callback) {
         var alreadyRequested = false;


### PR DESCRIPTION
**Feature/Bug description:**
The calculateHeight function could make the screen shake in some situations.

**Solution:**
I've removed the function from everywhere it was used and replaced that with some css.

![screenshot from 2018-03-14 14-58-07](https://user-images.githubusercontent.com/23387866/37421480-2e48d47e-2798-11e8-8d9a-2cb857f56dc5.png)



**TODO/FIXME:** n/a