### PR TITLE
Fix transferring administration when is the super user

### DIFF
--- a/backend/models/institution.py
+++ b/backend/models/institution.py
@@ -5,6 +5,7 @@ from google.appengine.ext import ndb
 from search_module.search_institution import SearchInstitution
 from models.address import Address
 from permissions import DEFAULT_ADMIN_PERMISSIONS
+from permissions import DEFAULT_SUPER_USER_PERMISSIONS
 
 
 def get_actuation_area(data):
@@ -327,4 +328,29 @@ class Institution(ndb.Model):
             children = children.get()
             children.get_all_hierarchy_admin_permissions(permissions)
         
+        return permissions
+
+    def get_super_user_admin_permissions(self, permissions=None):
+        """
+        This method get all admin permissions of 
+        Departamento do Complexo Industrial e Inovacao em Saude.
+        When result, returns a dict containing
+        the admin permissions of super user.
+
+        Arguments:
+        permissions(Optional) -- Dict of previous permissions added for add more permissons. 
+        If not passed, creates new dict of permissions
+        """
+
+        if not permissions:
+            permissions = {}
+
+        if self.name == 'Complexo Industrial da Saude':
+            institution_key = self.key.urlsafe()
+            for permission in DEFAULT_SUPER_USER_PERMISSIONS:
+                if permission in permissions:
+                    permissions[permission].update({institution_key: True})
+                else:
+                    permissions.update({permission: {institution_key: True}})
+            
         return permissions

--- a/backend/models/institution.py
+++ b/backend/models/institution.py
@@ -332,8 +332,9 @@ class Institution(ndb.Model):
 
     def get_super_user_admin_permissions(self, permissions=None):
         """
-        This method get all admin permissions of 
-        Departamento do Complexo Industrial e Inovacao em Saude.
+        This method get all super user permissions.
+        The type permmission is only possible when the institution is
+        'Departamento do Complexo Industrial e Inovacao em Saude'
         When result, returns a dict containing
         the admin permissions of super user.
 

--- a/backend/models/institution.py
+++ b/backend/models/institution.py
@@ -345,7 +345,7 @@ class Institution(ndb.Model):
         if not permissions:
             permissions = {}
 
-        if self.name == 'Complexo Industrial da Saude':
+        if self.name == 'Departamento do Complexo Industrial e Inovacao em Saude':
             institution_key = self.key.urlsafe()
             for permission in DEFAULT_SUPER_USER_PERMISSIONS:
                 if permission in permissions:

--- a/backend/test/invite_user_adm_handler_test.py
+++ b/backend/test/invite_user_adm_handler_test.py
@@ -374,7 +374,7 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
         new_admin = mocks.create_user()
 
         institution = mocks.create_institution()
-        institution.name = "Complexo Industrial da Saude"
+        institution.name = "Departamento do Complexo Industrial e Inovacao em Saude"
         institution.set_admin(admin.key)
         institution.add_member(admin)
         institution.add_member(new_admin)

--- a/backend/test/invite_user_adm_handler_test.py
+++ b/backend/test/invite_user_adm_handler_test.py
@@ -14,11 +14,20 @@ import permissions
 
 from mock import patch
 
-def addAdminPermission(user, institution_key):
+def add_admin_permission(user, institution_key):
     user.add_permissions(permissions.DEFAULT_ADMIN_PERMISSIONS, institution_key)
 
-def hasAdminPermissions(user, institution_key):
+def add_super_user_permission(user, institution_key):
+    user.add_permissions(permissions.DEFAULT_SUPER_USER_PERMISSIONS, institution_key)
+
+def has_admin_permissions(user, institution_key):
     for permission in permissions.DEFAULT_ADMIN_PERMISSIONS:
+        if not user.has_permission(permission, institution_key):
+            return False
+    return True
+
+def has_super_user_permissions(user, institution_key):
+    for permission in permissions.DEFAULT_SUPER_USER_PERMISSIONS:
         if not user.has_permission(permission, institution_key):
             return False
     return True
@@ -55,7 +64,7 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
         institution.add_member(new_admin)
 
         admin.add_institution_admin(institution.key)
-        addAdminPermission(admin, institution.key.urlsafe())
+        add_admin_permission(admin, institution.key.urlsafe())
 
         institution.put()
         admin.put()
@@ -65,11 +74,11 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
         invite = mocks.create_invite(admin, institution.key, 'USER_ADM', new_admin.key.urlsafe())
 
         self.assertTrue(
-            hasAdminPermissions(admin, institution.key.urlsafe()),
+            has_admin_permissions(admin, institution.key.urlsafe()),
             'Admin must have super user permissions for this institution!'
         )
         self.assertFalse(
-            hasAdminPermissions(new_admin, institution.key.urlsafe()),
+            has_admin_permissions(new_admin, institution.key.urlsafe()),
             'new_admin should not have super user permissions for this institution!'
         )
         self.assertEquals(
@@ -86,11 +95,11 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
         invite = invite.key.get()
 
         self.assertFalse(
-            hasAdminPermissions(admin, institution.key.urlsafe()),
+            has_admin_permissions(admin, institution.key.urlsafe()),
             'Admin should not have super user permissions for this institution!'    
         )
         self.assertTrue(
-            hasAdminPermissions(new_admin, institution.key.urlsafe()),
+            has_admin_permissions(new_admin, institution.key.urlsafe()),
             'New_admin must have super user permissions for this institution!'
         )
         self.assertEquals(
@@ -136,10 +145,10 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
         admin.add_institution_admin(institution.key)
         admin.add_institution_admin(third_inst.key)
         other_admin.add_institution_admin(second_inst.key)
-        addAdminPermission(admin, institution.key.urlsafe())
-        addAdminPermission(admin, second_inst.key.urlsafe())
-        addAdminPermission(admin, third_inst.key.urlsafe())
-        addAdminPermission(other_admin, second_inst.key.urlsafe())
+        add_admin_permission(admin, institution.key.urlsafe())
+        add_admin_permission(admin, second_inst.key.urlsafe())
+        add_admin_permission(admin, third_inst.key.urlsafe())
+        add_admin_permission(other_admin, second_inst.key.urlsafe())
 
         institution.put()
         second_inst.put()
@@ -152,31 +161,31 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
         invite = mocks.create_invite(admin, institution.key, 'USER_ADM', new_admin.key.urlsafe())
 
         self.assertTrue(
-            hasAdminPermissions(admin, institution.key.urlsafe()),
+            has_admin_permissions(admin, institution.key.urlsafe()),
             'Admin must have super user permissions for this institution!'
         )
         self.assertTrue(
-            hasAdminPermissions(admin, second_inst.key.urlsafe()),
+            has_admin_permissions(admin, second_inst.key.urlsafe()),
             'Admin must have super user permissions for second_inst institution!'
         )
         self.assertTrue(
-            hasAdminPermissions(admin, third_inst.key.urlsafe()),
+            has_admin_permissions(admin, third_inst.key.urlsafe()),
             'Admin must have super user permissions for third_inst institution!'
         )
         self.assertTrue(
-            hasAdminPermissions(other_admin, second_inst.key.urlsafe()),
+            has_admin_permissions(other_admin, second_inst.key.urlsafe()),
             'other_admin must have super user permissions for second_inst institution!'    
         )
         self.assertFalse(
-            hasAdminPermissions(new_admin, institution.key.urlsafe()),
+            has_admin_permissions(new_admin, institution.key.urlsafe()),
             'new_admin should not have super user permissions for this institution!'
         )
         self.assertFalse(
-            hasAdminPermissions(new_admin, second_inst.key.urlsafe()),
+            has_admin_permissions(new_admin, second_inst.key.urlsafe()),
             'new_admin should not have super user permissions for the second_inst institution!'
         )
         self.assertFalse(
-            hasAdminPermissions(new_admin, third_inst.key.urlsafe()),
+            has_admin_permissions(new_admin, third_inst.key.urlsafe()),
             'new_admin should not have super user permissions for the third_inst institution!'
         )
         self.assertEquals(
@@ -196,31 +205,31 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
         invite = invite.key.get()
 
         self.assertFalse(
-            hasAdminPermissions(admin, institution.key.urlsafe()),
+            has_admin_permissions(admin, institution.key.urlsafe()),
             'admin should not have super user permissions for this institution!'
         )
         self.assertFalse(
-            hasAdminPermissions(admin, second_inst.key.urlsafe()),
+            has_admin_permissions(admin, second_inst.key.urlsafe()),
             'admin should not have super user permissions for the third_inst institution!'
         )
         self.assertTrue(
-            hasAdminPermissions(admin, third_inst.key.urlsafe()),
+            has_admin_permissions(admin, third_inst.key.urlsafe()),
             'Admin must have super user permissions for third_inst institution!'    
         )
         self.assertTrue(
-            hasAdminPermissions(other_admin, second_inst.key.urlsafe()),
+            has_admin_permissions(other_admin, second_inst.key.urlsafe()),
             'other_admin must have super user permissions for second_inst institution!'
         )
         self.assertTrue(
-            hasAdminPermissions(new_admin, institution.key.urlsafe()),
+            has_admin_permissions(new_admin, institution.key.urlsafe()),
             'new_admin must have super user permissions for this institution!'
         )
         self.assertTrue(
-            hasAdminPermissions(new_admin, second_inst.key.urlsafe()),
+            has_admin_permissions(new_admin, second_inst.key.urlsafe()),
             'New_admin must have super user permissions for second_inst institution!'
         )
         self.assertTrue(
-            hasAdminPermissions(new_admin, third_inst.key.urlsafe()),
+            has_admin_permissions(new_admin, third_inst.key.urlsafe()),
             'New_admin must have super user permissions for third_inst institution!'
         )
         self.assertEquals(
@@ -261,10 +270,10 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
         admin.add_institution_admin(institution.key)
         admin.add_institution_admin(third_inst.key)
         other_admin.add_institution_admin(second_inst.key)
-        addAdminPermission(admin, institution.key.urlsafe())
-        addAdminPermission(admin, second_inst.key.urlsafe())
-        addAdminPermission(admin, third_inst.key.urlsafe())
-        addAdminPermission(other_admin, second_inst.key.urlsafe())
+        add_admin_permission(admin, institution.key.urlsafe())
+        add_admin_permission(admin, second_inst.key.urlsafe())
+        add_admin_permission(admin, third_inst.key.urlsafe())
+        add_admin_permission(other_admin, second_inst.key.urlsafe())
 
         institution.put()
         second_inst.put()
@@ -277,31 +286,31 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
         invite = mocks.create_invite(admin, third_inst.key, 'USER_ADM', new_admin.key.urlsafe())
 
         self.assertTrue(
-            hasAdminPermissions(admin, institution.key.urlsafe()),
+            has_admin_permissions(admin, institution.key.urlsafe()),
             'Admin must have super user permissions for this institution!'
         )
         self.assertTrue(
-            hasAdminPermissions(admin, second_inst.key.urlsafe()),
+            has_admin_permissions(admin, second_inst.key.urlsafe()),
             'Admin must have super user permissions for second_inst institution!'
         )
         self.assertTrue(
-            hasAdminPermissions(admin, third_inst.key.urlsafe()),
+            has_admin_permissions(admin, third_inst.key.urlsafe()),
             'Admin must have super user permissions for third_inst institution!'
         )
         self.assertTrue(
-            hasAdminPermissions(other_admin, second_inst.key.urlsafe()),
+            has_admin_permissions(other_admin, second_inst.key.urlsafe()),
             'other_admin must have super user permissions for second_inst institution!'    
         )
         self.assertFalse(
-            hasAdminPermissions(new_admin, institution.key.urlsafe()),
+            has_admin_permissions(new_admin, institution.key.urlsafe()),
             'new_admin should not have super user permissions for this institution!'
         )
         self.assertFalse(
-            hasAdminPermissions(new_admin, second_inst.key.urlsafe()),
+            has_admin_permissions(new_admin, second_inst.key.urlsafe()),
             'new_admin should not have super user permissions for the second_inst institution!'
         )
         self.assertFalse(
-            hasAdminPermissions(new_admin, third_inst.key.urlsafe()),
+            has_admin_permissions(new_admin, third_inst.key.urlsafe()),
             'new_admin should not have super user permissions for the third_inst institution!'
         )
         self.assertEquals(
@@ -321,31 +330,31 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
         invite = invite.key.get()
 
         self.assertTrue(
-            hasAdminPermissions(admin, institution.key.urlsafe()),
+            has_admin_permissions(admin, institution.key.urlsafe()),
             'admin must have super user permissions for this institution!'
         )
         self.assertTrue(
-            hasAdminPermissions(admin, second_inst.key.urlsafe()),
+            has_admin_permissions(admin, second_inst.key.urlsafe()),
             'Admin must have super user permissions for second_inst institution!'
         )
         self.assertTrue(
-            hasAdminPermissions(admin, third_inst.key.urlsafe()),
+            has_admin_permissions(admin, third_inst.key.urlsafe()),
             'Admin must have super user permissions for third_inst institution!'    
         )
         self.assertTrue(
-            hasAdminPermissions(other_admin, second_inst.key.urlsafe()),
+            has_admin_permissions(other_admin, second_inst.key.urlsafe()),
             'other_admin must have super user permissions for second_inst institution!'
         )
         self.assertFalse(
-            hasAdminPermissions(new_admin, institution.key.urlsafe()),
+            has_admin_permissions(new_admin, institution.key.urlsafe()),
             'new_admin should not have super user permissions for this institution!'
         )
         self.assertFalse(
-            hasAdminPermissions(new_admin, second_inst.key.urlsafe()),
+            has_admin_permissions(new_admin, second_inst.key.urlsafe()),
             'new_admin should not have super user permissions for the second_inst institution!'
         )
         self.assertTrue(
-            hasAdminPermissions(new_admin, third_inst.key.urlsafe()),
+            has_admin_permissions(new_admin, third_inst.key.urlsafe()),
             'New_admin must have super user permissions for third_inst institution!'
         )
         self.assertEquals(
@@ -354,6 +363,76 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
             'New_admin must be the administrator of the institution!'
         )
     
+    @patch('models.invite_user_adm.InviteUserAdm.send_notification')
+    @patch('handlers.invite_user_adm_handler.enqueue_task')
+    @patch('utils.verify_token', return_value={'email': 'usr_test@test.com'})
+    def test_put_invite_super_user(self, verify_token, enqueue_task, send_notification):
+        """Test put invite with user is admin of parent institution."""
+        enqueue_task.side_effect = self.enqueue_task
+
+        admin = mocks.create_user()
+        new_admin = mocks.create_user()
+
+        institution = mocks.create_institution()
+        institution.name = "Complexo Industrial da Saude"
+        institution.set_admin(admin.key)
+        institution.add_member(admin)
+        institution.add_member(new_admin)
+
+        new_admin.add_institution(institution.key)
+        admin.add_institution(institution.key)        
+        admin.add_institution_admin(institution.key)
+        
+        add_admin_permission(admin, institution.key.urlsafe())
+        add_super_user_permission(admin, institution.key.urlsafe())
+
+        institution.put()
+        admin.put()
+        new_admin.put()
+    
+        verify_token._mock_return_value = {'email': new_admin.email[0]}
+        invite = mocks.create_invite(admin, institution.key, 'USER_ADM', new_admin.key.urlsafe())
+
+        self.assertTrue(
+            has_admin_permissions(admin, institution.key.urlsafe()),
+            'Admin must have administrative permissions!'
+        )
+        self.assertTrue(
+            has_super_user_permissions(admin, institution.key.urlsafe()),
+            'Admin must have super user permissions for this institution!'
+        )    
+        self.assertFalse(
+            has_admin_permissions(new_admin, institution.key.urlsafe()),
+            'new_admin should not have administrative permissions for this institution!'
+        )
+        self.assertFalse(
+            has_super_user_permissions(new_admin, institution.key.urlsafe()),
+            'new_admin should not have super user permissions for this institution!'
+        )   
+
+        self.testapp.put('/api/invites/%s/institution_adm' %(invite.key.urlsafe()))
+
+        institution = institution.key.get()
+        admin = admin.key.get()
+        new_admin = new_admin.key.get()
+        invite = invite.key.get()
+
+        self.assertFalse(
+            has_admin_permissions(admin, institution.key.urlsafe()),
+            'admin must have super user permissions for this institution!'
+        )
+        self.assertFalse(
+            has_super_user_permissions(admin, institution.key.urlsafe()),
+            'admin must have super user permissions for this institution!'
+        )
+        self.assertTrue(
+            has_admin_permissions(new_admin, institution.key.urlsafe()),
+            'Admin must have super user permissions for second_inst institution!'
+        )
+        self.assertTrue(
+            has_super_user_permissions(new_admin, institution.key.urlsafe()),
+            'Admin must have super user permissions for second_inst institution!'
+        )
 
     @patch('utils.verify_token', return_value={'email': 'usr_test@test.com'})
     def test_put_accepted_and_rejected_invite(self, verify_token):
@@ -367,7 +446,7 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
         institution.add_member(new_admin)
 
         admin.add_institution_admin(institution.key)
-        addAdminPermission(admin, institution.key.urlsafe())
+        add_admin_permission(admin, institution.key.urlsafe())
 
         institution.put()
         admin.put()
@@ -377,11 +456,11 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
         invite.change_status('accepted')
 
         self.assertTrue(
-            hasAdminPermissions(admin, institution.key.urlsafe()),
+            has_admin_permissions(admin, institution.key.urlsafe()),
             'Admin must have super user permissions for this institution!'
         )
         self.assertFalse(
-            hasAdminPermissions(new_admin, institution.key.urlsafe()),
+            has_admin_permissions(new_admin, institution.key.urlsafe()),
             'New_admin should not have super user permissions for this institution!'
         )
         self.assertEquals(
@@ -398,11 +477,11 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
         new_admin = new_admin.key.get()
 
         self.assertTrue(
-            hasAdminPermissions(admin, institution.key.urlsafe()),
+            has_admin_permissions(admin, institution.key.urlsafe()),
             'Admin must have super user permissions for this institution!'
         )
         self.assertFalse(
-            hasAdminPermissions(new_admin, institution.key.urlsafe()),
+            has_admin_permissions(new_admin, institution.key.urlsafe()),
             'New_admin should not have super user permissions for this institution!'
         )
         self.assertEquals(
@@ -434,11 +513,11 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
         invite = invite.key.get()
 
         self.assertTrue(
-            hasAdminPermissions(admin, institution.key.urlsafe()),
+            has_admin_permissions(admin, institution.key.urlsafe()),
             'Admin must have super user permissions for this institution!'
         )
         self.assertFalse(
-            hasAdminPermissions(new_admin, institution.key.urlsafe()),
+            has_admin_permissions(new_admin, institution.key.urlsafe()),
             'New_admin should not have super user permissions for this institution!'
         )
         self.assertEquals(
@@ -471,7 +550,7 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
         institution.add_member(new_admin)
 
         admin.add_institution_admin(institution.key)
-        addAdminPermission(admin, institution.key.urlsafe())
+        add_admin_permission(admin, institution.key.urlsafe())
 
         institution.put()
         admin.put()
@@ -480,11 +559,11 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
         invite = mocks.create_invite(admin, institution.key, 'USER')
 
         self.assertTrue(
-            hasAdminPermissions(admin, institution.key.urlsafe()),
+            has_admin_permissions(admin, institution.key.urlsafe()),
             'Admin must have super user permissions for this institution!'
         )
         self.assertFalse(
-            hasAdminPermissions(new_admin, institution.key.urlsafe()),
+            has_admin_permissions(new_admin, institution.key.urlsafe()),
             'New_admin should not have super user permissions for this institution!'    
         )
         self.assertEquals(
@@ -502,11 +581,11 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
         invite = invite.key.get()
 
         self.assertTrue(
-            hasAdminPermissions(admin, institution.key.urlsafe()), 
+            has_admin_permissions(admin, institution.key.urlsafe()), 
             'Admin must have super user permissions for this institution!'
         )
         self.assertFalse(
-            hasAdminPermissions(new_admin, institution.key.urlsafe()),
+            has_admin_permissions(new_admin, institution.key.urlsafe()),
             'New_admin should not have super user permissions for this institution!'
         )
         self.assertEquals(
@@ -540,7 +619,7 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
         institution.add_member(new_admin)
 
         admin.add_institution_admin(institution.key)
-        addAdminPermission(admin, institution.key.urlsafe())
+        add_admin_permission(admin, institution.key.urlsafe())
 
         institution.put()
         admin.put()
@@ -548,11 +627,11 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
     
         invite = mocks.create_invite(admin, institution.key, 'USER_ADM', new_admin.key.urlsafe())
         self.assertTrue(
-            hasAdminPermissions(admin, institution.key.urlsafe()), 
+            has_admin_permissions(admin, institution.key.urlsafe()), 
             'Admin must have super user permissions for this institution!'
         )
         self.assertFalse(
-            hasAdminPermissions(new_admin, institution.key.urlsafe()),
+            has_admin_permissions(new_admin, institution.key.urlsafe()),
             'New_admin should not have super user permissions for this institution!'
         )
         self.assertEquals(
@@ -569,11 +648,11 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
         invite = invite.key.get()
 
         self.assertTrue(
-            hasAdminPermissions(admin, institution.key.urlsafe()),
+            has_admin_permissions(admin, institution.key.urlsafe()),
             'Admin must have super user permissions for this institution!'
         )
         self.assertFalse(
-            hasAdminPermissions(new_admin, institution.key.urlsafe()),
+            has_admin_permissions(new_admin, institution.key.urlsafe()),
             'New_admin should not have super user permissions for this institution!'
         )
         self.assertEquals(

--- a/backend/test/invite_user_adm_handler_test.py
+++ b/backend/test/invite_user_adm_handler_test.py
@@ -410,7 +410,6 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
         verify_token._mock_return_value = {'email': new_admin.email[0]}
         invite = mocks.create_invite(admin, second_inst.key, 'USER_ADM', new_admin.key.urlsafe())
 
-        # Permissions of admin before transferring administration
         self.assertTrue(
             has_admin_permissions(admin, institution.key.urlsafe()),
             'Admin must have admin permissions for this institution!'
@@ -427,11 +426,9 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
             has_admin_permissions(admin, third_inst.key.urlsafe()),
             'Admin must have admin user permissions for third_inst institution!'
         )
-
-        # Permissions of new_admin before transferring administration
         self.assertFalse(
             has_admin_permissions(new_admin, institution.key.urlsafe()),
-            'Admin must have admin permissions for this institution!'
+            'Admin must have not admin permissions for this institution!'
         )
         self.assertFalse(
             has_admin_permissions(new_admin, second_inst.key.urlsafe()),
@@ -455,7 +452,6 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
         new_admin = new_admin.key.get()
         invite = invite.key.get()
 
-        # Admin permissions after transferring administration
         self.assertTrue(
             has_admin_permissions(admin, institution.key.urlsafe()),
             'admin must have super user permissions for this institution!'
@@ -472,8 +468,6 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
             has_admin_permissions(admin, third_inst.key.urlsafe()),
             'Admin must have super user permissions for third_inst institution!'    
         )
-
-        # New_admin permissions after transfering administration
         self.assertTrue(
             has_admin_permissions(new_admin, second_inst.key.urlsafe()),
             'new_admin must have admin user permissions for second_inst institution!'
@@ -547,19 +541,19 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
 
         self.assertFalse(
             has_admin_permissions(admin, institution.key.urlsafe()),
-            'admin must have super user permissions for this institution!'
+            'admin must have super not user permissions for this institution!'
         )
         self.assertFalse(
             has_super_user_permissions(admin, institution.key.urlsafe()),
-            'admin must have super user permissions for this institution!'
+            'admin must have not super user permissions for this institution!'
         )
         self.assertTrue(
             has_admin_permissions(new_admin, institution.key.urlsafe()),
-            'Admin must have super user permissions for second_inst institution!'
+            'new_admin must have super user permissions for second_inst institution!'
         )
         self.assertTrue(
             has_super_user_permissions(new_admin, institution.key.urlsafe()),
-            'Admin must have super user permissions for second_inst institution!'
+            'new_admin must have super user permissions for second_inst institution!'
         )
 
     @patch('utils.verify_token', return_value={'email': 'usr_test@test.com'})

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -349,7 +349,7 @@ class TransferAdminPermissionsHandler(BaseHandler):
                 permissions_filtered = filter_permissions_to_remove(admin, permissions, institution_key)
                 self.remove_permissions(admin, permissions_filtered)
 
-            if(institution.name == 'Complexo Industrial da Saude'):
+            if(institution.name == 'Departamento do Complexo Industrial e Inovacao em Saude'):
                 permissions_super_user = ["analyze_request_inst", "send_invite_inst"]
                 for permission in permissions_super_user:
                     admin.remove_permission(permission, institution.key.urlsafe())

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -348,7 +348,10 @@ class TransferAdminPermissionsHandler(BaseHandler):
             if (not institution.parent_institution) or (not is_admin_of_parent_inst(admin, institution.parent_institution.urlsafe())):
                 permissions_filtered = filter_permissions_to_remove(admin, permissions, institution_key)
                 self.remove_permissions(admin, permissions_filtered)
-
+            
+            """"TODO: Change how to check if user is super user.
+            @author: Maiana Brito 04/04/2018
+            """
             if(institution.name == 'Departamento do Complexo Industrial e Inovacao em Saude'):
                 permissions_super_user = ["analyze_request_inst", "send_invite_inst"]
                 for permission in permissions_super_user:

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -1,7 +1,6 @@
 """Send notifications handler."""
 import webapp2
 import json
-import permissions
 from firebase import send_notification
 from google.appengine.api import mail
 import logging
@@ -14,6 +13,7 @@ from utils import json_response
 from service_messages import send_message_notification
 from service_messages import send_message_email
 from jinja2 import Environment, FileSystemLoader
+from permissions import DEFAULT_SUPER_USER_PERMISSIONS
 
 
 def should_remove(user, institution_key, current_inst_key):
@@ -353,8 +353,7 @@ class TransferAdminPermissionsHandler(BaseHandler):
             @author: Maiana Brito 04/04/2018
             """
             if(institution.name == 'Departamento do Complexo Industrial e Inovacao em Saude'):
-                permissions_super_user = ["analyze_request_inst", "send_invite_inst"]
-                for permission in permissions_super_user:
+                for permission in DEFAULT_SUPER_USER_PERMISSIONS:
                     admin.remove_permission(permission, institution.key.urlsafe())
 
             new_admin.put()

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -341,12 +341,18 @@ class TransferAdminPermissionsHandler(BaseHandler):
         @ndb.transactional(xg=True, retries=10)
         def save_changes(admin, new_admin, institution):
             permissions = institution.get_all_hierarchy_admin_permissions()
+            permissions = institution.get_super_user_admin_permissions(permissions)
             institution.set_admin(new_admin.key)
             self.add_permissions(new_admin, permissions)
             
             if (not institution.parent_institution) or (not is_admin_of_parent_inst(admin, institution.parent_institution.urlsafe())):
                 permissions_filtered = filter_permissions_to_remove(admin, permissions, institution_key)
                 self.remove_permissions(admin, permissions_filtered)
+
+            if(institution.name == 'Complexo Industrial da Saude'):
+                permissions_super_user = ["analyze_request_inst", "send_invite_inst"]
+                for permission in permissions_super_user:
+                    admin.remove_permission(permission, institution.key.urlsafe())
 
             new_admin.put()
             admin.put()


### PR DESCRIPTION
**Feature/Bug description:** When transferring administration of the institution that turns the user an super user the permissions type super user should be transferring too.

**Solution:** Create verification and transferring permissions.

**TODO/FIXME:** n/a