### PR TITLE
Don't unfollow institution when remove link between member and institution.

### DIFF
--- a/backend/models/institution.py
+++ b/backend/models/institution.py
@@ -118,7 +118,6 @@ class Institution(ndb.Model):
                 raise Exception("Admin can not be removed")
             member.remove_institution(self.key)
             self.members.remove(member.key)
-            print ">>>>>>>>>>>>>>>>>>>>>>>>>>> chamou aqui"
             self.put()
 
     def add_post(self, post):

--- a/backend/models/institution.py
+++ b/backend/models/institution.py
@@ -118,7 +118,7 @@ class Institution(ndb.Model):
                 raise Exception("Admin can not be removed")
             member.remove_institution(self.key)
             self.members.remove(member.key)
-            self.followers.remove(member.key)
+            print ">>>>>>>>>>>>>>>>>>>>>>>>>>> chamou aqui"
             self.put()
 
     def add_post(self, post):

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -164,7 +164,6 @@ class User(ndb.Model):
             self.remove_permission('publish_post', institution.urlsafe())
             self.remove_permission('publish_survey', institution.urlsafe())
             self.remove_profile(institution.urlsafe())
-            self.follows.remove(institution)
             if len(self.institutions) == 0:
                 self.change_state('inactive')
             self.put()

--- a/backend/test/user_institutions_handler_test.py
+++ b/backend/test/user_institutions_handler_test.py
@@ -39,10 +39,10 @@ class UserInstitutionsHandlerTest(TestBaseHandler):
 
         # Assert the expected conditions
         self.assertTrue(self.second_user.key not in self.institution.members)
-        self.assertTrue(self.second_user.key not in self.institution.followers)
+        self.assertTrue(self.second_user.key in self.institution.followers)
         self.assertTrue(
             self.institution.key not in self.second_user.institutions)
-        self.assertTrue(self.institution.key not in self.second_user.follows)
+        self.assertTrue(self.institution.key in self.second_user.follows)
 
         # Assert that send_email has been called
         send_email.assert_called()

--- a/frontend/test/specs/userSpec.js
+++ b/frontend/test/specs/userSpec.js
@@ -201,7 +201,7 @@
 
         describe('removeInstitution', function() {
 
-          it('should remove the institution from user.institutions and user.follows',
+          it('should remove the institution from user.institutions',
             function() {
               userData = {
                 name: 'Tiago Pereira',
@@ -213,11 +213,11 @@
               };
               user = createUser();
               user.removeInstitution(inst.key);
-              expect(user.follows).toEqual([]);
+              expect(user.follows).toEqual([inst]);
               expect(user.institutions).toEqual([]);
           });
 
-          it('should remove the institution from user.institutions, user.follows and institutions_admin',
+          it('should remove the institution from user.institutions and institutions_admin',
             function () {
               userData = {
                 name: 'Tiago Pereira',
@@ -230,7 +230,7 @@
               };
               user = createUser();
               user.removeInstitution(inst.key);
-              expect(user.follows).toEqual([]);
+              expect(user.follows).toEqual([inst]);
               expect(user.institutions).toEqual([]);
               expect(user.institutions_admin).toEqual([]);
             });

--- a/frontend/user/user.js
+++ b/frontend/user/user.js
@@ -108,7 +108,6 @@ User.prototype.removeInstitution = function removeInstitution(institutionKey, re
     };
 
     _.remove(this.institutions, toRemove);
-    _.remove(this.follows, toRemove);
     
     if(this.isAdmin(institutionKey)) {
         _.remove(this.institutions_admin, function(currentInstUrl) {


### PR DESCRIPTION
**Feature/Bug description:**  When remove link between member and institution the user unfollow institution.

**Solution:** Didn't unfollow.

**TODO/FIXME:** n/a