### PR TITLE
Fix Institution Controller when use the content object and these not exist.

### DIFF
--- a/frontend/institution/institutionController.js
+++ b/frontend/institution/institutionController.js
@@ -6,7 +6,7 @@
     app.controller("InstitutionController", function InstitutionController($state, InstitutionService,
             InviteService, AuthService, MessageService, $sce, $mdDialog, PdfService, $rootScope, $window, ProfileService, $q, CropImageService, ImageService) {
         var institutionCtrl = this;
-        var content = document.getElementById("instPage");
+        var content = document.getElementById("instPage") || {};
         var morePosts = true;
         var actualPage = 0;
 


### PR DESCRIPTION
**Feature/Bug description:** When you open the institution edit page, an error occurred because in setScrollListener you use the content attribute, however, the content object does not exist.

**Solution:** Added default object the content.

**TODO/FIXME:** n/a