### PR TITLE
Fix institution image border at floating cover

### DIFF
--- a/frontend/styles/custom.css
+++ b/frontend/styles/custom.css
@@ -1069,6 +1069,7 @@ md-input-container:not(.md-input-invalid).md-input-has-value .inputEmail {
     height: 4em;
     border-radius: 50%;
     margin-left: 3em;
+    box-shadow: 0 0 1px 0px grey;
 }
 
 .floating-cover {


### PR DESCRIPTION
**Feature/Bug description:** When the background image is white, the image border disappear.

**Solution:** It was added a shadow to the institution image at the floating cover

**TODO/FIXME:** n/a

**Without shadow**
![screenshot from 2018-03-21 11-01-12](https://user-images.githubusercontent.com/13683704/37714430-4101d2c2-2cf8-11e8-9281-4807364d9096.png)

**With shadow**
![screenshot from 2018-03-21 11-00-40](https://user-images.githubusercontent.com/13683704/37714436-44d5b3f0-2cf8-11e8-8c07-bd3c17cd9581.png)
