### PR TITLE
Hide manage admins tab

### DIFF
--- a/frontend/institution/management_members.html
+++ b/frontend/institution/management_members.html
@@ -61,7 +61,7 @@
       </md-card-content>
     </md-card>
     <!-- MANAGE ADMINISTRATORS -->
-    <md-card>
+    <!-- <md-card>
       <md-toolbar md-colors="{background: 'teal-500'}" layout="row"
         class="clickable-no-hover" ng-click="manageMemberCtrl.toggleElement('showAdministrator')">
         <div class="md-toolbar-tools" flex layout="row" layout-align="center center">
@@ -127,7 +127,7 @@
           TRANSFERIR
         </md-button>
       </md-card-actions>
-    </md-card>
+    </md-card> -->
     <!-- MANAGE MEMBERS -->
     <md-card>
       <md-toolbar md-colors="{background: 'teal-500'}" layout="row" 

--- a/frontend/institution/management_members.html
+++ b/frontend/institution/management_members.html
@@ -61,7 +61,7 @@
       </md-card-content>
     </md-card>
     <!-- MANAGE ADMINISTRATORS -->
-    <!-- <md-card>
+    <md-card ng-if="false">
       <md-toolbar md-colors="{background: 'teal-500'}" layout="row"
         class="clickable-no-hover" ng-click="manageMemberCtrl.toggleElement('showAdministrator')">
         <div class="md-toolbar-tools" flex layout="row" layout-align="center center">
@@ -127,7 +127,7 @@
           TRANSFERIR
         </md-button>
       </md-card-actions>
-    </md-card> -->
+    </md-card>
     <!-- MANAGE MEMBERS -->
     <md-card>
       <md-toolbar md-colors="{background: 'teal-500'}" layout="row" 


### PR DESCRIPTION
**Feature/Bug description:**  The template for manage admin was hidded using 'ng-if=false'.

**Solution:** ...

**TODO/FIXME:** Remove the ng-if-false after solve the bug