### PR TITLE
Fix change institution profile color

### DIFF
--- a/frontend/home/homeController.js
+++ b/frontend/home/homeController.js
@@ -245,7 +245,7 @@
         };
 
         function loadProfile(){
-            colorPickerCtrl.newUser =  Utils.clone(colorPickerCtrl.user);
+            colorPickerCtrl.newUser =  _.cloneDeep(colorPickerCtrl.user);
 
             colorPickerCtrl.newProfile = _.find(colorPickerCtrl.newUser.institution_profiles, function (profile) {
                 return profile.institution_key === colorPickerCtrl.newUser.current_institution.key;

--- a/support/auth/utils.js
+++ b/support/auth/utils.js
@@ -1,21 +1,6 @@
 "use strict";
 
 var Utils = {
-    clone: function clone(obj) {
-        var copy;
-    
-        if (null == obj || "object" != typeof obj) return obj;
-    
-        if (obj instanceof Object) {
-            copy = {};
-            for (var attr in obj) {
-                if (obj.hasOwnProperty(attr)) copy[attr] = clone(obj[attr]);
-            }
-            return copy;
-        }
-    
-        throw new Error("Unable to copy obj! Its type isn't supported.");
-    },
     addHttpsToUrl :  function addHttpsToUrl(text, urls) {
         if(urls) {
             var http = "http://";


### PR DESCRIPTION
**Feature/Bug description:** When you change the cover color of an institution and enter the user edit information page and try to edit an institution's profile, the editing dialog does not open.

**Solution:** I changed how to clone the user when the color change dialog of the institution cover is opened because the cloning method previously used could not clone lists, and this caused bugs in the edition of user profiles because of this method transformant lists in objects which are not lists.

**TODO/FIXME:** n/a