### PR TITLE
Fix the position of invite modal

### DIFF
--- a/frontend/invites/new_invite_page.html
+++ b/frontend/invites/new_invite_page.html
@@ -1,4 +1,4 @@
-<md-content flex md-colors="{background: 'teal-500'}">
+<md-content layout-fill layout="row" layout-align="center center" md-colors="{background: 'teal-500'}">
   <div layout="column" layout-align="center center">
     <div layout="row" layout-xs="column" layout-align="center center">
       <div flex-sm="60" flex-gt-sm="40" layout-align="center center">


### PR DESCRIPTION
**Feature/Bug description:** The modal of the invite is not centered on the screen.

![screenshot from 2018-04-03 16-27-31](https://user-images.githubusercontent.com/20300259/38271244-4dbd7b24-375c-11e8-986a-eb0c34d28983.png)



**Solution:** Adding tags to align with the center of the screen.


![screenshot from 2018-04-03 16-27-14](https://user-images.githubusercontent.com/20300259/38271253-52dda700-375c-11e8-9ae2-6dbbfb8c0b83.png)



**TODO/FIXME:** n/a