### PR TITLE
Refact the method get_deciis 

### DIFF
--- a/backend/handlers/institution_followers_handler.py
+++ b/backend/handlers/institution_followers_handler.py
@@ -64,7 +64,7 @@ class InstitutionFollowersHandler(BaseHandler):
         Utils._assert(institution.name == 'Ministério da Saúde',
                       "The institution can not be unfollowed", NotAuthorizedException)
 
-        Utils._assert(institution.name == 'Departamento do Complexo Industrial e Inovação em Saúde',
+        Utils._assert(institution.trusted == True,
                       "The institution can not be unfollowed", NotAuthorizedException)
 
         if(not type(institution) is Institution):

--- a/backend/test/institution_request_collection_handler_test.py
+++ b/backend/test/institution_request_collection_handler_test.py
@@ -34,6 +34,7 @@ class InstitutionRequestCollectionHandlerTest(TestBaseHandler):
         self.new_inst = mocks.create_institution()
         self.new_inst.name = "Departamento do Complexo Industrial e Inovação em Saúde"
         self.new_inst.acronym = "DECIIS"
+        self.new_inst.trusted = True
         self.new_inst.address = self.address
         self.new_inst.put()
 

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -173,13 +173,9 @@ def get_health_ministry():
     query = Institution.query(Institution.name == "Ministério da Saúde", Institution.acronym == "MS")
     return query.get()
 
-"""TODO: Refactor this function to get the DECIIS Institution, making a get for 
-    the institution with that field trusted is equal to true.
-    And certificate that DECIIS is the unique institution trusted in system.
-    @author: Mayza Nunes 05/04/2018"""
 def get_deciis():
     """Get health ministry institution."""
-    query = Institution.query(Institution.name == "Departamento do Complexo Industrial e Inovação em Saúde", Institution.acronym == "DECIIS")
+    query = Institution.query(Institution.trusted == True)
     return query.get()
 
 def json_response(method):


### PR DESCRIPTION
**Feature/Bug description:** The method to get the super-institution DECIIS, get the institution filtered by name. But if the name of institution change, the logic doesn't work anymore.

**Solution:** Get the super institution filtering by the flag trusted

**TODO/FIXME:** Change the DECIIS flag trusted to true on production environment.