### PR TITLE
Fix missing error function in removeInst

### DIFF
--- a/frontend/institution/institutionController.js
+++ b/frontend/institution/institutionController.js
@@ -428,6 +428,8 @@
                     $state.go("app.user.home");
                 }
                 MessageService.showToast("Instituição removida com sucesso.");
+            }, function error(response) {
+                MessageService.showToast(response.data.msg);
             });
         };
 

--- a/frontend/utils/messageService.js
+++ b/frontend/utils/messageService.js
@@ -31,7 +31,8 @@
             "Error! The sender is already a member": "O usuário já é um membro.",
             "Error! The sender is already invited": "O usuário já foi convidado para ser membro dessa instituição.",
             "Error! User is not allowed to send invites": "O usuário não tem permissão para enviar convites",
-            "Error! The event has been deleted.": "Esse evento foi removido"
+            "Error! The event has been deleted.": "Esse evento foi removido",
+            "Error! User is not allowed to remove institution": "O usuário não tem permissão para remover essa instituição."
         };
 
         service.showToast = function showToast(message) {


### PR DESCRIPTION
**Feature/Bug description:**
It was missing an error function that should send a message to the user.

**Solution:**
I've passed a second function to .then that handles with possible error and called showToast inside of it.

![screenshot from 2018-04-09 17-18-20](https://user-images.githubusercontent.com/23387866/38521074-f879f034-3c1a-11e8-84e3-26128cd0d233.png)


**TODO/FIXME:** n/a