### PR TITLE
Standardize card titles in management page

### DIFF
--- a/frontend/institution/management_members.html
+++ b/frontend/institution/management_members.html
@@ -8,7 +8,7 @@
         <div class="md-toolbar-tools" flex layout="row" layout-align="center center">
           <h1>
             <md-icon>send</md-icon>
-            ENVIAR CONVITE
+            Enviar convite
           </h1>
           <span flex md-truncate></span>
           <md-button class="md-icon-button md-secondary">
@@ -67,7 +67,7 @@
         <div class="md-toolbar-tools" flex layout="row" layout-align="center center">
           <h1>
             <md-icon>account_circle </md-icon>
-            ADMINISTRADOR
+            Administrador
           </h1>
           <span flex md-truncate></span>
           <md-button class="md-icon-button md-secondary">


### PR DESCRIPTION
**Feature/Bug description:**
The titles were out of pattern.

**Solution:**
I've changed the titles to lower case pattern.

![screenshot from 2018-03-29 08-20-37](https://user-images.githubusercontent.com/23387866/38086387-815ea4d4-332a-11e8-9107-be490a925632.png)


**TODO/FIXME:** n/a