### PR TITLE
Changing the way that the showButtonDelete of post works

### DIFF
--- a/frontend/home/homeController.js
+++ b/frontend/home/homeController.js
@@ -23,7 +23,7 @@
         homeCtrl.stateView = "";
 
         homeCtrl.user = AuthService.getCurrentUser();
-
+        console.log(homeCtrl.user);
         function loadStateView(){
             homeCtrl.stateView = $state.current.name.split(".")[2];
         }

--- a/frontend/home/homeController.js
+++ b/frontend/home/homeController.js
@@ -23,7 +23,6 @@
         homeCtrl.stateView = "";
 
         homeCtrl.user = AuthService.getCurrentUser();
-        console.log(homeCtrl.user);
         function loadStateView(){
             homeCtrl.stateView = $state.current.name.split(".")[2];
         }

--- a/frontend/post/postDetailsDirective.js
+++ b/frontend/post/postDetailsDirective.js
@@ -9,6 +9,7 @@
         var postDetailsCtrl = this;
 
         var LIMIT_POST_CHARACTERS = 1000;
+        const REMOVE_POST_PERMISSION = 'remove_posts';
 
         postDetailsCtrl.showComments = false;
         postDetailsCtrl.savingComment = false;
@@ -17,7 +18,7 @@
 
         var URL_POST = '/posts/';
         postDetailsCtrl.user = AuthService.getCurrentUser();
-
+        
         postDetailsCtrl.deletePost = function deletePost(ev) {
             var confirm = $mdDialog.confirm()
                 .clickOutsideToClose(true)
@@ -144,7 +145,10 @@
         };
 
         postDetailsCtrl.showButtonDelete = function showButtonDelete() {
-            return postDetailsCtrl.isAuthorized() &&
+            console.log(postDetailsCtrl.user.permissions);
+            const hasPermission = postDetailsCtrl.user.hasPermission(REMOVE_POST_PERMISSION, postDetailsCtrl.post.institution_key);
+            const hasPermissionOrIsAuthor =  hasPermission || postDetailsCtrl.isPostAuthor();
+            return  hasPermissionOrIsAuthor &&
                 !postDetailsCtrl.isDeleted(postDetailsCtrl.post);
         };
 
@@ -419,7 +423,7 @@
         };
 
         postDetailsCtrl.isPostAuthor = function isPostAuthor() {
-            return postDetailsCtrl.post.author_key == postDetailsCtrl.user.key;
+            return postDetailsCtrl.post.author_key === postDetailsCtrl.user.key;
         };
 
         postDetailsCtrl.isPostEmpty = function  isPostEmpty() {

--- a/frontend/post/postDetailsDirective.js
+++ b/frontend/post/postDetailsDirective.js
@@ -9,7 +9,8 @@
         var postDetailsCtrl = this;
 
         var LIMIT_POST_CHARACTERS = 1000;
-        const REMOVE_POST_PERMISSION = 'remove_posts';
+        const REMOVE_POST_BY_INST_PERMISSION = 'remove_posts';
+        const REMOVE_POST_BY_POST_PERMISSION = 'remove_post';
 
         postDetailsCtrl.showComments = false;
         postDetailsCtrl.savingComment = false;
@@ -145,11 +146,10 @@
         };
 
         postDetailsCtrl.showButtonDelete = function showButtonDelete() {
-            console.log(postDetailsCtrl.user.permissions);
-            const hasPermission = postDetailsCtrl.user.hasPermission(REMOVE_POST_PERMISSION, postDetailsCtrl.post.institution_key);
-            const hasPermissionOrIsAuthor =  hasPermission || postDetailsCtrl.isPostAuthor();
-            return  hasPermissionOrIsAuthor &&
-                !postDetailsCtrl.isDeleted(postDetailsCtrl.post);
+            const hasInstitutionPermission = postDetailsCtrl.user.hasPermission(REMOVE_POST_BY_INST_PERMISSION, postDetailsCtrl.post.institution_key);
+            const hasPostPermission = postDetailsCtrl.user.hasPermission(REMOVE_POST_BY_POST_PERMISSION, postDetailsCtrl.post.key);
+            const hasPermission = hasInstitutionPermission || hasPostPermission;
+            return hasPermission && !postDetailsCtrl.isDeleted(postDetailsCtrl.post);
         };
 
         postDetailsCtrl.showActivityButtons = function showActivityButtons() {

--- a/frontend/post/postDirective.js
+++ b/frontend/post/postDirective.js
@@ -238,6 +238,8 @@
                         changeTimelineToStart();
                         $mdDialog.hide();
                         postCtrl.loadingPost = false;
+                        const postAuthorPermissions = ["edit_post", "remove_post"];
+                        postCtrl.user.addPermissions(postAuthorPermissions, response.data.key);
                     }, function error(response) {
                         AuthService.reload().then(function success() {
                             $mdDialog.hide();

--- a/frontend/test/specs/postDetailsControllerSpec.js
+++ b/frontend/test/specs/postDetailsControllerSpec.js
@@ -508,11 +508,10 @@
 
     describe('showButtonDelete', function () {
         it('should return true', function () {
-            let post = new Post({author_key: user.key});
+            let post = new Post({author_key: user.key, key: 'oakspo-OAKSDPO'});
             postDetailsCtrl.user.permissions = {};
             postDetailsCtrl.post = post;
-            let returnedValue = postDetailsCtrl.showButtonDelete();
-            expect(returnedValue).toBeTruthy();
+            let returnedValue;
 
             var institution_key = institutions[0].key;
             postDetailsCtrl.post.author_key = 'oaksd-oKOKOPDkoa';
@@ -520,6 +519,12 @@
             postDetailsCtrl.post.institution_key = institution_key;
             postDetailsCtrl.user.permissions.remove_posts = {};
             postDetailsCtrl.user.permissions.remove_posts[institution_key] = true;
+            returnedValue = postDetailsCtrl.showButtonDelete();
+            expect(returnedValue).toBeTruthy();
+
+            postDetailsCtrl.user.permissions.remove_posts = {};
+            postDetailsCtrl.user.permissions.remove_post = {};
+            postDetailsCtrl.user.permissions.remove_post[post.key] = true;
             returnedValue = postDetailsCtrl.showButtonDelete();
             expect(returnedValue).toBeTruthy();
         });

--- a/frontend/test/specs/postDetailsControllerSpec.js
+++ b/frontend/test/specs/postDetailsControllerSpec.js
@@ -505,4 +505,45 @@
             expect(result.background).toEqual('grey');
         })
     });
+
+    describe('showButtonDelete', function () {
+        it('should return true', function () {
+            let post = new Post({author_key: user.key});
+            postDetailsCtrl.user.permissions = {};
+            postDetailsCtrl.post = post;
+            let returnedValue = postDetailsCtrl.showButtonDelete();
+            expect(returnedValue).toBeTruthy();
+
+            var institution_key = institutions[0].key;
+            postDetailsCtrl.post.author_key = 'oaksd-oKOKOPDkoa';
+            postDetailsCtrl.post.key = 'aoskdopa-KAPODKPOpo';
+            postDetailsCtrl.post.institution_key = institution_key;
+            postDetailsCtrl.user.permissions.remove_posts = {};
+            postDetailsCtrl.user.permissions.remove_posts[institution_key] = true;
+            returnedValue = postDetailsCtrl.showButtonDelete();
+            expect(returnedValue).toBeTruthy();
+        });
+
+        it("should return false", function () {
+            let post = new Post({ author_key: user.key, state: 'deleted' });
+            postDetailsCtrl.user.permissions = {};
+            postDetailsCtrl.post = post;
+            let returnedValue = postDetailsCtrl.showButtonDelete();
+            expect(returnedValue).toBeFalsy();
+
+            var institution_key = institutions[0].key;
+            postDetailsCtrl.post.author_key = 'oaksd-oKOKOPDkoa';
+            postDetailsCtrl.post.key = 'aoskdopa-KAPODKPOpo';
+            postDetailsCtrl.post.institution_key = institution_key;
+            postDetailsCtrl.user.permissions.remove_posts = {};
+            postDetailsCtrl.user.permissions.remove_posts[institution_key] = true;
+            returnedValue = postDetailsCtrl.showButtonDelete();
+            expect(returnedValue).toBeFalsy();
+
+            post = new Post({institution_key: institution_key, author_key: 'oaksdpoka-KOPEkPO'});
+            postDetailsCtrl.user.permissions = {}
+            returnedValue = postDetailsCtrl.showButtonDelete();
+            expect(returnedValue).toBeFalsy();
+        });
+    });
 }));

--- a/frontend/test/specs/userSpec.js
+++ b/frontend/test/specs/userSpec.js
@@ -328,5 +328,20 @@
             expect(user.current_institution).toBe(test_inst);
           });
         });
+
+        describe('addPermissions', function () {
+          it('should add the permissions', function () {
+            var user = new User({permissions: {}});
+
+            expect(user.permissions).toEqual({});
+
+            user.addPermissions(['edit_post'], 'key-1');
+            
+            expect(user.permissions).toEqual({'edit_post': {'key-1': true}});
+
+            user.addPermissions(['remove_post'], 'key-1');
+            expect(user.permissions).toEqual({ 'remove_post': { 'key-1': true }, 'edit_post': {'key-1': true} });
+          });
+        });
    });
 }));

--- a/frontend/user/user.js
+++ b/frontend/user/user.js
@@ -156,6 +156,16 @@ User.prototype.hasPermission = function hasPermission(permissionType, entityKey)
     return false;
 };
 
+User.prototype.addPermissions = function addPermissions(permissionsList, entityKey) {
+    _.each(permissionsList, (permission) => {
+        if(!this.permissions[permission]) {
+            this.permissions[permission] = {};
+        }
+        this.permissions[permission][entityKey] = true
+    });
+    window.localStorage.userInfo = JSON.stringify(this);
+};
+
 User.prototype.updateInstProfile = function updateInstProfile(institution) {
     const index = _.findIndex(this.institution_profiles, ['institution_key', institution.key]);
     this.institution_profiles[index].institution.name = institution.name;


### PR DESCRIPTION
**Feature/Bug description:**
This function was only checking if the user was the author or the admin, but the user should be able to delete the post if he has the permission for.

**Solution:**
I've made a different approach, checking the user permissions instead of check if he is the adm.

![screenshot from 2018-04-13 16-15-00](https://user-images.githubusercontent.com/23387866/38753946-62689108-3f36-11e8-916b-2f450bdd120a.png)


**TODO/FIXME:** n/a