### PR TITLE
Fix the reload on create_inst_form page in case of invite to create institution

### DIFF
--- a/frontend/institution/configInstDirective.js
+++ b/frontend/institution/configInstDirective.js
@@ -434,16 +434,29 @@
                 .filter(invite => invite.type_of_invite === "INSTITUTION" && invite.status === "sent"));
         }
 
-        (function main(){
-            if (institutionKey) {
+        function isRequest() {
+            return configInstCtrl.user.state !== "active" && !hasPendingInstInvite();
+        }
+
+        function loadRequestState() {
+            configInstCtrl.isSubmission = true;
+            configInstCtrl.newInstitution.admin = {};
+            loadAddress();
+        }
+
+        configInstCtrl.initController = function initController() {
+            if (configInstCtrl.institutionKey) {
                 loadInstitution();
-            } else if(configInstCtrl.user.state !== "active" && !hasPendingInstInvite()) {
-                configInstCtrl.isSubmission = true;
-                configInstCtrl.newInstitution.admin = {};
-                loadAddress();
+            } else if(isRequest()) {
+                loadRequestState();
             } else {
                 $state.go('signin');
             }
+        };
+
+        (function main(){
+            configInstCtrl.institutionKey = institutionKey;
+            configInstCtrl.initController();
         })();
     });
 

--- a/frontend/institution/configInstDirective.js
+++ b/frontend/institution/configInstDirective.js
@@ -432,10 +432,12 @@
         (function main(){
             if (institutionKey) {
                 loadInstitution();
-            } else {
+            } else if(_.isUndefined(institutionKey) && _.isEmpty(configInstCtrl.user.institutions)) {
                 configInstCtrl.isSubmission = true;
                 configInstCtrl.newInstitution.admin = {};
                 loadAddress();
+            } else {
+                $state.go('signin');
             }
         })();
     });

--- a/frontend/institution/configInstDirective.js
+++ b/frontend/institution/configInstDirective.js
@@ -429,10 +429,15 @@
             configInstCtrl.newInstitution.photo_url = configInstCtrl.newInstitution.photo_url || defaultPhotoUrl;
         }
 
+        function hasPendingInstInvite() {
+            return !_.isEmpty(configInstCtrl.user.invites
+                .filter(invite => invite.type_of_invite === "INSTITUTION" && invite.status === "sent"));
+        }
+
         (function main(){
             if (institutionKey) {
                 loadInstitution();
-            } else if(_.isUndefined(institutionKey) && _.isEmpty(configInstCtrl.user.institutions)) {
+            } else if(configInstCtrl.user.state !== "active" && !hasPendingInstInvite()) {
                 configInstCtrl.isSubmission = true;
                 configInstCtrl.newInstitution.admin = {};
                 loadAddress();


### PR DESCRIPTION
**Feature/Bug description:** When the user reloads the creat_inst_form page in case of an invite, the behavior of form becomes to request create an institution.

**Solution:** Adding a case to verify if the user is not active and no has institution invites, the behavior of form should be to request to create an institution, in this case. Otherwise, redirect to signin page to recognize the invite again and get the institutionKey of the stub institution.

**TODO/FIXME:** n/a