### PR TITLE
Fix the overflow of event image in modal of share event

### DIFF
--- a/frontend/post/share_post_dialog.html
+++ b/frontend/post/share_post_dialog.html
@@ -31,6 +31,7 @@
             <span ng-if="!sharePostCtrl.isSurvey() && !sharePostCtrl.isEvent()" class="md-text">
               <b>{{ sharePostCtrl.post.title }}</b>
             </span>
+          </br>
             <event-details ng-if="sharePostCtrl.isEvent()" event="sharePostCtrl.post" is-event-page=false></event-details>
             <span class="md-subhead" ng-if="!sharePostCtrl.isEvent() && sharePostCtrl.post.text" ng-bind-html="sharePostCtrl.postToURL(sharePostCtrl.post.text)"></span>
             <pdf-view ng-if="sharePostCtrl.showPdfFiles()" pdf-files='sharePostCtrl.post.pdf_files' is-editing="false"></pdf-view>


### PR DESCRIPTION
**Feature/Bug description:** The image exceeds the layout in modal of share event.

![screenshot from 2018-04-02 14-05-19](https://user-images.githubusercontent.com/20300259/38206131-980e0b7c-367f-11e8-884b-0c504851695a.png)


**Solution:** Adding a broken line to adjust the preview display of event.

![screenshot from 2018-04-02 14-04-59](https://user-images.githubusercontent.com/20300259/38206137-9fa9a620-367f-11e8-9cfc-1678bb0b9a5c.png)



**TODO/FIXME:** n/a