### PR TITLE
Fix change color when click delete member notification

### DIFF
--- a/frontend/home/homeController.js
+++ b/frontend/home/homeController.js
@@ -212,6 +212,14 @@
             });
         };
 
+        homeCtrl.getProfileColor = function getProfileColor() {
+            const instKey = homeCtrl.user.current_institution.key;
+            const color = homeCtrl.user.institution_profiles.reduce(
+                (color, profile) => (profile.institution_key === instKey) ? profile.color : color, 'grey');
+            
+            return color;
+        };
+
         (function main() {
             NotificationService.watchPostNotification(homeCtrl.user.key, homeCtrl.setRefreshTimelineButton);
             loadEvents();
@@ -230,7 +238,7 @@
             var promise = ProfileService.editProfile(diff);
             promise.then(function success() {
                 MessageService.showToast('Cor salva com sucesso');
-                colorPickerCtrl.user.current_institution.color = colorPickerCtrl.newProfile.color;
+                //colorPickerCtrl.user.current_institution.color = colorPickerCtrl.newProfile.color;
                 colorPickerCtrl.user.institution_profiles = colorPickerCtrl.newUser.institution_profiles;
                 $mdDialog.cancel();
                 AuthService.save();

--- a/frontend/home/homeController.js
+++ b/frontend/home/homeController.js
@@ -212,14 +212,6 @@
             });
         };
 
-        homeCtrl.getProfileColor = function getProfileColor() {
-            const instKey = homeCtrl.user.current_institution.key;
-            const color = homeCtrl.user.institution_profiles.reduce(
-                (color, profile) => (profile.institution_key === instKey) ? profile.color : color, 'grey');
-            
-            return color;
-        };
-
         (function main() {
             NotificationService.watchPostNotification(homeCtrl.user.key, homeCtrl.setRefreshTimelineButton);
             loadEvents();

--- a/frontend/home/homeController.js
+++ b/frontend/home/homeController.js
@@ -230,7 +230,6 @@
             var promise = ProfileService.editProfile(diff);
             promise.then(function success() {
                 MessageService.showToast('Cor salva com sucesso');
-                //colorPickerCtrl.user.current_institution.color = colorPickerCtrl.newProfile.color;
                 colorPickerCtrl.user.institution_profiles = colorPickerCtrl.newUser.institution_profiles;
                 $mdDialog.cancel();
                 AuthService.save();

--- a/frontend/institution/management_institution_page.html
+++ b/frontend/institution/management_institution_page.html
@@ -11,14 +11,14 @@
         <div class="container">
           <div class="row">
             <div class="card hovercard" 
-            md-colors="{background: institutionCtrl.user.current_institution.color+'-800'}">
+            md-colors="{background: institutionCtrl.user.getProfileColor()+'-800'}">
               <div class="cardheader">
                 <div class="avatar">
                   <img alt="Foto da Instituição" ng-src="{{ institutionCtrl.institution.photo_url || '/app/images/institution.png' }}">
                 </div>
               </div>
               <div class="info" 
-              md-colors="{background: institutionCtrl.user.current_institution.color+'-600'}">
+              md-colors="{background: institutionCtrl.user.getProfileColor()+'-600'}">
                 <div class="desc">
                   <div class="md-title">{{ institutionCtrl.institution.name }}</div>
                 </div>

--- a/frontend/notification/notificationDirective.js
+++ b/frontend/notification/notificationDirective.js
@@ -21,13 +21,17 @@
             "DELETE_MEMBER": {
                 icon: "clear",
                 action: function (properties, notification, event) {
-                    return refreshUserInstitutions(notification);
+                    if (notification.status !== 'READ') {
+                        return refreshUserInstitutions(notification);
+                    }
                 }
             },
             "DELETED_INSTITUTION": {
                 icon: "clear",
                 action: function (properties, notification, event) {
-                    return refreshUserInstitutions(notification);
+                    if (notification.status !== 'READ') {
+                        return refreshUserInstitutions(notification);
+                    }
                 }
             },
             "POST": {

--- a/frontend/test/specs/colorPickerControllerSpec.js
+++ b/frontend/test/specs/colorPickerControllerSpec.js
@@ -6,7 +6,6 @@
     var colorPickerCtrl, scope, httpBackend, mdDialog, http, profileService, rootScope;
 
     var institution = {
-        'color' : 'red',
         'email' : 'institution@gmail.com',
         'key': '123456',
         'institution_key' : '123456'
@@ -71,7 +70,7 @@
             httpBackend.expect('PATCH', '/api/user').respond(200);
             var promise = colorPickerCtrl.saveColor();
             promise.should.be.fulfilled.then(function() {
-                expect(colorPickerCtrl.user.current_institution.color).toBe('blue');
+                expect(colorPickerCtrl.user.getProfileColor()).toBe('blue');
                 expect(colorPickerCtrl.user.institution_profiles).toHaveBeenCalled(change);
             }).should.notify(done);
             httpBackend.flush();

--- a/frontend/user/left_nav.html
+++ b/frontend/user/left_nav.html
@@ -10,14 +10,14 @@
             <div class="container">
               <div class="row">
                   <div class="card hovercard" 
-                      md-colors="{background: homeCtrl.getProfileColor() +'-800'}">
+                      md-colors="{background: homeCtrl.user.getProfileColor() +'-800'}">
                     <div class="cardheader">
                       <div class="avatar">
                         <img style="background-color: white;" alt="Foto do Perfil" ng-src="{{ homeCtrl.user.photo_url }}">
                       </div>
                     </div>
                     <div class="info" 
-                        md-colors="{background: homeCtrl.getProfileColor() +'-600'}">
+                        md-colors="{background: homeCtrl.user.getProfileColor() +'-600'}">
                       <div class="desc">
                         <div class="md-title">{{ homeCtrl.user.name }}</div>
                         <span>{{ homeCtrl.user.current_institution.name }}</span>

--- a/frontend/user/left_nav.html
+++ b/frontend/user/left_nav.html
@@ -10,14 +10,14 @@
             <div class="container">
               <div class="row">
                   <div class="card hovercard" 
-                      md-colors="{background: homeCtrl.user.current_institution.color+'-800'}">
+                      md-colors="{background: homeCtrl.getProfileColor() +'-800'}">
                     <div class="cardheader">
                       <div class="avatar">
                         <img style="background-color: white;" alt="Foto do Perfil" ng-src="{{ homeCtrl.user.photo_url }}">
                       </div>
                     </div>
                     <div class="info" 
-                        md-colors="{background: homeCtrl.user.current_institution.color+'-600'}">
+                        md-colors="{background: homeCtrl.getProfileColor() +'-600'}">
                       <div class="desc">
                         <div class="md-title">{{ homeCtrl.user.name }}</div>
                         <span>{{ homeCtrl.user.current_institution.name }}</span>

--- a/frontend/user/user.js
+++ b/frontend/user/user.js
@@ -177,6 +177,14 @@ User.prototype.goToDifferentInstitution = function goToDifferentInstitution(prev
     });
 };
 
+User.prototype.getProfileColor = function getProfileColor() {
+    const instKey = this.current_institution.key;
+    return this.institution_profiles.reduce(
+        (color, profile) => (profile.institution_key === instKey) ? profile.color : color, 
+        'grey'
+    );
+};
+
 function changeProfileColor(user, institution) {
     var profile = _.find(user.institution_profiles, {
         'institution_key': institution.key

--- a/frontend/user/user.js
+++ b/frontend/user/user.js
@@ -17,7 +17,6 @@ User.prototype.changeInstitution = function changeInstitution(institution) {
     if (this.institutions && this.institutions.length > 0) {
         institution = institution || this.institutions[0];
         this.current_institution = _.find(this.institutions, {'key': institution.key});
-        //changeProfileColor(this, institution);
         window.localStorage.userInfo = JSON.stringify(this);
     }
 };
@@ -170,7 +169,6 @@ User.prototype.goToDifferentInstitution = function goToDifferentInstitution(prev
             const institutionHasBeenDeleted = removeHierarchy === "true" && institution.parent_institution === previousKey;
             if (!(institutionHasBeenDeleted)) {
                 user.current_institution = institution;
-                //changeProfileColor(user, institution);
                 window.localStorage.userInfo = JSON.stringify(this);
             }
         }
@@ -184,14 +182,6 @@ User.prototype.getProfileColor = function getProfileColor() {
         'grey'
     );
 };
-
-function changeProfileColor(user, institution) {
-    var profile = _.find(user.institution_profiles, {
-        'institution_key': institution.key
-    });
-    const color = profile ? profile.color : 'grey';
-    user.current_institution.color = color;
-}
 
 function updateFollowInstitution(follows, institution) {
     var index = _.findIndex(follows, ['key', institution.key]);

--- a/frontend/user/user.js
+++ b/frontend/user/user.js
@@ -17,7 +17,7 @@ User.prototype.changeInstitution = function changeInstitution(institution) {
     if (this.institutions && this.institutions.length > 0) {
         institution = institution || this.institutions[0];
         this.current_institution = _.find(this.institutions, {'key': institution.key});
-        changeProfileColor(this, institution);
+        //changeProfileColor(this, institution);
         window.localStorage.userInfo = JSON.stringify(this);
     }
 };
@@ -170,7 +170,7 @@ User.prototype.goToDifferentInstitution = function goToDifferentInstitution(prev
             const institutionHasBeenDeleted = removeHierarchy === "true" && institution.parent_institution === previousKey;
             if (!(institutionHasBeenDeleted)) {
                 user.current_institution = institution;
-                changeProfileColor(user, institution);
+                //changeProfileColor(user, institution);
                 window.localStorage.userInfo = JSON.stringify(this);
             }
         }


### PR DESCRIPTION
**Feature/Bug description:** By clicking on the notification that the user has been deleted from an institution the color of the user's cover changes, and if it is clicked several times, it changes with each click given in the notification.

**Solution:** I checked if the notification had already been clicked, if yes, no longer reload the server user and also modified the way to get the color of the user's cover, the color was being saved directly in the user's current institution, and now own profile.

**TODO/FIXME:** n/a