### PR TITLE
Fix tutorial appearing in invite page

### DIFF
--- a/frontend/invites/newInviteController.js
+++ b/frontend/invites/newInviteController.js
@@ -67,7 +67,7 @@
                     newInviteCtrl.user.changeInstitution(newInviteCtrl.institution);
                     AuthService.save();
                     $state.go("app.user.home");
-                    showAlert(event);
+                    _.isEmpty(newInviteCtrl.user.invites) && showAlert(event);
                 }, function error(response) {
                     MessageService.showToast(response.data.msg);
                 });


### PR DESCRIPTION
**Feature/Bug description:** When the user has more than one invite, the tutorial of cis appears above the next invite.

**Solution:** Adding verification if the user has no invites before calling the tutorial dialog.

**TODO/FIXME:** n/a