### PR TITLE
Use ObserverRecorderService for generate jsonpatch observer

### DIFF
--- a/frontend/event/eventController.js
+++ b/frontend/event/eventController.js
@@ -89,7 +89,7 @@
     });
 
     app.controller('EventDialogController', function EventDialogController(MessageService, brCidadesEstados,
-            ImageService, AuthService, EventService, $state, $rootScope, $mdDialog, $http, $q) {
+            ImageService, AuthService, EventService, $state, $rootScope, $mdDialog, $http, $q, ObserverRecorderService) {
         var dialogCtrl = this;
 
         dialogCtrl.loading = false;
@@ -158,7 +158,7 @@
             var event = new Event(dialogCtrl.event, dialogCtrl.user.current_institution.key);
             if(event.isValid()) {
                 dialogCtrl.loading = true;
-                var patch = jsonpatch.generate(dialogCtrl.observer);
+                var patch = ObserverRecorderService.generate(dialogCtrl.observer);
                 var formatedPatch = formatPatch(generatePatch(patch, event));
                 EventService.editEvent(dialogCtrl.event.key, formatedPatch)
                 .then(function success() {
@@ -413,7 +413,7 @@
         }
 
         function initPatchObserver() {
-            dialogCtrl.observer = jsonpatch.observe(dialogCtrl.event);
+            dialogCtrl.observer = ObserverRecorderService.register(dialogCtrl.event);
         }
 
         function loadEventDates() {

--- a/frontend/institution/configInstDirective.js
+++ b/frontend/institution/configInstDirective.js
@@ -3,7 +3,7 @@
     var app = angular.module("app");
     app.controller("ConfigInstController", function ConfigInstController(AuthService, InstitutionService, CropImageService,$state,
             $mdToast, $mdDialog, $http, InviteService, ImageService, $rootScope, MessageService, PdfService, $q, $window,
-            RequestInvitationService, brCidadesEstados) {
+            RequestInvitationService, brCidadesEstados, ObserverRecorderService) {
 
         var configInstCtrl = this;
         var institutionKey = $state.params.institutionKey;
@@ -247,7 +247,7 @@
         }
 
         function patchIntitution() {
-            var patch = jsonpatch.generate(observer);
+            var patch = ObserverRecorderService.generate(observer);
             InstitutionService.update(institutionKey, patch).then(
                 function success() {
                     if(configInstCtrl.newInstitution)
@@ -415,7 +415,7 @@
                 configInstCtrl.newInstitution = response.data;
                 configInstCtrl.suggestedName = configInstCtrl.newInstitution.name;
                 currentPortfoliourl = configInstCtrl.newInstitution.portfolio_url;
-                observer = jsonpatch.observe(configInstCtrl.newInstitution);
+                observer = ObserverRecorderService.register(configInstCtrl.newInstitution);
                 loadAddress(); 
                 setDefaultPhotoUrl();
                 configInstCtrl.loading = false;

--- a/frontend/invites/newInviteController.js
+++ b/frontend/invites/newInviteController.js
@@ -4,7 +4,7 @@
    var app = angular.module('app');
 
    app.controller('NewInviteController', function NewInviteController(InstitutionService, AuthService, UserService, InviteService, $mdToast,
-    $mdDialog, MessageService, $state) {
+    $mdDialog, MessageService, ObserverRecorderService, $state) {
         var newInviteCtrl = this;
 
         newInviteCtrl.institution = null;
@@ -50,7 +50,7 @@
             newInviteCtrl.user.addProfile(profile);
             newInviteCtrl.user.name = getCurrentName();
             AuthService.save();
-            var patch = jsonpatch.generate(observer);
+            var patch = ObserverRecorderService.generate(observer);
             return patch;
         };
 
@@ -156,8 +156,7 @@
         }
 
         function loadInvite(){
-            observer = jsonpatch.observe(newInviteCtrl.user);
-            jsonpatch.unobserve(newInviteCtrl.user.current_institution, observer);
+            observer = ObserverRecorderService.register(newInviteCtrl.user);
             newInviteCtrl.checkUserName();
             InviteService.getInvite(newInviteCtrl.inviteKey).then(function success(response) {
                 newInviteCtrl.invite = new Invite(response.data);

--- a/frontend/post/postDirective.js
+++ b/frontend/post/postDirective.js
@@ -5,7 +5,8 @@
     var app = angular.module("app");
 
     app.controller("PostController", function PostController($mdDialog, PostService, AuthService,
-            $mdToast, $rootScope, ImageService, MessageService, $q, $scope, $state, PdfService, SubmitFormListenerService) {
+            $mdToast, $rootScope, ImageService, MessageService, $q, $scope, $state, PdfService, SubmitFormListenerService,
+            ObserverRecorderService) {
         var postCtrl = this;
 
         postCtrl.post = {};
@@ -373,7 +374,7 @@
         (function main() {
             if($scope.isEditing) {
                 postCtrl.createEditedPost($scope.originalPost);
-                observer = jsonpatch.observe(postCtrl.post);
+                observer = ObserverRecorderService.register(postCtrl.post);
             }
             postCtrl.typePost = 'Common';
         })();

--- a/frontend/post/postDirective.js
+++ b/frontend/post/postDirective.js
@@ -5,8 +5,7 @@
     var app = angular.module("app");
 
     app.controller("PostController", function PostController($mdDialog, PostService, AuthService,
-            $mdToast, $rootScope, ImageService, MessageService, $q, $scope, $state, PdfService, SubmitFormListenerService,
-            ObserverRecorderService) {
+            $mdToast, $rootScope, ImageService, MessageService, $q, $scope, $state, PdfService, SubmitFormListenerService) {
         var postCtrl = this;
 
         postCtrl.post = {};
@@ -25,7 +24,6 @@
                             'number_votes': 0,
                             'voters': []
                             };
-        var observer;
         var timelineContent = document.getElementById('content');
         var MAXIMUM_PDF_SIZE = 5242880; // 5Mb in bytes
 
@@ -374,7 +372,6 @@
         (function main() {
             if($scope.isEditing) {
                 postCtrl.createEditedPost($scope.originalPost);
-                observer = ObserverRecorderService.register(postCtrl.post);
             }
             postCtrl.typePost = 'Common';
         })();


### PR DESCRIPTION
**Feature/Bug description:** The way to create the object watchers to later create the modification patch is old, still using the jsonpatch library directly.

**Solution:** I have changed the way I generate watchers, instead of directly using the jsonpatch library, now uses the observerRecorderService service, which was created to better manage these observers.

**TODO/FIXME:** n/a