### PR TITLE
Fix position of report button

### DIFF
--- a/frontend/main/main.html
+++ b/frontend/main/main.html
@@ -49,7 +49,7 @@
 <md-content ui-view="content" flex layout="column" md-colors="{background: 'grey-200'}"></md-content>
 
 <div hide-xs hide-sm>
-  <md-button class="feedback-btn" ng-click="mainCtrl.goToReport()" style="z-index: 99";
+  <md-button class="feedback-btn" ng-click="mainCtrl.goToReport()" style="z-index: 20";
       md-colors="{background: 'light-green-700', color: 'grey-50'}">
     Reportar problemas
   </md-button>

--- a/frontend/main/main.html
+++ b/frontend/main/main.html
@@ -49,7 +49,7 @@
 <md-content ui-view="content" flex layout="column" md-colors="{background: 'grey-200'}"></md-content>
 
 <div hide-xs hide-sm>
-  <md-button class="feedback-btn" ng-click="mainCtrl.goToReport()" 
+  <md-button class="feedback-btn" ng-click="mainCtrl.goToReport()" style="z-index: 99";
       md-colors="{background: 'light-green-700', color: 'grey-50'}">
     Reportar problemas
   </md-button>


### PR DESCRIPTION
**Feature/Bug description:** When creating an event with a very large image, entering the event page and scrolling the page, the event sharing button was overlapping the report button.

![screenshot from 2018-04-02 15-14-09](https://user-images.githubusercontent.com/18005317/38208874-d0671258-3688-11e8-86cd-dedcd03d2e47.png)

**Solution:** I changed the z-index of the report button so it always stays in front of the page.

![screenshot from 2018-04-02 15-14-32](https://user-images.githubusercontent.com/18005317/38208880-d5d27458-3688-11e8-9d19-522abbe96e58.png)

**TODO/FIXME:** n/a