### PR TITLE
Fix bug on institution cards height

### DIFF
--- a/frontend/institution/institution_card.html
+++ b/frontend/institution/institution_card.html
@@ -43,9 +43,11 @@
             style="background-image: url({{institutionCardCtrl.institution.cover_photo}});">
         </div>
         <!--DESCRIPTION-->
-        <spam>
-            {{institutionCardCtrl.limitString(institutionCardCtrl.institution.description, 150)}}
-        </spam>
+        <div style="height: 5em;">
+            <spam>
+                {{institutionCardCtrl.limitString(institutionCardCtrl.institution.description, 150)}}
+            </spam>
+        </div>
     </md-card-content>
     <!-- BUTTONS -->
     <md-card-actions layout="row" layout-align="end center">


### PR DESCRIPTION
**Feature/Bug description:** The institution cards were with different height depending on the size of the institution description.

**Solution:** it was set a specific height to institution description.

**TODO/FIXME:** n/a

**Cards with different height**
![screenshot from 2018-03-20 09-16-50](https://user-images.githubusercontent.com/13683704/37660864-2b7da820-2c32-11e8-8971-cbdd3fc40b78.png)

**Cards with fixed height**

**On large screen**
![screenshot from 2018-03-20 11-20-39](https://user-images.githubusercontent.com/13683704/37660939-57f5c1b2-2c32-11e8-9faf-faa6383a05c4.png)

**On extra large screen**
![screenshot from 2018-03-20 11-19-36](https://user-images.githubusercontent.com/13683704/37660948-5fc25504-2c32-11e8-812c-8860edcfd030.png)

**On mobile**
![screenshot from 2018-03-20 11-20-07](https://user-images.githubusercontent.com/13683704/37660943-5c0f1078-2c32-11e8-8ce3-33de61e51c76.png)


