### PR TITLE
Fix remove account after delete an institution

### DIFF
--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -279,7 +279,7 @@ class User(ndb.Model):
     
     def remove_institution_admin(self, institution_key):
         """Remove a institution admin to user."""
-        if institution_key not in self.institutions_admin:
+        if institution_key in self.institutions_admin:
             self.institutions_admin.remove(institution_key)
             self.put()
 

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -163,6 +163,7 @@ class User(ndb.Model):
             self.institutions.remove(institution)
             self.remove_permission('publish_post', institution.urlsafe())
             self.remove_profile(institution.urlsafe())
+            self.follows.remove(institution)
             if len(self.institutions) == 0:
                 self.change_state('inactive')
             self.put()

--- a/backend/test/institution_handler_test.py
+++ b/backend/test/institution_handler_test.py
@@ -51,6 +51,7 @@ class InstitutionHandlerTest(TestBaseHandler):
         cls.first_inst.put()
         cls.user.institutions_admin = [cls.first_inst.key]
         cls.user.institutions = [cls.first_inst.key]
+        cls.user.follows = [cls.first_inst.key]
         cls.user.add_permission("update_inst", cls.first_inst.key.urlsafe())
         cls.user.add_permission("remove_inst", cls.first_inst.key.urlsafe())
         cls.user.put()
@@ -85,6 +86,7 @@ class InstitutionHandlerTest(TestBaseHandler):
         cls.third_inst = mocks.create_institution()
         cls.third_inst.members = [cls.user.key, cls.other_user.key]
         cls.other_user.add_institution(cls.third_inst.key)
+        cls.other_user.follows.append(cls.third_inst.key)
         cls.third_inst.followers = [cls.user.key, cls.other_user.key]
         cls.third_inst.admin = cls.other_user.key
         cls.third_inst.parent_institution = cls.second_inst.key
@@ -299,6 +301,7 @@ class InstitutionHandlerTest(TestBaseHandler):
         third_user = third_user.key.get()
         # add second_int to second user institutions
         second_user.institutions.append(second_inst.key)
+        second_user.follows.append(second_inst.key)
         second_user.put()
         # update headers
         self.headers['Institution-Authorization'] = second_inst.key.urlsafe()
@@ -410,6 +413,7 @@ class InstitutionHandlerTest(TestBaseHandler):
         self.third_inst.put()
         self.user.institutions.append(self.third_inst.key)
         self.user.institutions.append(self.second_inst.key)
+        self.user.follows = [self.third_inst.key, self.second_inst.key]
         self.user.institutions_admin.append(self.second_inst.key)
         self.user.add_permission("publish_post", self.third_inst.key.urlsafe())
         self.user.add_permissions(["publish_post", "remove_inst"], self.second_inst.key.urlsafe())
@@ -417,6 +421,7 @@ class InstitutionHandlerTest(TestBaseHandler):
         self.other_user.institutions_admin.append(self.third_inst.key)
         self.other_user.institutions.append(self.third_inst.key)
         self.other_user.institutions.append(self.second_inst.key)
+        self.other_user.follows = [self.third_inst.key, self.second_inst.key]
         self.other_user.add_permission("publish_post", self.third_inst.key.urlsafe())
         self.other_user.add_permission("publish_post", self.second_inst.key.urlsafe())
         self.other_user.put()
@@ -446,6 +451,7 @@ class InstitutionHandlerTest(TestBaseHandler):
         """Test delete child institution."""
         self.user.institutions_admin.append(self.second_inst.key)
         self.user.institutions.append(self.third_inst.key)
+        self.user.follows.append(self.third_inst.key)
         self.third_inst.state = "active"
         self.user.add_permissions(["publish_post", "remove_inst"], self.third_inst.key.urlsafe())
         self.user.add_permission("publish_post", self.second_inst.key.urlsafe())

--- a/backend/test/institution_member_handler_test.py
+++ b/backend/test/institution_member_handler_test.py
@@ -41,6 +41,7 @@ class InstitutionMemberHandlerTest(TestBaseHandler):
         cls.other_institution.put()
         # update user
         cls.user.institutions = [cls.institution.key, cls.other_institution.key]
+        cls.user.follows = [cls.institution.key, cls.other_institution.key]
         cls.user.institutions_admin = [cls.institution.key, cls.other_institution.key]
         cls.user.add_permission("publish_post", cls.institution.key.urlsafe())
         cls.user.add_permission("publish_post", cls.other_institution.key.urlsafe())
@@ -48,6 +49,7 @@ class InstitutionMemberHandlerTest(TestBaseHandler):
         cls.user.add_permission("remove_member", cls.other_institution.key.urlsafe())
         cls.user.put()
         cls.second_user.institutions = [cls.institution.key]
+        cls.second_user.follows = [cls.institution.key]
         cls.second_user.add_permission("publish_post", cls.institution.key.urlsafe())
         cls.second_user.put()
         # create headers
@@ -91,6 +93,7 @@ class InstitutionMemberHandlerTest(TestBaseHandler):
         # new user
         third_user = mocks.create_user()
         third_user.institutions = [self.institution.key]
+        third_user.follows = [self.institution.key]
         third_user.put()
         # update institution
         self.institution.members.append(third_user.key)

--- a/backend/test/remove_institution_handler_test.py
+++ b/backend/test/remove_institution_handler_test.py
@@ -31,9 +31,13 @@ class RemoveInstitutionHandlerTest(TestBaseHandler):
         institution.address = mocks.create_address()
         admin.institutions_admin = [institution.key]
         admin.add_institution(institution.key)
+        admin.follows = [institution.key]
         institution.members = [admin.key, common_user.key]
         institution.put()
         common_user.add_institution(institution.key)
+        common_user.follows = [institution.key]
+        admin.put()
+        common_user.put()
         self.assertTrue(institution.key in admin.institutions)
         self.assertTrue(institution.key in common_user.institutions)
         # Call the post method

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -199,7 +199,7 @@ class NotifyFollowersHandler(BaseHandler):
                     follower.key.urlsafe(),
                     sender_key,
                     entity_type,
-                    entity_key,
+                    entity_key or inst_key,
                     current_institution
                 )
 

--- a/frontend/auth/configProfileController.js
+++ b/frontend/auth/configProfileController.js
@@ -17,6 +17,8 @@
         configProfileCtrl.cpfRegex = /^\d{3}\.\d{3}\.\d{3}\-\d{2}$/;
         configProfileCtrl.photo_url = configProfileCtrl.newUser.photo_url;
         configProfileCtrl.loadingSubmission = false;
+        
+        observer = jsonpatch.observe(configProfileCtrl.user);
 
         var HAS_ONLY_ONE_INSTITUTION_MSG = "Esta é a única instituição ao qual você é vinculado." +
             " Ao remover o vínculo você não poderá mais acessar o sistema," +
@@ -201,6 +203,7 @@
 
         function deleteUser() {
             var patch = jsonpatch.generate(observer);
+            console.log(patch);
             var promise = UserService.save(patch);
             promise.then(function success() {
                 AuthService.logout();
@@ -209,10 +212,8 @@
             });
             return promise;
         }
-
+        
         (function main() {
-            observer = jsonpatch.observe(configProfileCtrl.user);
-
             if (configProfileCtrl.user.name === 'Unknown') {
                 delete configProfileCtrl.user.name;
                 delete configProfileCtrl.newUser.name;

--- a/frontend/auth/configProfileController.js
+++ b/frontend/auth/configProfileController.js
@@ -17,8 +17,6 @@
         configProfileCtrl.cpfRegex = /^\d{3}\.\d{3}\.\d{3}\-\d{2}$/;
         configProfileCtrl.photo_url = configProfileCtrl.newUser.photo_url;
         configProfileCtrl.loadingSubmission = false;
-        
-        observer = jsonpatch.observe(configProfileCtrl.user);
 
         var HAS_ONLY_ONE_INSTITUTION_MSG = "Esta é a única instituição ao qual você é vinculado." +
             " Ao remover o vínculo você não poderá mais acessar o sistema," +
@@ -202,8 +200,7 @@
         };
 
         function deleteUser() {
-            var patch = jsonpatch.generate(observer);
-            console.log(patch);
+            var patch = [{op: "replace", path: "/state", value: "inactive"}];
             var promise = UserService.save(patch);
             promise.then(function success() {
                 AuthService.logout();
@@ -214,6 +211,8 @@
         }
         
         (function main() {
+            observer = jsonpatch.observe(configProfileCtrl.user);
+
             if (configProfileCtrl.user.name === 'Unknown') {
                 delete configProfileCtrl.user.name;
                 delete configProfileCtrl.newUser.name;

--- a/frontend/test/specs/userSpec.js
+++ b/frontend/test/specs/userSpec.js
@@ -216,6 +216,24 @@
               expect(user.follows).toEqual([]);
               expect(user.institutions).toEqual([]);
           });
+
+          it('should remove the institution from user.institutions, user.follows and institutions_admin',
+            function () {
+              userData = {
+                name: 'Tiago Pereira',
+                cpf: '111.111.111-11',
+                email: 'tiago.pereira@ccc.ufcg.edu.br',
+                institutions: [inst],
+                follows: [inst],
+                invites: [inviteUser, inviteInstitution],
+                institutions_admin: ['/api/someurl/institution/' + inst.key]
+              };
+              user = createUser();
+              user.removeInstitution(inst.key);
+              expect(user.follows).toEqual([]);
+              expect(user.institutions).toEqual([]);
+              expect(user.institutions_admin).toEqual([]);
+            });
         });
 
         describe('removeProfile', function() {

--- a/frontend/user/user.js
+++ b/frontend/user/user.js
@@ -101,6 +101,16 @@ User.prototype.removeInstitution = function removeInstitution(institutionKey, re
     _.remove(this.institutions, toRemove);
     _.remove(this.follows, toRemove);
 
+    var isAdmin = _.find(this.institutions_admin, function (each) {
+        return _.includes(each, institutionKey);
+    });
+    
+    if(isAdmin) {
+        _.remove(this.institutions_admin, function(currentInstUrl) {
+            return _.includes(currentInstUrl, institutionKey);
+        });
+    }
+
     if(!_.isEmpty(this.institutions)) {
         this.changeInstitution();
     }

--- a/frontend/user/user.js
+++ b/frontend/user/user.js
@@ -100,12 +100,8 @@ User.prototype.removeInstitution = function removeInstitution(institutionKey, re
 
     _.remove(this.institutions, toRemove);
     _.remove(this.follows, toRemove);
-
-    var isAdmin = _.find(this.institutions_admin, function (each) {
-        return _.includes(each, institutionKey);
-    });
     
-    if(isAdmin) {
+    if(this.isAdmin(institutionKey)) {
         _.remove(this.institutions_admin, function(currentInstUrl) {
             return _.includes(currentInstUrl, institutionKey);
         });


### PR DESCRIPTION
**Feature/Bug description:**
The frontend wasn't updating the user.institutions_admin when deleting an institution. So, when the admin removed an institution he couldn't remove his account yet, because the inst was still there. Besides, the system wasn't send 'DELETED_INSTITUTION' notification because the worker had a little bug. Lastly, the patch object in the configProfileController, I don't know why, was getting the institution's remove operation.
**Solution:**
I've removed the inst from institutions_admin in the frontend, fixed the worker and make a patch without any observer.

**TODO/FIXME:** n/a