### PR TITLE
Fix delete event

### DIFF
--- a/frontend/event/eventDetailsDirective.js
+++ b/frontend/event/eventDetailsDirective.js
@@ -45,7 +45,7 @@
             let promise = EventService.deleteEvent(event);
             promise.then(function success() {
                 MessageService.showToast('Evento removido com sucesso!');
-                $state.go('app.user.events');
+                eventCtrl.event.state = "deleted";
             }, function error(response) {
                 MessageService.showToast(response.data.msg);
             });
@@ -131,6 +131,10 @@
                 return startDay === endDay && !eventCtrl.endInOtherMonth();
             }
         };
+
+        eventCtrl.isDeleted = () => {
+            return eventCtrl.event ? eventCtrl.event.state === 'deleted' : true;
+        }
 
         function isInstitutionAdmin(event) {
             if(event.institution_key)

--- a/frontend/event/event_page.html
+++ b/frontend/event/event_page.html
@@ -1,7 +1,12 @@
-<md-content layout="row" id="content" class="body custom-scrollbar">
+<md-content layout="row" id="content" class="body custom-scrollbar" ng-if="!eventCtrl.isDeleted()">
   <div layout="row" flex flex-gt-xs="95" layout-align="end start">
     <div flex flex-gt-xs="95">
       <event-details event="eventCtrl.event" is-event-page=true></event-details>
     </div>
   </div>
 </md-content>
+<div layout="row" layout-align="center center" ng-if="eventCtrl.isDeleted()" layout-fill>
+  <div layout="column" layout-align="center center">
+      <h2>Esse evento foi removido</h2>
+  </div>
+</div>

--- a/frontend/test/specs/eventDetailsControllerSpec.js
+++ b/frontend/test/specs/eventDetailsControllerSpec.js
@@ -86,6 +86,7 @@
 
         it('Should remove event of events', function () {
             httpBackend.expect('DELETE', EVENTS_URI + '/' + event.key).respond();
+            eventCtrl.event = other_event;
             eventCtrl.confirmDeleteEvent("$event", other_event);
             httpBackend.flush();
 


### PR DESCRIPTION
**Feature/Bug description:**
The user was being redirected to the event's page where there was an inconsistency because the event was still there.

**Solution:**
I've set the event's state to deleted in the success function and changed the html to work according to the event's state.

![screenshot from 2018-04-06 09-46-04](https://user-images.githubusercontent.com/23387866/38422437-282efe1a-3981-11e8-82d8-764476e8e144.png)


**TODO/FIXME:** n/a