### PR TITLE
Fix change institution in mainCtrl

### DIFF
--- a/frontend/main/mainController.js
+++ b/frontend/main/mainController.js
@@ -52,6 +52,7 @@
         };
 
         mainCtrl.changeInstitution = function changeInstitution(profile) {
+            mainCtrl.user = AuthService.getCurrentUser();
             mainCtrl.user.changeInstitution({'key': profile.institution_key});
             mainCtrl.getPendingTasks();
         };

--- a/frontend/test/specs/mainControllerSpec.js
+++ b/frontend/test/specs/mainControllerSpec.js
@@ -111,7 +111,6 @@
         });
         it('Should change active institution', function() {
             spyOn(mainCtrl.user, 'changeInstitution');
-
             var user_inst = {
                 name: 'user_inst',
                 key: 'veqw56eqw7r89',
@@ -122,15 +121,21 @@
                     'status': 'sent'
                 }]
             };
-
             user_inst.institutions = [otherInstitution, institution];
+            spyOn(mainCtrl, 'getPendingTasks');
+            spyOn(authService, 'getCurrentUser').and.callFake(function () {
+                return new User(user_inst);
+            });
+            
             mainCtrl.user = new User(user_inst);
-
+    
             expect(mainCtrl.user.current_institution).toBe(otherInstitution);
 
-            mainCtrl.user.changeInstitution(institution);
+            mainCtrl.changeInstitution({'institution_key': institution.key});
 
             expect(mainCtrl.user.current_institution).toBe(institution);
+            expect(authService.getCurrentUser).toHaveBeenCalled();
+            expect(mainCtrl.getPendingTasks).toHaveBeenCalled();
         });
         it('Should call state.go() in function goTo()', function(){
             spyOn(state, 'go');


### PR DESCRIPTION
**Feature/Bug description:**
When an user tried to change the institution as soon as the admin accepted his request many errors appeared in the console coming from the changeInstitution function because the user in mainCtrl wasn't updated. 

**Solution:**
I've refreshed the user before call user.changeInstitution().

**TODO/FIXME:** n/a