### PR TITLE
Fix bug on new invite form shaking

### DIFF
--- a/frontend/invites/new_invite_page.html
+++ b/frontend/invites/new_invite_page.html
@@ -1,4 +1,4 @@
-<md-content flex md-colors="{background: 'teal-500'}">
+<md-content flex md-colors="{background: 'teal-500'}" style="overflow:hidden">
   <div layout="column" layout-align="center center" layout-fill flex>
     <div layout="row" layout-xs="column" layout-align="center center">
       <div flex-sm="60" flex-gt-sm="40" layout-align="center center">
@@ -22,7 +22,9 @@
                     </md-list-item>
                   </md-list>
                   <div layout="column" layout-align="center">
-                    <p class="small-text increase-distance md-title green-text">{{newInviteCtrl.isInviteUser() ? 'PREENCHA O FORMULÁRIO PARA SE TORNAR UM MEMBRO:' : 'PREENCHA O FORMULÁRIO PARA CADASTRAR A INSTITUIÇÃO:'}}</p>
+                    <p class="small-text increase-distance md-title green-text">
+                      {{newInviteCtrl.isInviteUser() ? 'PREENCHA O FORMULÁRIO PARA SE TORNAR UM MEMBRO:' : 'PREENCHA O FORMULÁRIO PARA CADASTRAR A INSTITUIÇÃO:'}}
+                    </p>
 
                     <!-- INVITED INSTITUTION -->
                     <div ng-if="!newInviteCtrl.isInviteUser()">
@@ -69,8 +71,13 @@
                   </div>
               </div>
               <md-card-actions layout="row" layout-align="end center">
-                <md-button ng-if="!newInviteCtrl.acceptedInvite" ng-click="newInviteCtrl.rejectInvite($event)" md-colors="{background: 'teal-500'}">Cancelar</md-button>
-                <md-button ng-if="!newInviteCtrl.acceptedInvite" type="submit" md-colors="{background: 'teal-500'}">{{newInviteCtrl.isInviteUser() ? 'Enviar' : 'Próximo'}}</md-button>
+                <md-button ng-if="!newInviteCtrl.acceptedInvite" ng-click="newInviteCtrl.rejectInvite($event)"
+                  md-colors="{background: 'teal-500'}">
+                  Cancelar
+                </md-button>
+                <md-button ng-if="!newInviteCtrl.acceptedInvite" type="submit" md-colors="{background: 'teal-500'}">
+                  {{newInviteCtrl.isInviteUser() ? 'Enviar' : 'Próximo'}}
+                </md-button>
                 <div ng-if="newInviteCtrl.acceptedInvite" flex="100" layout="row" layout-align="center center">
                   <md-progress-circular  class="md-hue-2" md-diameter="30px"></md-progress-circular>
                 </div>


### PR DESCRIPTION
**Feature/Bug description:** On screens heights less than 900px the new invite form was shaking every time a field was select. This happens because of the card has its height increased when a new field is selected, so it gets bigger than the page and the scrollbar appears for an instant and than disappear.

**Solution:** 
The md-content overflow property was set to hidden.

**TODO/FIXME:** n/a

**Bug**
![treme](https://user-images.githubusercontent.com/13683704/38087904-5680a1f8-3330-11e8-9101-e6e5ee8354be.gif)

**Solved**
![invite](https://user-images.githubusercontent.com/13683704/38088099-08ef9b5a-3331-11e8-90fc-b0c31f8daa0c.gif)
