### PR TITLE
Fix edit event error

### DIFF
--- a/frontend/event/eventController.js
+++ b/frontend/event/eventController.js
@@ -168,6 +168,7 @@
                 }, function error(response) {
                     MessageService.showToast(response.data.msg);
                     $state.go("app.user.home");
+                    $mdDialog.hide(event);
                 });
             } else {
                 MessageService.showToast('Evento inválido');

--- a/frontend/event/eventController.js
+++ b/frontend/event/eventController.js
@@ -167,7 +167,6 @@
                     MessageService.showToast('Evento editado com sucesso.');
                 }, function error(response) {
                     MessageService.showToast(response.data.msg);
-                    $state.go("app.user.home");
                     $mdDialog.hide(event);
                 });
             } else {


### PR DESCRIPTION
**Feature/Bug description:**
When an error occurs in the event edition the user is sent to home but the dialog doesn't get closed.

**Solution:**
I've called $mdDialog.hide(event) in the error callback function.

**TODO/FIXME:** n/a