### PR TITLE
Fix deleted event accessible by URL

### DIFF
--- a/backend/handlers/event_handler.py
+++ b/backend/handlers/event_handler.py
@@ -36,6 +36,9 @@ class EventHandler(BaseHandler):
         event_key = ndb.Key(urlsafe=url_string)
         event = event_key.get()
 
+        Utils._assert(event.state == 'deleted', 
+            "The event has been deleted.", NotAuthorizedException)
+
         assert type(event) is Event, "Key is not an Event"
         event_json = Event.make(event)
 

--- a/backend/handlers/event_handler.py
+++ b/backend/handlers/event_handler.py
@@ -72,6 +72,10 @@ class EventHandler(BaseHandler):
         patch = self.request.body
 
         event = ndb.Key(urlsafe=key).get()
+
+        Utils._assert(event.state == 'deleted',
+                      "The event has been deleted.", NotAuthorizedException)
+
         event.verify_patch(patch)
 
         """Apply patch."""

--- a/frontend/utils/messageService.js
+++ b/frontend/utils/messageService.js
@@ -30,7 +30,8 @@
             "Error! An invitation is already being processed for this institution!": "Um convite desse mesmo tipo já está sendo processado para essa instituição.",
             "Error! The sender is already a member": "O usuário já é um membro.",
             "Error! The sender is already invited": "O usuário já foi convidado para ser membro dessa instituição.",
-            "Error! User is not allowed to send invites": "O usuário não tem permissão para enviar convites"
+            "Error! User is not allowed to send invites": "O usuário não tem permissão para enviar convites",
+            "Error! The event has been deleted.": "Esse evento foi removido"
         };
 
         service.showToast = function showToast(message) {


### PR DESCRIPTION
**Feature/Bug description:**
When the event was deleted the user still could access it by its url.
**Solution:**
I've checked the event's state before answer the request.

**TODO/FIXME:** n/a