### PR TITLE
Fix the align of next events in mozilla firefox

### DIFF
--- a/frontend/home/home.html
+++ b/frontend/home/home.html
@@ -42,8 +42,8 @@
                 </center>
               </div>
               <div layout="row" ng-repeat="event in homeCtrl.events | filter: homeCtrl.eventInProgress" class="event-item">
-                <div layout="row">
-                  <div class="rounded-circle event-date">
+                <div layout="column">
+                  <div layout-align="center center" style="padding: 3px;" class="rounded-circle event-date">
                     <span class="event-day">
                       {{ event.start_time | amUtc | amLocal | amDateFormat:'DD'}}
                     </span>

--- a/frontend/styles/custom.css
+++ b/frontend/styles/custom.css
@@ -656,18 +656,16 @@ a:active {
 }
 
 .event-item .event-day {
-    position: relative;
-    top: 5px;
+    margin-bottom: -35px;
+    font-size: 23px;
     font-weight: bold;
-    font-size: 20px;
+    margin: 1px;
 }
 
 .event-item .event-month {
-    position: relative;
-    top: 5px;
-    margin: 10px;
     font-weight: 300;
     font-size: 10px;
+    margin: 1px;
 }
 
 .section-menu {


### PR DESCRIPTION
**Feature/Bug description:** The right navbar "Próximos eventos" contains icons not aligned in Mozilla Firefox.

![screenshot from 2018-04-12 16-25-24](https://user-images.githubusercontent.com/20300259/38699516-98930948-3e6e-11e8-8748-0c931822469e.png)

**Solution:** Adding layout-align and changing the CSS classes to work fine in Mozilla Firefox and Chrome too.

![screenshot from 2018-04-12 16-24-59](https://user-images.githubusercontent.com/20300259/38699562-b7c7f468-3e6e-11e8-91ce-f50973b54d79.png)


**TODO/FIXME:** n/a