### PR TITLE
Fix notification of accept invite intitution

### DIFF
--- a/backend/handlers/institution_handler.py
+++ b/backend/handlers/institution_handler.py
@@ -162,7 +162,6 @@ class InstitutionHandler(BaseHandler):
         user.add_permissions(permissions.DEFAULT_ADMIN_PERMISSIONS, institution.key.urlsafe())
         user.put()
 
-        invite = ndb.Key(urlsafe=inviteKey).get()
         invite.send_response_notification(user.current_institution, user.key, 'ACCEPT')
 
         enqueue_task('add-admin-permissions', {'institution_key': institution_key})

--- a/backend/handlers/institution_handler.py
+++ b/backend/handlers/institution_handler.py
@@ -162,7 +162,7 @@ class InstitutionHandler(BaseHandler):
         user.add_permissions(permissions.DEFAULT_ADMIN_PERMISSIONS, institution.key.urlsafe())
         user.put()
 
-        invite.send_response_notification(user.current_institution, user.key, 'ACCEPT')
+        invite.send_response_notification(institution.key, user.key, 'ACCEPT')
 
         enqueue_task('add-admin-permissions', {'institution_key': institution_key})
 

--- a/backend/models/invite_institution_children.py
+++ b/backend/models/invite_institution_children.py
@@ -26,5 +26,5 @@ class InviteInstitutionChildren(InviteInstitution):
 
     def send_response_notification(self, current_institution, invitee_key, action):
         """Define the entity type of notification when the invite is accepted or rejected."""
-        entity_type = 'ACCEPT_INVITE_INSTITUTION' if action == 'ACCEPT' else 'REJECT_INVITE_INSTITUTION'
+        entity_type = 'ACCEPT_INVITE_HIERARCHY' if action == 'ACCEPT' else 'REJECT_INSTITUTION_LINK'
         self.send_response(current_institution, invitee_key, entity_type)

--- a/backend/models/invite_institution_children.py
+++ b/backend/models/invite_institution_children.py
@@ -26,5 +26,5 @@ class InviteInstitutionChildren(InviteInstitution):
 
     def send_response_notification(self, current_institution, invitee_key, action):
         """Define the entity type of notification when the invite is accepted or rejected."""
-        entity_type = '' if action == 'ACCEPT' else ''
+        entity_type = 'ACCEPT_INVITE_INSTITUTION' if action == 'ACCEPT' else 'REJECT_INVITE_INSTITUTION'
         self.send_response(current_institution, invitee_key, entity_type)

--- a/backend/models/invite_institution_parent.py
+++ b/backend/models/invite_institution_parent.py
@@ -26,5 +26,5 @@ class InviteInstitutionParent(InviteInstitution):
 
     def send_response_notification(self, current_institution, invitee_key, action):
         """Define the entity type of notification when the invite is accepted or rejected."""
-        entity_type = 'ACCEPT_INSTITUTION_LINK' if action == 'ACCEPT' else 'REJECT_INSTITUTION_LINK'
+        entity_type = 'ACCEPT_INVITE_HIERARCHY' if action == 'ACCEPT' else 'REJECT_INSTITUTION_LINK'
         self.send_response(current_institution, invitee_key, entity_type)

--- a/frontend/notification/notificationDirective.js
+++ b/frontend/notification/notificationDirective.js
@@ -184,7 +184,10 @@
             },
             "REJECT_INVITE_USER_ADM": {
                 icon: "account_balance"
-            }
+            },
+            "ACCEPT_INVITE_HIERARCHY": {
+                icon: "account_balance",
+            },
         };
 
         notificationCtrl.markAsRead = function markAsRead(notification) {

--- a/frontend/notification/notificationService.js
+++ b/frontend/notification/notificationService.js
@@ -36,7 +36,7 @@
             'REJECT_INVITE_USER': messageCreator('Rejeitou o convite para ser membro de ', SINGLE_INST),
             'ACCEPT_INVITE_USER': messageCreator('Aceitou o convite para ser membro de ', SINGLE_INST),
             'REJECT_INVITE_INSTITUTION': messageCreator('Rejeitou o seu convite para ser administrador', NO_INST),
-            'ACCEPT_INVITE_INSTITUTION': messageCreator('Aceitou o seu convite e criou ', SINGLE_INST),
+            'ACCEPT_INVITE_INSTITUTION': messageCreator('Aceitou o seu convite para ser administrador', NO_INST),
             'DELETE_MEMBER': messageCreator('Removeu você de ', SINGLE_INST),
             'ACCEPTED_LINK': messageCreator('Aceitou sua solicitação de vínculo com ', SINGLE_INST),
             'SHARED_EVENT': messageCreator('Compartilhou um evento de ', SINGLE_INST),
@@ -44,7 +44,8 @@
             'REPLY_COMMENT': messageCreator('Respondeu um comentário seu'),
             'USER_ADM': messageCreator('Indicou você para ser administrador da instituição ', SINGLE_INST),
             'ACCEPT_INVITE_USER_ADM': messageCreator('Aceitou seu convite para ser administrador de ', SINGLE_INST),
-            'REJECT_INVITE_USER_ADM': messageCreator('Rejeitou seu convite para ser administrador de ', SINGLE_INST)
+            'REJECT_INVITE_USER_ADM': messageCreator('Rejeitou seu convite para ser administrador de ', SINGLE_INST),
+            'ACCEPT_INVITE_HIERARCHY': messageCreator('Aceitou seu convite e estabeleceu vínculo entre ', DOUBLE_INST)
         };
 
         var POST_NOTIFICATION = 'POST';

--- a/frontend/notification/notificationService.js
+++ b/frontend/notification/notificationService.js
@@ -36,7 +36,7 @@
             'REJECT_INVITE_USER': messageCreator('Rejeitou o convite para ser membro de ', SINGLE_INST),
             'ACCEPT_INVITE_USER': messageCreator('Aceitou o convite para ser membro de ', SINGLE_INST),
             'REJECT_INVITE_INSTITUTION': messageCreator('Rejeitou o seu convite para ser administrador', NO_INST),
-            'ACCEPT_INVITE_INSTITUTION': messageCreator('Aceitou o seu convite para ser administrador', NO_INST),
+            'ACCEPT_INVITE_INSTITUTION': messageCreator('Aceitou o seu convite e criou ', SINGLE_INST),
             'DELETE_MEMBER': messageCreator('Removeu você de ', SINGLE_INST),
             'ACCEPTED_LINK': messageCreator('Aceitou sua solicitação de vínculo com ', SINGLE_INST),
             'SHARED_EVENT': messageCreator('Compartilhou um evento de ', SINGLE_INST),

--- a/frontend/notification/notifications_page.html
+++ b/frontend/notification/notifications_page.html
@@ -19,7 +19,7 @@
             </div>
             <md-content class="custom-scrollbar">
                 <md-list style="padding: 10px;">
-                    <md-list-item class="md-3-line" md-colors="{background: 'grey-200'}" style="margin-bottom: 5px; padding: 3 0 3 0;"
+                    <md-list-item title="{{notificationCtrl.format(notification)}}" class="md-3-line" md-colors="{background: 'grey-200'}" style="margin-bottom: 5px; padding: 3 0 3 0;"
                         ng-repeat="notification in notificationCtrl.allNotifications | orderBy:'-timestamp' | filter: notificationCtrl.keyword" 
                         ng-click="notificationCtrl.action(notification, $event)">
                             <img ng-src="{{notification.from.photo_url}}" class="md-avatar" style="width: 60px; height: 60px;"/>


### PR DESCRIPTION
**Feature/Bug description:** When an invitation to create a daughter institution was sent and the invited user accepts the invitation, the notification that that user accepted the invitation is wrong.

![screenshot from 2018-04-16 11-28-55](https://user-images.githubusercontent.com/18005317/38815093-835e0200-4169-11e8-9a96-cd25924ff55f.png)

**Solution:** I created a new notification type 'ACCEPT_INVITE_HIERARCHY' to show the message that the institution was created and, on the backend, set the send_reponse_notification of the invite institution children model so that it sends the correct notification.

![screenshot from 2018-04-16 11-20-48](https://user-images.githubusercontent.com/18005317/38814735-9f1fcb78-4168-11e8-957f-0afc06b7af52.png)


**TODO/FIXME:** n/a