### PR TITLE
Fix remove member notification action

### DIFF
--- a/frontend/notification/notificationDirective.js
+++ b/frontend/notification/notificationDirective.js
@@ -20,14 +20,14 @@
             },
             "DELETE_MEMBER": {
                 icon: "clear",
-                action: function() {
-                    return refreshUserInstitutions();
+                action: function (properties, notification, event) {
+                    return refreshUserInstitutions(notification);
                 }
             },
             "DELETED_INSTITUTION": {
                 icon: "clear",
-                action: function() {
-                    return refreshUserInstitutions();
+                action: function (properties, notification, event) {
+                    return refreshUserInstitutions(notification);
                 }
             },
             "POST": {
@@ -260,14 +260,12 @@
             $state.go('app.user.notifications');
         }
 
-        function refreshUserInstitutions () {
+        function refreshUserInstitutions (notification) {
+            notificationCtrl.user.goToDifferentInstitution(notification.entity.key);
             UserService.load().then(function success(response) {
                 notificationCtrl.user.institutions = response.institutions;
                 notificationCtrl.user.follows = response.follows;
                 notificationCtrl.user.institution_profiles = response.institution_profiles;
-                if(!_.isEmpty(notificationCtrl.user.institutions)) {
-                    notificationCtrl.user.changeInstitution();
-                }
                 AuthService.save();
             });
         }

--- a/frontend/test/specs/userSpec.js
+++ b/frontend/test/specs/userSpec.js
@@ -288,5 +288,33 @@
               expect(user.institution_profiles).toEqual([]);
             });
         });
+
+        describe('goToDifferentInstitution', function () {
+          it('should change current institution', function () {
+            var user = new User({
+              institutions: [inst, other_inst],
+              current_institution: inst
+            });
+            
+            expect(user.current_institution).toBe(inst);
+
+            user.goToDifferentInstitution(inst.key);
+
+            expect(user.current_institution).toBe(other_inst);
+          });
+
+          it('should not change the current institution', function() {
+            var user = new User({
+              institutions: [inst],
+              current_institution: inst
+            });
+
+            expect(user.current_institution).toBe(inst);
+
+            user.goToDifferentInstitution(inst.key);
+
+            expect(user.current_institution).toBe(inst);
+          });
+        });
    });
 }));

--- a/frontend/user/user.js
+++ b/frontend/user/user.js
@@ -163,6 +163,17 @@ User.prototype.updateInstProfile = function updateInstProfile(institution) {
     this.institution_profiles[index].institution.photo_url = institution.photo_url;
 };
 
+User.prototype.goToDifferentInstitution = function goToDifferentInstitution(previousKey) {
+    var user = this;
+    _.forEach(this.institutions, function(institution) {
+        if(institution.key !== previousKey) {
+            user.current_institution = institution;
+            changeProfileColor(user, institution);
+            window.localStorage.userInfo = JSON.stringify(this);
+        }
+    });
+};
+
 function changeProfileColor(user, institution) {
     var profile = _.find(user.institution_profiles, {
         'institution_key': institution.key


### PR DESCRIPTION
**Feature/Bug description:**
Handle with current_institution in the backend became a problem to us in this situation. The user who the request came from wasn't a current_institution's member anymore, what make the server raise an exception and making the notification's action work with problem.
**Solution:**
I've changed the current_institution before make the request to the server to reload the user.

**TODO/FIXME:** n/a