### PR TITLE
Fix institution image border at following institutions

### DIFF
--- a/frontend/styles/custom.css
+++ b/frontend/styles/custom.css
@@ -610,6 +610,7 @@ a:active {
     -webkit-border-radius: 50%;
     -moz-border-radius: 50%;
     border-radius: 50%;
+    box-shadow: 0 0 1px 0px grey;
 }
 
 .grey-circle {


### PR DESCRIPTION
**Feature/Bug description:** When the background image is white, the image border disappear.

**Solution:**  It was added a shadow to the institution image

**TODO/FIXME:** n/a

**Before**
![screenshot from 2018-03-21 11-37-14](https://user-images.githubusercontent.com/13683704/37716312-fc0daf56-2cfc-11e8-9cae-7236720b232c.png)

**After**
![screenshot from 2018-03-21 11-38-18](https://user-images.githubusercontent.com/13683704/37716329-04751e72-2cfd-11e8-92f5-6edf1c8a248c.png)
