### PR TITLE
Fix notification when the author share yourself event 

### DIFF
--- a/backend/handlers/post_collection_handler.py
+++ b/backend/handlers/post_collection_handler.py
@@ -97,13 +97,14 @@ class PostCollectionHandler(BaseHandler):
             enqueue_task('post-notification', params)
         elif post.shared_event:
             shared_event = post.shared_event.get()
-            send_message_notification(
-                shared_event.author_key.urlsafe(),
-                user.key.urlsafe(),
-                'SHARED_EVENT',
-                post.key.urlsafe(),
-                user.current_institution
-            )
+            if shared_event.author_key != user.key.urlsafe():
+                send_message_notification(
+                    shared_event.author_key.urlsafe(),
+                    user.key.urlsafe(),
+                    'SHARED_EVENT',
+                    post.key.urlsafe(),
+                    user.current_institution
+                )
 
 
         self.response.write(json.dumps(post.make(self.request.host)))


### PR DESCRIPTION
**Feature/Bug description:** When the event author shares your event, you receive the notification.

**Solution:** Added verification that not send the notification to event author.

**TODO/FIXME:** n/a