### PR TITLE
Fix create institution

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -90,6 +90,7 @@
   <script src="app/post/post.js"></script>
   <script src="app/invites/invite.js"></script>
   <script src="app/institution/institution.js"></script>
+  <script src="app/institution/address.js"></script>
 
   <!-- Main Application Library -->
   <script src="app/config.js"></script>

--- a/frontend/institution/address.js
+++ b/frontend/institution/address.js
@@ -1,0 +1,13 @@
+"use strict";
+
+function Address(data={}) {
+    data.city = data.city || "";
+    data.country = data.country || "";
+    data.federal_state = data.federal_state || "";
+    data.neighbourhood = data.neighbourhood || "";
+    data.street = data.street || "";
+    data.cep = data.cep || "";
+    data.number = data.number || "";
+
+    _.extend(this, data);
+}

--- a/frontend/institution/configInstDirective.js
+++ b/frontend/institution/configInstDirective.js
@@ -436,7 +436,6 @@
             if (institutionKey) {
                 loadInstitution();
             } else {
-                console.log(">>>>>>>>>>>>>>. é novo");
                 configInstCtrl.isSubmission = true;
                 configInstCtrl.newInstitution.admin = {};
                 loadAddress();

--- a/frontend/institution/configInstDirective.js
+++ b/frontend/institution/configInstDirective.js
@@ -360,12 +360,12 @@
 
         configInstCtrl.isValidAddress =  function isValidAddress(){       
             var valid = true;
-            var address = configInstCtrl.address;    
+            var address = configInstCtrl.address;
+            var fields = ['city', 'country', 'federal_state', 'neighbourhood', 'street', 'cep'];    
             if(address && address.country === "Brasil"){     
-                _.forEach(address, function(value, key) {
-                    var isNotNumber =  key !== "number";
-                    var isValid =  !value || _.isEmpty(value); 
-                    if(isNotNumber && isValid) {
+                _.forEach(fields, function(field) {
+                    let value = _.get(address, field);
+                    if(!value || _.isEmpty(value)) {
                         valid = false;        
                     }     
                 });       
@@ -436,6 +436,7 @@
             if (institutionKey) {
                 loadInstitution();
             } else {
+                console.log(">>>>>>>>>>>>>>. é novo");
                 configInstCtrl.isSubmission = true;
                 configInstCtrl.newInstitution.admin = {};
                 loadAddress();

--- a/frontend/institution/configInstDirective.js
+++ b/frontend/institution/configInstDirective.js
@@ -41,7 +41,7 @@
         }
 
         function loadAddress() {
-            configInstCtrl.newInstitution.address = configInstCtrl.newInstitution.address || {};
+            configInstCtrl.newInstitution.address = new Address(configInstCtrl.newInstitution.address);
             configInstCtrl.address = configInstCtrl.newInstitution.address;
             loadCountry();
             loadStateAndCities();
@@ -361,17 +361,14 @@
         configInstCtrl.isValidAddress =  function isValidAddress(){       
             var valid = true;
             var address = configInstCtrl.address;
-            var fields = ['city', 'country', 'federal_state', 'neighbourhood', 'street', 'cep'];    
-            if(address && address.country === "Brasil"){     
-                _.forEach(fields, function(field) {
-                    let value = _.get(address, field);
-                    if(!value || _.isEmpty(value)) {
-                        valid = false;        
-                    }     
+            if(address && address.country === "Brasil"){    
+                _.forEach(address, function(value, key) {
+                    var isNotNumber =  key !== "number";
+                    (isNotNumber && _.isEmpty(value)) ? valid = false : '';
                 });       
             }     
             return valid;     
-         }     
+         };     
 
         function isCurrentStepValid(currentStep) {
             var isValid = true;

--- a/frontend/test/specs/configInstDirectiveSpec.js
+++ b/frontend/test/specs/configInstDirectiveSpec.js
@@ -26,7 +26,7 @@ describe('Test ConfigInstDirective', function() {
             actuation_area: "government agencies",
             phone_number: "phone",
             cnpj: "cnpj",
-            address: address,
+            address: new Address(address),
             leader: "leader name",
             institutional_email: "email@institutional.com",
             description: "teste"


### PR DESCRIPTION
**Feature/Bug description:** When the inactive user requests the creation of the institution, it can create without responding all the attributes of the address, because the object "address" has only the attribute "country"

**Solution:** Added array that contains all the attributes that should be answered when the country is Brazil.

**TODO/FIXME:** n/a

![screenshot from 2018-03-28 09-54-39](https://user-images.githubusercontent.com/18709274/38032076-1ae25794-3273-11e8-8f07-d66414f561c3.png)
