### PR TITLE
Fix remove institution in configProfile

### DIFF
--- a/frontend/auth/config_profile.html
+++ b/frontend/auth/config_profile.html
@@ -63,7 +63,7 @@
           <md-card-content >
               <md-list class="md-dense" flex>
                   <md-subheader class="md-no-sticky">Seus vínculos institucionais:</md-subheader>
-                  <md-list-item class="md-3-line" ng-repeat="institution in configProfileCtrl.newUser.institutions track by institution.key">
+                  <md-list-item class="md-3-line" ng-repeat="institution in configProfileCtrl.user.institutions track by institution.key">
                     <img style="border-radius: 50%; " ng-src="{{ institution.photo_url }}" width="50px" height="50px" />
                     <div style="margin-left: 10px; margin-top: 9px;" class="md-list-item-text" layout="column">
                       <a href class="hyperlink" target="_blank" ng-click="configProfileCtrl.goToInstitution(institution.key)">


### PR DESCRIPTION
**Feature/Bug description:**
The view wasn't refreshing when the user deleted an institution in his profile's configuration.

**Solution:**
I've changed the ng-repeat to iterate for user.institutions instead of newUser.institutions once only the user was modified when the operation was done.

**TODO/FIXME:** n/a