### PR TITLE
Fix followers institution handler test and request user test

### DIFF
--- a/backend/test/followers_institution_handler_test.py
+++ b/backend/test/followers_institution_handler_test.py
@@ -26,7 +26,6 @@ class InstitutionFollowersHandlerTest(TestBaseHandler):
         """Test that user member try unfollow the institution."""
         user = mocks.create_user(USER['email'])
         institution = mocks.create_institution()
-        institution.address = mocks.create_address()
         user.follow(institution.key)
         user.add_institution(institution.key)
         institution.followers = [user.key]
@@ -56,7 +55,6 @@ class InstitutionFollowersHandlerTest(TestBaseHandler):
         """Test that user member try unfollow the health ministry institution."""
         user = mocks.create_user(USER['email'])
         institution = mocks.create_institution()
-        institution.address = mocks.create_address()
         user.follow(institution.key)
         user.add_institution(institution.key)
         institution.followers = [user.key]
@@ -80,15 +78,11 @@ class InstitutionFollowersHandlerTest(TestBaseHandler):
             "Expected exception message must be equal to Error! The institution can not be unfollowed")
 
         
-
-    # TODO: fix this test because not work after add fiel 'description' in search_institution.py
-    # Author: Tiago Pereira - 22/12/2017
-'''  @patch('utils.verify_token', return_value=USER)
+    @patch('utils.verify_token', return_value=USER)
     def test_delete(self, verify_token):
         """Test the institution_follower_handler delete method."""
         user = mocks.create_user(USER['email'])
         institution = mocks.create_institution()
-        institution.address = mocks.create_address()
         user.follow(institution.key)
         institution.follow(user.key)
         # Assert that the user follows the institution
@@ -115,7 +109,6 @@ class InstitutionFollowersHandlerTest(TestBaseHandler):
         """Test the institution_follower_handler post method."""
         user = mocks.create_user(USER['email'])
         institution = mocks.create_institution()
-        institution.address = mocks.create_address()
         institution.put()
         self.assertEquals(len(institution.followers), 0,
                           "The institution shouldn't have any follower")
@@ -147,4 +140,4 @@ class InstitutionFollowersHandlerTest(TestBaseHandler):
         self.assertEquals(len(institution.followers), 1,
                           "The institution should have a follower")
         self.assertEquals(len(user.follows), 1,
-                          "The user should follow institution") '''
+                          "The user should follow institution")

--- a/backend/test/model_test/request_user_test.py
+++ b/backend/test/model_test/request_user_test.py
@@ -92,9 +92,7 @@ class RequestUserTest(TestBase):
             str(ex.exception),
             'Expected message is The sender is already invited')
 
-    # TODO: fix this test because not work after add fiel 'description' in search_institution.py
-    # Author: Tiago Pereira - 22/12/2017
-'''     def test_make(self):
+    def test_make(self):
         """Test method make."""
         admin_user = mocks.create_user('adminuser@test.com')
         other_user = mocks.create_user('otheruser@test.com')
@@ -116,6 +114,10 @@ class RequestUserTest(TestBase):
         request = RequestUser.create(data)
         request.put()
 
+        REQUIRED_PROPERTIES = ['name', 'address', 'description',
+                               'key', 'photo_url', 'institutional_email',
+                               'phone_number', 'email', 'trusted']
+
         make = {
             'status': 'sent',
             'institution_admin': {
@@ -124,15 +126,12 @@ class RequestUserTest(TestBase):
             'sender': other_user.email,
             'admin_name': admin_user.name,
             'key': request.key.urlsafe(),
-            'institution': {
-                'name': 'inst test',
-                'key': inst_test.key.urlsafe(),
-                'address': dict(inst_test.address)
-            },
+            'institution': inst_test.make(REQUIRED_PROPERTIES),
             'type_of_invite': 'REQUEST_USER',
             'institution_key': inst_test.key.urlsafe(),
             'office': 'teacher',
             'sender_name': 'other_user',
+            'sender_key': other_user.key.urlsafe(),
             'institutional_email': 'otheruser@inst_test.com'
         }
 
@@ -142,6 +141,7 @@ class RequestUserTest(TestBase):
                 make_institution = make[key]
                 request_institution = request_make[key]
                 for inst_key in make_institution.keys():
+
                     self.assertEqual(
                         str(make_institution[inst_key]).encode('utf-8'),
                         str(request_institution[inst_key]).encode('utf-8'),
@@ -152,4 +152,4 @@ class RequestUserTest(TestBase):
                     str(make[key]).encode('utf-8'),
                     str(request_make[key]).encode('utf-8'),
                     "The make object must be equal to variable make"
-                ) '''
+                )

--- a/backend/test/test_base.py
+++ b/backend/test/test_base.py
@@ -38,3 +38,4 @@ class TestBase(unittest.TestCase):
         testbed_instance.init_app_identity_stub()
         testbed_instance.init_mail_stub()
         testbed_instance.init_taskqueue_stub(root_path="..")
+        testbed_instance.init_search_stub()


### PR DESCRIPTION
**Feature/Bug description:** The tests of the follower's institution handler test and request user test were commented because at the time in which form the institution search module was in trouble.

**Solution:** I removed the comments and updated the tests.

**TODO/FIXME:** n/a