### PR TITLE
Fix send invit user adm

### DIFF
--- a/backend/models/invite_user_adm.py
+++ b/backend/models/invite_user_adm.py
@@ -18,6 +18,12 @@ class InviteUserAdm(InviteUser):
             NotAuthorizedException)
         
         Utils._assert(
+            invitee == institution.admin,
+            "The invitee is already admin of this institution", 
+            NotAuthorizedException
+        )
+        
+        Utils._assert(
             self.sender_key != institution.admin, 
             "Sender is not admin of this institution!", 
             NotAuthorizedException

--- a/backend/models/invite_user_adm.py
+++ b/backend/models/invite_user_adm.py
@@ -19,7 +19,7 @@ class InviteUserAdm(InviteUser):
         
         Utils._assert(
             invitee == institution.admin,
-            "The invitee is already admin of this institution", 
+            "The invitee is already admin of this institution!", 
             NotAuthorizedException
         )
         

--- a/backend/test/model_test/invite_user_adm_test.py
+++ b/backend/test/model_test/invite_user_adm_test.py
@@ -168,6 +168,38 @@ class InviteUserAdmTest(TestBase):
             'Sender is not admin of this institution!',
             'Expected message of exception must be equal to Sender is not admin of this institution!'
         )
+    
+    def test_create_user_already_admin(self):
+        """Test create with user already admin."""
+        institution = mocks.create_institution()
+        admin = mocks.create_user()
+
+        institution.set_admin(admin.key)
+        institution.add_member(admin)
+        admin.add_institution_admin(institution.key)
+
+        institution.put()
+        admin.put()
+
+        data = {
+            "invitee": admin.email[0],
+            "institution_key": institution.key.urlsafe(),
+            "admin_key": admin.key.urlsafe(),
+            "is_request": False,
+            "sender_key": admin.key.urlsafe(),
+            "sender_name": admin.name,
+            "invitee_key": admin.key.urlsafe()
+        }
+
+        with self.assertRaises(NotAuthorizedException) as raises_context:
+            InviteUserAdm.create(data)
+        
+        message_exeption = str(raises_context.exception)
+        self.assertEqual(
+            message_exeption, 
+            'The invitee is already admin of this institution!',
+            'Expected message of exception must be equal to The invitee is already admin of this institution!'
+        )
 
     
     def test_make(self):

--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -525,24 +525,28 @@
 
         transferAdminCtrl.confirm = function confirm() {
             if (transferAdminCtrl.selectedMember) {
-                let data = {
-                    institution_key: institution.key,
-                    admin_key: institution.admin.key,
-                    type_of_invite: 'USER_ADM',
-                    sender_name: institution.admin.name,
-                    invitee_key: transferAdminCtrl.selectedMember.key,
-                    invitee: transferAdminCtrl.selectedMember.email[0]
-                };
+                if (transferAdminCtrl.selectedMember.key !== institution.admin.key) {
+                    let data = {
+                        institution_key: institution.key,
+                        admin_key: institution.admin.key,
+                        type_of_invite: 'USER_ADM',
+                        sender_name: institution.admin.name,
+                        invitee_key: transferAdminCtrl.selectedMember.key,
+                        invitee: transferAdminCtrl.selectedMember.email[0]
+                    };
 
-                let invite = new Invite(data);
+                    let invite = new Invite(data);
 
-                InviteService.sendInviteUserAdm(invite).then(function success(response) {
-                    invite.status = 'sent';
-                    $mdDialog.hide(invite);
-                    MessageService.showToast("Convite enviado com sucesso!");
-                }, function error(response) {
-                    MessageService.showToast(response.data);
-                });
+                    InviteService.sendInviteUserAdm(invite).then(function success(response) {
+                        invite.status = 'sent';
+                        $mdDialog.hide(invite);
+                        MessageService.showToast("Convite enviado com sucesso!");
+                    }, function error(response) {
+                        MessageService.showToast(response.data);
+                    });
+                } else {
+                    MessageService.showToast('Você já é administrador da instituição, selecione outro membro!');
+                }
             } else {
                 MessageService.showToast('Selecione um memebro!');
             }

--- a/frontend/institution/management_members.html
+++ b/frontend/institution/management_members.html
@@ -61,7 +61,7 @@
       </md-card-content>
     </md-card>
     <!-- MANAGE ADMINISTRATORS -->
-    <md-card ng-if="false">
+    <md-card>
       <md-toolbar md-colors="{background: 'teal-500'}" layout="row"
         class="clickable-no-hover" ng-click="manageMemberCtrl.toggleElement('showAdministrator')">
         <div class="md-toolbar-tools" flex layout="row" layout-align="center center">

--- a/frontend/invites/processInviteUserAdmController.js
+++ b/frontend/invites/processInviteUserAdmController.js
@@ -17,11 +17,7 @@
         processCtrl.accept = function accept() {
             InviteService.acceptInviteUserAdm(processCtrl.invite.key).then(function success() {
                 processCtrl.current_user.institutions_admin.push(processCtrl.invite.institution_key);
-                let institution = processCtrl.current_user.institutions.reduce(
-                    (inst_found, institution) => (institution.key === processCtrl.invite.institution_key) ? institution : inst_found, 
-                    {}
-                );
-                institution.admin = processCtrl.current_user.key;
+                set_inst_admin(processCtrl.current_user.institutions);
                 AuthService.save();
                 processCtrl.typeOfDialog = processCtrl.VIEW_INVITE_INVITEE;
                 processCtrl.isAccepting = true;
@@ -73,6 +69,20 @@
                     MessageService.showToast('Convite já processado!');
                 }
             });
+        }
+
+        /**
+         * This method iterates through the user list that is accepting the invitation 
+         * to become an administrator and picks up the institution in which it will be 
+         * the new administrator and switches the administrator key to the user key.
+         * @param {*} user_institutions - Institutions list of new admin 
+         */
+        function set_inst_admin(user_institutions) {
+            let institution = user_institutions.reduce(
+                (instFound, institution) => (institution.key === processCtrl.invite.institution_key) ? institution : instFound, 
+                {}
+            );
+            institution.admin = processCtrl.current_user.key;
         }
 
         (function main() {

--- a/frontend/invites/processInviteUserAdmController.js
+++ b/frontend/invites/processInviteUserAdmController.js
@@ -17,6 +17,11 @@
         processCtrl.accept = function accept() {
             InviteService.acceptInviteUserAdm(processCtrl.invite.key).then(function success() {
                 processCtrl.current_user.institutions_admin.push(processCtrl.invite.institution_key);
+                let institution = processCtrl.current_user.institutions.reduce(
+                    (inst_found, institution) => (institution.key === processCtrl.invite.institution_key) ? institution : inst_found, 
+                    {}
+                );
+                institution.admin = processCtrl.current_user.key;
                 AuthService.save();
                 processCtrl.typeOfDialog = processCtrl.VIEW_INVITE_INVITEE;
                 processCtrl.isAccepting = true;

--- a/frontend/test/specs/processInviteUserAdmControllerSpec.js
+++ b/frontend/test/specs/processInviteUserAdmControllerSpec.js
@@ -25,6 +25,7 @@
             current_institution: {key: "institutuion_key"},
             email: ['user@email.com'],
             institutions_admin: [],
+            institutions: [{key: "institutuion_key"}],
             state: 'active',
             key: '3242343rdsf324s'
         };
@@ -77,6 +78,7 @@
             user = JSON.parse(window.localStorage.userInfo);
 
             expect(user.institutions_admin).toEqual([institution.key]);
+            expect(user.institutions[0].admin).toEqual(user.key);
             expect(processInviteUserAdmCtrl.typeOfDialog).toEqual('VIEW_ACCEPTED_INVITATION_INVITEE');
             expect(processInviteUserAdmCtrl.isAccepting).toBeTruthy();
             expect(inviteService.acceptInviteUserAdm).toHaveBeenCalledWith(invite.key);

--- a/frontend/test/specs/transferAdminControllerSpec.js
+++ b/frontend/test/specs/transferAdminControllerSpec.js
@@ -13,7 +13,8 @@
     var otherUser = {
         name: 'other',
         email: ['other@email.com'],
-        state: 'active'
+        state: 'active',
+        key: 'eioruwiour83748932749'
     };
 
     var institution = {
@@ -85,7 +86,8 @@
             spyOn(messageService, 'showToast').and.callFake(function() {});
         });
 
-        it('Should must send the invitation.', function() {
+        it('Should not send the invitation.', function() {
+
             let data = {
                 institution_key: institution.key,
                 admin_key: institution.admin.key,
@@ -99,6 +101,26 @@
             invite.status = 'sent';
 
             transferAdminCtrl.selectMember(user);
+            transferAdminCtrl.confirm();
+
+            expect(messageService.showToast).toHaveBeenCalledWith("Você já é administrador da instituição, selecione outro membro!");
+        });
+
+        it('Should must send the invitation.', function() {
+
+            let data = {
+                institution_key: institution.key,
+                admin_key: institution.admin.key,
+                type_of_invite: 'USER_ADM',
+                sender_name: institution.admin.name,
+                invitee_key: otherUser.key,
+                invitee: otherUser.email[0]
+            };
+
+            let invite = new Invite(data);
+            invite.status = 'sent';
+
+            transferAdminCtrl.selectMember(otherUser);
             transferAdminCtrl.confirm();
 
             expect(inviteService.sendInviteUserAdm).toHaveBeenCalledWith(invite);


### PR DESCRIPTION
**Feature/Bug description:** The admin transfer page was allowing the admin to send an invitation to himself.

**Solution:** Block, both on the server and on the client, sending the admin transfer invitation to itself.

**TODO/FIXME:** n/a