### PR TITLE
Fix event's end_time when the start_time is not defined

### DIFF
--- a/frontend/event/event_dialog.html
+++ b/frontend/event/event_dialog.html
@@ -76,7 +76,12 @@
                   <md-input-container style="margin: 0" flex="45">
                       <input mdc-datetime-picker="" ng-change="controller.changeDate('endTime')" date="true" time="true" type="text"today-text="Hoje"
                       placeholder="Data final" class=" md-input" format="DD-MM-YYYY HH:mm" max-date="null"
-                      ng-model="controller.event.end_time" cancel-text="Cancelar" min-date="controller.start_time" required>
+                      ng-model="controller.event.end_time" cancel-text="Cancelar" min-date="controller.start_time" ng-disabled="!controller.event.start_time" required>
+                      <div ng-messages>
+                        <div ng-show="!controller.event.start_time" style="opacity: 0.9; margin-top: 2px; font-size: 0.8em;">
+                          Primeiro defina a data inicial
+                        </div>
+                      </div>
                   </md-input-container>
               </div>
               <md-input-container style="margin: 0">


### PR DESCRIPTION
**Feature/Bug description:**
When the user selected the end_time before the start_time, the last one couldn't be defined later.

**Solution:**
I've disabled the end_time when the start_time is not defined.

![screenshot from 2018-03-26 16-20-45](https://user-images.githubusercontent.com/23387866/37928121-2ef36780-3112-11e8-9304-1bfb3f6fdfb6.png)

![screenshot from 2018-03-26 16-21-02](https://user-images.githubusercontent.com/23387866/37928131-33217220-3112-11e8-80a2-7619a299ffcf.png)


**TODO/FIXME:** n/a