### PR TITLE
Fix resend invite

### DIFF
--- a/backend/test/invite_collection_handler_test.py
+++ b/backend/test/invite_collection_handler_test.py
@@ -181,7 +181,7 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         self.assertEqual(
             answer["msg"], 'The invites are being processed.')
 
-        #The return is array of invite
+        #The entity 'invites' is an array that contains email and key of invites
         invite = answer['invites'][0]
         self.assertEqual(invite['email'], 'ana@gmail.com')
         self.assertTrue(invite['key'])

--- a/backend/test/invite_collection_handler_test.py
+++ b/backend/test/invite_collection_handler_test.py
@@ -177,9 +177,14 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         # Retrieve the entities
         answer = json.loads(answer._app_iter[0])
         enqueue_task.assert_called()
+        
+        self.assertEqual(
+            answer["msg"], 'The invites are being processed.')
 
-        self.assertTrue(
-            answer == {'msg': 'The invites are being processed.'})
+        #The return is array of invite
+        invite = answer['invites'][0]
+        self.assertEqual(invite['email'], 'ana@gmail.com')
+        self.assertTrue(invite['key'])
 
     @patch('handlers.invite_collection_handler.enqueue_task')
     @patch('utils.verify_token', return_value=ADMIN)
@@ -202,8 +207,13 @@ class InviteCollectionHandlerTest(TestBaseHandler):
             headers={'institution-authorization': institution.key.urlsafe()})
         answer = json.loads(answer._app_iter[0])
 
-        self.assertTrue(
-            answer == {'msg': 'The invites are being processed.'})
+        self.assertEqual(
+            answer["msg"], 'The invites are being processed.')
+        
+        invite = answer['invites'][0]
+        self.assertEqual(invite['email'], 'otheruser@ccc.ufcg.edu.br')
+        self.assertTrue(invite['key'])
+
         enqueue_task.assert_called()
 
     @patch.object(Invite, 'send_invite')
@@ -253,6 +263,11 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         # Retrieve the entities
         answer = json.loads(answer._app_iter[0])
 
-        self.assertTrue(
-            answer == {'msg': 'The invites are being processed.'})
+        self.assertEqual(
+            answer["msg"], 'The invites are being processed.')
+
+        invite = answer['invites'][0]
+        self.assertEqual(invite['email'], 'ana@gmail.com')
+        self.assertTrue(invite['key'])
+        
         enqueue_task.assert_called()

--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -100,7 +100,7 @@
                 manageMemberCtrl.isLoadingInvite = true;
                 var promise = InviteService.sendInvite(requestBody);
                 promise.then(function success(response) {
-                    refreshSentInvitations(requestBody.emails);
+                    refreshSentInvitations(requestBody.emails, response.data.invites);
                     manageMemberCtrl.clearInvite(); 
                     manageMemberCtrl.showInvites = true; 
                     manageMemberCtrl.showSendInvite = false;
@@ -114,10 +114,11 @@
             }
         };
 
-        function refreshSentInvitations(emails) {
+        function refreshSentInvitations(emails, invites) {
             var inviteToAdd = new Invite(manageMemberCtrl.invite);
             _.each(emails, function(email) {
                 inviteToAdd.invitee = email;
+                inviteToAdd.key = invites.reduce(invite => invite.email === email).key;
                 manageMemberCtrl.sent_invitations.push(_.clone(inviteToAdd));
             });
         }

--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -118,7 +118,7 @@
             var inviteToAdd = new Invite(manageMemberCtrl.invite);
             _.each(emails, function(email) {
                 inviteToAdd.invitee = email;
-                inviteToAdd.key = invites.reduce(invite => invite.email === email).key;
+                inviteToAdd.key = invites.reduce((acum, invite) => (invite.email === email) ? invite.key : acum, "");
                 manageMemberCtrl.sent_invitations.push(_.clone(inviteToAdd));
             });
         }

--- a/frontend/test/specs/managementMembersControllerSpec.js
+++ b/frontend/test/specs/managementMembersControllerSpec.js
@@ -138,7 +138,11 @@
                     return {
                         then: function(callback) {
                             return callback(
-                                { data: { 'msg': 'Os convites estão sendo processados.' }}
+                                { data: { 
+                                          'msg': 'Os convites estão sendo processados.'.clone,
+                                          'invites': [{ 'email': "teste@gmail.com", 'key': '123' }]
+                                        }
+                                }
                             );
                         }
                     };


### PR DESCRIPTION
**Feature/Bug description:** When the user sends an invitation and then clicks to resend it, it is not possible because the invitation does not yet have the key.

**Solution:** When the invitations are made the post has returned an array that contains key and email objects

**TODO/FIXME:** n/a