### PR TITLE
Fix null event on event page

### DIFF
--- a/frontend/event/eventDetailsDirective.js
+++ b/frontend/event/eventDetailsDirective.js
@@ -59,7 +59,8 @@
         };
 
         eventCtrl.canChange = function canChange(event) {
-            return eventCtrl.isEventAuthor(event) || isInstitutionAdmin(event);
+            if(event)
+                return eventCtrl.isEventAuthor(event) || isInstitutionAdmin(event);
         };
 
         eventCtrl.canEdit = function canEdit(event) {
@@ -132,8 +133,9 @@
         };
 
         function isInstitutionAdmin(event) {
-            return _.includes(_.map(eventCtrl.user.institutions_admin, Utils.getKeyFromUrl),
-                Utils.getKeyFromUrl(event.institution_key));
+            if(event.institution_key)
+                return _.includes(_.map(eventCtrl.user.institutions_admin, Utils.getKeyFromUrl),
+                    Utils.getKeyFromUrl(event.institution_key));
         }
     });
     

--- a/frontend/event/eventDetailsDirective.js
+++ b/frontend/event/eventDetailsDirective.js
@@ -59,8 +59,7 @@
         };
 
         eventCtrl.canChange = function canChange(event) {
-            if(event)
-                return eventCtrl.isEventAuthor(event) || isInstitutionAdmin(event);
+            return event && eventCtrl.isEventAuthor(event) || isInstitutionAdmin(event);
         };
 
         eventCtrl.canEdit = function canEdit(event) {


### PR DESCRIPTION
**Feature/Bug description:** When the event page is opened the console displays the following error: cannot read property 'institution_key' of null.

**Solution:** Adding verification if the event is defined before the return of functions 'isInstitutionAdmin' and 'canChange'.

**TODO/FIXME:** n/a