### PR TITLE
Fix null event in event page

### DIFF
--- a/frontend/event/eventDetailsDirective.js
+++ b/frontend/event/eventDetailsDirective.js
@@ -59,7 +59,8 @@
         };
 
         eventCtrl.canChange = function canChange(event) {
-            return event && eventCtrl.isEventAuthor(event) || isInstitutionAdmin(event);
+            if(event)
+                return eventCtrl.isEventAuthor(event) || isInstitutionAdmin(event);
         };
 
         eventCtrl.canEdit = function canEdit(event) {


### PR DESCRIPTION
**Feature/Bug description:** When the event page is opened the console displays the following error: cannot read property 'institution_key' of null.

**Solution:** Adding verification if the event is defined.

**TODO/FIXME:** n/a