### PR TITLE
Fix email of new admin when transferring the administration of an institution

### DIFF
--- a/backend/models/institution.py
+++ b/backend/models/institution.py
@@ -247,6 +247,7 @@ class Institution(ndb.Model):
     
     def set_admin(self, user_key):
         self.admin = user_key
+        self.email = user_key.get().email[0]
         self.put()
 
     @ndb.transactional(xg=True)

--- a/frontend/institution/institutionController.js
+++ b/frontend/institution/institutionController.js
@@ -6,7 +6,7 @@
     app.controller("InstitutionController", function InstitutionController($state, InstitutionService,
             InviteService, AuthService, MessageService, $sce, $mdDialog, PdfService, $rootScope, $window, ProfileService, $q, CropImageService, ImageService) {
         var institutionCtrl = this;
-        var content = document.getElementById("instPage");
+        var content = document.getElementById("instPage") || {};
         var morePosts = true;
         var actualPage = 0;
 

--- a/frontend/institution/institutionController.js
+++ b/frontend/institution/institutionController.js
@@ -6,7 +6,7 @@
     app.controller("InstitutionController", function InstitutionController($state, InstitutionService,
             InviteService, AuthService, MessageService, $sce, $mdDialog, PdfService, $rootScope, $window, ProfileService, $q, CropImageService, ImageService) {
         var institutionCtrl = this;
-        var content = document.getElementById("instPage") || {};
+        var content = document.getElementById("instPage");
         var morePosts = true;
         var actualPage = 0;
 


### PR DESCRIPTION
**Feature/Bug description:** When transferring the administration of an institution the email of new admin didn't change.

**Solution:** Pass the email when set the admin.

**TODO/FIXME:** n/a

![screenshot from 2018-04-03 10-33-43](https://user-images.githubusercontent.com/18709274/38253255-95d13e08-372c-11e8-83a3-67ff10d017a3.png)
![screenshot from 2018-04-03 10-33-31](https://user-images.githubusercontent.com/18709274/38253256-95ef56e0-372c-11e8-8ba7-3afd442826cd.png)
