### PR TITLE
Fix long url bigger than limit of text in post

### DIFF
--- a/frontend/post/postDetailsDirective.js
+++ b/frontend/post/postDetailsDirective.js
@@ -8,7 +8,7 @@
 
         var postDetailsCtrl = this;
 
-        var LIMIT_POST_CHARACTERS = 2000;
+        var LIMIT_POST_CHARACTERS = 1000;
 
         postDetailsCtrl.showComments = false;
         postDetailsCtrl.savingComment = false;

--- a/frontend/utils/utils.js
+++ b/frontend/utils/utils.js
@@ -64,15 +64,17 @@ var Utils = {
         return indexes;
     },
     limitString : function limitString(string, limit) {
-        var undefinedIndex = -1;
-        var endIndexesOfLast = this.getIndexesOf("</a>", string);
-        var indexOfLastAboveLimit = endIndexesOfLast.findIndex((index) => index >= limit);
-        if(indexOfLastAboveLimit !== undefinedIndex) {
-            var shiftToCloseTag = 4;
-            limit = endIndexesOfLast[indexOfLastAboveLimit] + shiftToCloseTag;
+        if(string) {
+            var undefinedIndex = -1;
+            var endIndexesOfLast = this.getIndexesOf("</a>", string);
+            var indexOfLastAboveLimit = endIndexesOfLast.findIndex((index) => index >= limit);
+            if(indexOfLastAboveLimit !== undefinedIndex) {
+                var shiftToCloseTag = 4;
+                limit = endIndexesOfLast[indexOfLastAboveLimit] + shiftToCloseTag;
+            }
+            return string && string.length > limit ?
+                string.substring(0, limit+1) + "..." : string;
         }
-        return string && string.length > limit ?
-            string.substring(0, limit+1) + "..." : string;
     },
 
     generateLink : function generateLink(url){

--- a/frontend/utils/utils.js
+++ b/frontend/utils/utils.js
@@ -52,14 +52,13 @@ var Utils = {
         config.url = config.url.replace(restApiRegex, restApiUrl + '/api/$1');
     },
     getIndexesOf : function getIndexesOf(substring, string) {
-        if (substring.length == 0) {
-            return [];
-        }
-        var startIndex = 0, index, indexes = [];
-
-        while((index = string.indexOf(substring, startIndex)) > -1) {
-            indexes.push(index);
-            startIndex = index + substring.length;
+        var indexes = [];
+        if (substring.length !== 0) {
+            var startIndex = 0, index;
+            while((index = string.indexOf(substring, startIndex)) > -1) {
+                indexes.push(index);
+                startIndex = index + substring.length;
+            }
         }
         return indexes;
     },

--- a/frontend/utils/utils.js
+++ b/frontend/utils/utils.js
@@ -65,7 +65,6 @@ var Utils = {
     },
     limitString : function limitString(string, limit) {
         var undefinedIndex = -1;
-        var initIndexesOfLastUrl = this.getIndexesOf("<a href=", string);
         var endIndexesOfLast = this.getIndexesOf("</a>", string);
         var indexOfLastAboveLimit = endIndexesOfLast.findIndex((index) => index >= limit);
         if(indexOfLastAboveLimit !== undefinedIndex) {

--- a/frontend/utils/utils.js
+++ b/frontend/utils/utils.js
@@ -51,10 +51,29 @@ var Utils = {
 
         config.url = config.url.replace(restApiRegex, restApiUrl + '/api/$1');
     },
+    getIndexesOf : function getIndexesOf(substring, string) {
+        if (substring.length == 0) {
+            return [];
+        }
+        var startIndex = 0, index, indexes = [];
 
-    limitString : function limitString(string, limit){
-            return string && string.length > limit ?  
-                string.substring(0, limit+1) + "..." : string;
+        while((index = string.indexOf(substring, startIndex)) > -1) {
+            indexes.push(index);
+            startIndex = index + substring.length;
+        }
+        return indexes;
+    },
+    limitString : function limitString(string, limit) {
+        var undefinedIndex = -1;
+        var initIndexesOfLastUrl = this.getIndexesOf("<a href=", string);
+        var endIndexesOfLast = this.getIndexesOf("</a>", string);
+        var indexOfLastAboveLimit = endIndexesOfLast.findIndex((index) => index >= limit);
+        if(indexOfLastAboveLimit !== undefinedIndex) {
+            var shiftToCloseTag = 4;
+            limit = endIndexesOfLast[indexOfLastAboveLimit] + shiftToCloseTag;
+        }
+        return string && string.length > limit ?
+            string.substring(0, limit+1) + "..." : string;
     },
 
     generateLink : function generateLink(url){

--- a/frontend/utils/utils.js
+++ b/frontend/utils/utils.js
@@ -72,7 +72,7 @@ var Utils = {
                 var shiftToCloseTag = 4;
                 limit = endIndexesOfLast[indexOfLastAboveLimit] + shiftToCloseTag;
             }
-            return string && string.length > limit ?
+            return string.length > limit ?
                 string.substring(0, limit+1) + "..." : string;
         }
     },


### PR DESCRIPTION
**Feature/Bug description:** If has a bigger URL in a post and this URL exceeds the limit of chars to display in the timeline the post shows the HTML tags and don't generate a hyperlink.

**Solution:** Creating an algorithm to find the HTML tags to show the hyperlink and verify if the end of tags is above of limit of the text, isolate the position of the first occurrence which exceeds the limit of text and replaces the limit of text to support the complete hyperlink.

**TODO/FIXME:** n/a