### PR TITLE
Fix accepted invite when institution is inactive

### DIFF
--- a/backend/handlers/invite_handler.py
+++ b/backend/handlers/invite_handler.py
@@ -26,6 +26,10 @@ def check_if_user_is_member(user, institution):
     """Check if the user is already a member."""
     return institution.has_member(user.key) and user.is_member(institution.key)
 
+def check_if_inst_is_active(institution):
+    """Check if the institution is active."""
+    return institution.state == "active"
+
 
 class InviteHandler(BaseHandler):
     """Invite Handler."""
@@ -75,6 +79,9 @@ class InviteHandler(BaseHandler):
 
         Utils._assert(check_if_user_is_member(user, institution), 
             "The user is already a member", NotAuthorizedException)
+        
+        Utils._assert(not check_if_inst_is_active(institution), 
+            "The institution is not active.", NotAuthorizedException)
 
         invite.change_status('accepted')
 

--- a/backend/handlers/user_handler.py
+++ b/backend/handlers/user_handler.py
@@ -17,7 +17,7 @@ from handlers.base_handler import BaseHandler
 from google.appengine.ext import ndb
 
 
-def getInvites(user_email):
+def get_invites(user_email):
     """Query that return list of invites for this user."""
     invites = []
 
@@ -34,7 +34,7 @@ def define_entity(dictionary):
     return InstitutionProfile
 
 
-def makeUser(user, request):
+def make_user(user, request):
     """TODO: Move this method to User when utils.py is refactored.
 
     @author Andre L Abrantes - 20-06-2017
@@ -78,8 +78,8 @@ class UserHandler(BaseHandler):
         if not user.key:
             user = create_user(user.name, user.email)
 
-        user_json = makeUser(user, self.request)
-        user_json['invites'] = getInvites(user.email)
+        user_json = make_user(user, self.request)
+        user_json['invites'] = get_invites(user.email)
 
         self.response.write(json.dumps(user_json))
 
@@ -111,4 +111,4 @@ class UserHandler(BaseHandler):
         """Update user."""
         user.put()
 
-        self.response.write(json.dumps(makeUser(user, self.request)))
+        self.response.write(json.dumps(make_user(user, self.request)))

--- a/backend/handlers/user_handler.py
+++ b/backend/handlers/user_handler.py
@@ -22,8 +22,9 @@ def getInvites(user_email):
     invites = []
 
     queryInvites = Invite.query(Invite.invitee.IN(user_email),
-                                Invite.status == 'sent')
-    invites = [invite.make() for invite in queryInvites]
+                                Invite.status == 'sent')                              
+
+    invites = [invite.make() if invite.institution_key.get().state == "active" else '' for invite in queryInvites]
 
     return invites
 

--- a/backend/search_module/search_institution.py
+++ b/backend/search_module/search_institution.py
@@ -13,6 +13,7 @@ def institution_has_changes(fields, entity):
         if not isinstance(entity, Address):
             for field in fields:
                 if not hasattr(entity, field.name):
+                    print entity
                     entity = entity.address
 
                 if field.value != getattr(entity, field.name):

--- a/backend/test/invite_handler_test.py
+++ b/backend/test/invite_handler_test.py
@@ -42,6 +42,7 @@ class InviteHandlerTest(TestBaseHandler):
         # new Institution inst test
         cls.inst_test = mocks.create_institution()
         cls.inst_test.admin = cls.user_admin.key
+        cls.inst_test.state = "active"
         cls.inst_test.put()
         # New invite user
         cls.data = {
@@ -206,6 +207,29 @@ class InviteHandlerTest(TestBaseHandler):
         
         # assert the notification was not sent
         send_notification.assert_not_called()
+    
+    @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
+    def test_patch_with_inst_inactive(self, verify_token):
+        """Test a patch invite_user when the user is already a member."""
+        self.inst_test.state = "inactive"
+        self.inst_test.put()
+
+        with self.assertRaises(Exception) as raises_context:
+            self.testapp.patch(
+                '/api/invites/%s'
+                % self.invite.key.urlsafe()
+            )
+
+        message_exception = self.get_message_exception(
+            str(raises_context.exception))
+        
+        expected_message = "Error! The institution is not active."
+
+        self.assertEqual(
+            message_exception,
+            expected_message,
+            "Expected exception message must be equal to %s" %message_exception
+        )
     
     @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
     def test_patch_with_a_user_that_is_already_a_member(self, verify_token):

--- a/frontend/utils/messageService.js
+++ b/frontend/utils/messageService.js
@@ -18,7 +18,8 @@
             "Error! This comment has been deleted.": "Esse comentário foi removido!",
             "Error! This post has been deleted": "Esse post foi removido.",
             "Error! User already liked this comment.": "O usuário já curtiu esse comentário.",
-            "The invites are being processed.": "Os convites estão sendo processados."
+            "The invites are being processed.": "Os convites estão sendo processados.",
+            "Error! The institution is not active.": "Essa instituição não está ativa."
         };
 
         service.showToast = function showToast(message) {


### PR DESCRIPTION
**Feature/Bug description:** The user can accept the invitation that was sent by the institution that is currently inactive.

**Solution:** Added verification in handler so the user can't accept the invite and show only valid invites.

**TODO/FIXME:** n/a