### PR TITLE
Centralize event month name

### DIFF
--- a/frontend/event/event_details.html
+++ b/frontend/event/event_details.html
@@ -14,7 +14,7 @@
               {{eventDetailsCtrl.event.start_time | amUtc | amLocal | amDateFormat:'DD'}}</h1>
           </div>
             <md-divider style="border: 1px; border-style: solid; color: #03b3a1;"></md-divider>
-          <div layout="row" md-colors="{background: 'default-grey-200'}" style="padding: 0 10px 0 10px">
+          <div layout="row" md-colors="{background: 'default-grey-200'}" layout-align="center center">
             <h3 md-colors="{color:'default-teal-400'}" ng-if="eventDetailsCtrl.endInOtherMonth()">
               {{eventDetailsCtrl.event.start_time | amUtc | amLocal | amDateFormat:'MMM' | uppercase}}
               | {{eventDetailsCtrl.event.end_time | amUtc | amLocal | amDateFormat:'MMM' | uppercase}}
@@ -27,7 +27,7 @@
       </md-card-content>
       <md-card-content flex-gt-xs layout="column">
           <a href class="md-title hyperlink" ng-click="eventDetailsCtrl.goToEvent(eventDetailsCtrl.event)">
-              <span style="color: white;">{{ eventDetailsCtrl.event.title | uppercase}}</span>
+            <span style="color: white;">{{ eventDetailsCtrl.event.title | uppercase}}</span>
           </a>
           <span style="color: white; margin-top: auto;">Organizado por {{eventDetailsCtrl.event.institution_name}}</span>
       </md-card-content>


### PR DESCRIPTION
**Feature/Bug description:** When the begging and end date of the event was in the same month, the month name was not centralized

![screenshot from 2018-04-10 09-40-47](https://user-images.githubusercontent.com/13683704/38572032-5e93d346-3cc8-11e8-8c61-9bb8ee923fb9.png)

**Solution:** The element padding was replaced by the directive layout-alignment

**TODO/FIXME:** n/a

**Event on event page**
![screenshot from 2018-04-10 13-57-56](https://user-images.githubusercontent.com/13683704/38572047-68dfba68-3cc8-11e8-9e65-8d76e0d3f6ec.png)

**Event on event datails page**
![screenshot from 2018-04-10 13-58-06](https://user-images.githubusercontent.com/13683704/38572053-6b6f109e-3cc8-11e8-9f4a-9f5d89d51383.png)
