### PR TITLE
Creating the page to show institutional links of an institution

### DIFF
--- a/backend/handlers/institution_handler.py
+++ b/backend/handlers/institution_handler.py
@@ -51,7 +51,7 @@ def isUserInvited(method):
 
 def childrenToJson(obj):
     """Return the array with json from institution that are obj children."""
-    json = [Institution.make(institution.get(), ['name', 'key', 'state', 'invite', 'parent_institution'])
+    json = [Institution.make(institution.get(), ['name', 'photo_url', 'key', 'state', 'invite', 'parent_institution'])
             for institution in obj.children_institutions]
     return json
 
@@ -61,7 +61,7 @@ def parentToJson(obj):
     if(obj.parent_institution):
         parent_institution = obj.parent_institution.get()
         institution_parent_json = Institution.make(parent_institution, [
-                                                   'name', 'key', 'state', 'invite'])
+                                                   'name', 'key', 'state', 'invite', 'photo_url'])
         institution_parent_json['children_institutions'] = childrenToJson(parent_institution)
         return institution_parent_json
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -172,6 +172,15 @@
                     }
                 }
             })
+            .state("app.institution.institutional_links", {
+                url: "/institution/:institutionKey/institutional_links",
+                views: {
+                    institution_content: {
+                        templateUrl: "app/institution/institutional_links.html",
+                        controller: "InstitutionLinksController as instLinksCtrl"
+                    }
+                }
+            })
             .state("app.post", {
                 url: "/posts/:key",
                 views: {

--- a/frontend/institution/base_institution_page.html
+++ b/frontend/institution/base_institution_page.html
@@ -124,13 +124,11 @@
                                                 <b>Seguidores</b>
                                             </md-button>
                                         </md-menu-item>
-                                        <!--TODO: Show the item below when hierarchical invitations can be sent 
-                                        @author: Mayza Nunes 10/01/17-->
-                                        <md-menu-item ng-if="false">
-                                            <md-button ng-class="institutionCtrl.getSelectedItemClass('settings')"
-                                                ng-click="institutionCtrl.goToCommingSoon(institutionCtrl.institution.key)">
-                                                <md-icon>settings</md-icon>
-                                                <b>Vinculos Institucionais</b>
+                                        <md-menu-item>
+                                            <md-button ng-class="institutionCtrl.getSelectedItemClass('institutional_links')"
+                                                ng-click="institutionCtrl.goToLinks(institutionCtrl.institution.key)">
+                                                <md-icon>account_balance</md-icon>
+                                                <b>Vinculos institucionais</b>
                                             </md-button>
                                         </md-menu-item>
                                         <md-menu-item ng-if="institutionCtrl.portfolioUrl">

--- a/frontend/institution/base_institution_page.html
+++ b/frontend/institution/base_institution_page.html
@@ -128,7 +128,7 @@
                                             <md-button ng-class="institutionCtrl.getSelectedItemClass('institutional_links')"
                                                 ng-click="institutionCtrl.goToLinks(institutionCtrl.institution.key)">
                                                 <md-icon>account_balance</md-icon>
-                                                <b>Vinculos institucionais</b>
+                                                <b>Vínculos institucionais</b>
                                             </md-button>
                                         </md-menu-item>
                                         <md-menu-item ng-if="institutionCtrl.portfolioUrl">

--- a/frontend/institution/institutionController.js
+++ b/frontend/institution/institutionController.js
@@ -505,11 +505,11 @@
 
         function loadInstitution() {
             InstitutionService.getInstitution(currentInstitutionKey).then(function success(response) {
-                instLinksCtrl.parentInstitution = response.data.parent_institution;
-                instLinksCtrl.childrenInstitutions = response.data.children_institutions;
+                var parentInstitution = response.data.parent_institution;
+                instLinksCtrl.parentInstitution = parentInstitution && parentInstitution.state === "active" ? parentInstitution : {};
+                instLinksCtrl.childrenInstitutions = response.data.children_institutions.filter(inst => inst.state === "active");
                 instLinksCtrl.isLoadingInsts = false;
             }, function error(response) {
-                $state.go("app.user.home");
                 instLinksCtrl.isLoadingInsts = true;
                 MessageService.showToast(response.data.msg);
             });

--- a/frontend/institution/institutionController.js
+++ b/frontend/institution/institutionController.js
@@ -189,6 +189,11 @@
             $state.go('app.institution.events', {institutionKey: institutionKey, posts: institutionCtrl.posts});
         };
 
+        institutionCtrl.goToLinks = function goToLinks(institutionKey) {
+            institutionCtrl.stateView = "institutional_links";
+            $state.go('app.institution.institutional_links', {institutionKey: institutionKey});
+        };
+
         institutionCtrl.goToHome = function goToHome() {
             $state.go('app.user.home');
         };
@@ -468,5 +473,48 @@
 
         getFollowers();
 
+    });
+
+    app.controller("InstitutionLinksController", function InstitutionLinksController($state, InstitutionService, MessageService) {
+
+        var instLinksCtrl = this;
+        var currentInstitutionKey = $state.params.institutionKey;
+
+        instLinksCtrl.isLoadingInsts = true;
+        instLinksCtrl.currentInstitution = "";
+        instLinksCtrl.parentInstitution = {};
+        instLinksCtrl.childrenInstitutions = [];
+
+        instLinksCtrl.goToInst = function goToInst(institutionKey) {
+            const url = $state.href('app.institution.timeline', {institutionKey: institutionKey});
+            window.open(url, '_blank');
+        };
+
+        instLinksCtrl.hasInstitutions = function hasInstitutions() {
+            return !instLinksCtrl.isLoadingInsts
+                && (instLinksCtrl.hasParentInst() || instLinksCtrl.hasChildrenInst());
+        };
+
+        instLinksCtrl.hasParentInst = function hasParentInst() {
+            return !_.isEmpty(instLinksCtrl.parentInstitution);
+        };
+
+        instLinksCtrl.hasChildrenInst = function hasChildrenInst() {
+            return !_.isEmpty(instLinksCtrl.childrenInstitutions);
+        };
+
+        function loadInstitution() {
+            InstitutionService.getInstitution(currentInstitutionKey).then(function success(response) {
+                instLinksCtrl.parentInstitution = response.data.parent_institution;
+                instLinksCtrl.childrenInstitutions = response.data.children_institutions;
+                instLinksCtrl.isLoadingInsts = false;
+            }, function error(response) {
+                $state.go("app.user.home");
+                instLinksCtrl.isLoadingInsts = true;
+                MessageService.showToast(response.data.msg);
+            });
+        }
+
+        loadInstitution();
     });
 })();

--- a/frontend/institution/institutional_links.html
+++ b/frontend/institution/institutional_links.html
@@ -1,0 +1,54 @@
+<div layout="row" flex layout-align="center">
+	<load-circle flex add-layout-fill="true" ng-if="instLinksCtrl.isLoadingInsts"></load-circle>
+    <div ng-if="!instLinksCtrl.isLoadingInsts" flex flex-md="95" layout="row" layout-align="space-around"
+            md-colors="{background: 'grey-50'}">
+          <!-- CONTENT -->
+        <div class="custom-scrollbar" flex="90">
+			<md-card>
+				<md-toolbar md-colors="{background: 'teal-500'}" layout="row">
+					<div class="md-toolbar-tools" flex layout="row" layout-align="center center">
+						<md-icon>account_balance </md-icon>
+						<h5 style="font-weight:normal; margin-left: 2%">         
+						VÍNCULOS INSTITUCIONAIS
+						</h5>
+						<span flex md-truncate></span>
+					</div>
+				</md-toolbar>
+				<md-card-content ng-if="instLinksCtrl.hasInstitutions()">
+                    <div ng-if="instLinksCtrl.hasParentInst()">
+                        <h3 style="margin-top: 0.5em">INSTITUIÇÃO SUPERIOR</h3>
+                        <div layout="row" style="margin-top: 1%; margin-bottom: 3%" 
+                            md-colors="{background: 'grey-300'}" ng-click="instLinksCtrl.goToInst(instLinksCtrl.parentInstitution.key)">  
+                            <img title="{{instLinksCtrl.parentInstitution.name}}" ng-src="{{instLinksCtrl.parentInstitution.photo_url}}" class="md-avatar"
+                            style="width: 60px; height: 60px; margin-right: 2%; border-radius: 50%;"/>
+                            <div layout="column" layout-align="center" 
+                                ng-click="instLinksCtrl.goToInst(instLinksCtrl.parentInstitution.key)">
+                                <b>{{ instLinksCtrl.parentInstitution.name }}</b>
+                            </div>
+                        </div>
+                    </div>
+                    <div ng-if="instLinksCtrl.hasChildrenInst()">
+                        <h3>INSTITUIÇÕES SUBORDINADAS</h3>
+                        <md-content flex style="max-height: 210px;" class="custom-scrollbar">
+                            <md-list flex>
+                                <md-list-item class="list-item-dense" md-colors="{background: 'grey-300'}"
+                                ng-repeat="institution in instLinksCtrl.childrenInstitutions | filter: instLinksCtrl.currentInstitution" 
+                                ng-click="instLinksCtrl.goToInst(institution.key)" flex-xs>
+                                <img title="{{institution.name}}" ng-src="{{institution.photo_url}}" class="md-avatar" 
+                                    style="margin: 0 15px 0 -15px; width: 60px; height: 60px;"/>
+                                <div layout="column" 
+                                    ng-click="instLinksCtrl.goToInst(institution.key)">
+                                    <b>{{ institution.name }}</b>
+                                </div>
+                                </md-list-item>
+                            </md-list>
+                        </md-content>
+                    </div>
+                </md-card-content>
+                <md-card-content ng-if="!instLinksCtrl.hasInstitutions()">
+                    <h3 style="text-align: center;">Esta instituição não possui nenhum vínculo institucional</h3>
+                </md-card-content>
+			</md-card>
+        </div>
+    </div>
+</div>

--- a/frontend/test/specs/institutionControllerSpec.js
+++ b/frontend/test/specs/institutionControllerSpec.js
@@ -321,5 +321,12 @@
                 expect(state.go).toHaveBeenCalledWith('app.institution.events', {institutionKey: first_institution.key, posts: institutionCtrl.posts});
             });
         });
+        describe('goToLinks()', function() {
+            it('should call state.go', function() {
+                spyOn(state, 'go');
+                institutionCtrl.goToLinks(first_institution.key);
+                expect(state.go).toHaveBeenCalledWith('app.institution.institutional_links', {institutionKey: first_institution.key});
+            });
+        });
     });
 }));

--- a/frontend/test/specs/institutionLinksControllerSpec.js
+++ b/frontend/test/specs/institutionLinksControllerSpec.js
@@ -1,0 +1,122 @@
+'use strict';
+
+(describe('Test InstitutionLinksController', function() {
+
+    var instLinksCtrl, httpBackend, scope, institutionService, createCtrl, state;
+
+    var INSTITUTIONS_URI = "/api/institutions/";
+
+    var parent_institution_test = {
+        name: 'parentInst',
+        key: 'parentKey',
+    };
+
+    var children_institutions_test = [
+        {
+            name: 'childrenInst1',
+            key: 'chldKey1'
+        },
+        {
+            name: 'childrenInst2',
+            key: 'chldKey2'
+        }
+    ];
+
+    var institution = {
+        acronym: 'institution',
+        key: '987654321',
+        parent_institution: parent_institution_test,
+        children_institutions: children_institutions_test
+    };
+
+    beforeEach(module('app'));
+
+    beforeEach(inject(function($controller, $httpBackend, $rootScope, $state, 
+            InstitutionService) {
+        httpBackend = $httpBackend;
+        scope = $rootScope.$new();
+        state = $state;
+        institutionService = InstitutionService;
+
+        httpBackend.expect('GET', INSTITUTIONS_URI + institution.key).respond(institution);
+        httpBackend.when('GET', 'institution/institution_page.html').respond(200);
+        httpBackend.when('GET', 'institution/removeInstDialog.html').respond(200);
+        httpBackend.when('GET', "main/main.html").respond(200);
+        httpBackend.when('GET', "home/home.html").respond(200);
+
+        createCtrl = function() {
+            return $controller('InstitutionLinksController',
+                {
+                    scope: scope,
+                    institutionService: institutionService
+                });
+        };
+
+        state.params.institutionKey = institution.key;
+        instLinksCtrl = createCtrl();
+        httpBackend.flush();
+    }));
+
+    afterEach(function() {
+        httpBackend.verifyNoOutstandingExpectation();
+        httpBackend.verifyNoOutstandingRequest();
+    });
+
+    describe('InstitutionLinksController properties', function() {
+
+        it('The flag to indicate if is loading institutions should be false', function() {
+            expect(instLinksCtrl.isLoadingInsts).toBeFalsy();
+        });
+
+        it('Should has parent institution', function() {
+            expect(instLinksCtrl.parentInstitution).toEqual(parent_institution_test);
+        });
+
+        it('Should has two children institutions', function() {
+            expect(instLinksCtrl.childrenInstitutions.length).toEqual(2);
+        });
+
+    });
+
+    describe('InstitutionLinksController functions', function() {
+
+        it('goToInst() should call window.open', function() {
+            spyOn(window, 'open');
+            instLinksCtrl.goToInst(parent_institution_test.key);
+            expect(window.open).toHaveBeenCalledWith('/institution/' + parent_institution_test.key + '/home', '_blank');
+        });
+
+        it('hasInstitutions() should return true if has parent institution or has children institution', function() {
+            expect(instLinksCtrl.hasInstitutions()).toBeTruthy();
+        });
+
+        it('hasInstitutions() should return false if no has parent institution and no has children institutions', function() {
+            instLinksCtrl.parentInstitution = {};
+            instLinksCtrl.childrenInstitutions = [];
+            expect(instLinksCtrl.hasInstitutions()).toBeFalsy();
+        });
+
+        it('hasParentInst() should return true if has parent institution', function() {
+            expect(instLinksCtrl.hasParentInst()).toBeTruthy();
+        });
+
+        it('hasParentInst() should return false if not has parent institution', function() {
+            instLinksCtrl.parentInstitution = {};
+            expect(instLinksCtrl.hasParentInst()).toBeFalsy();
+        });
+
+        it('hasChildrenInst() should return true if has at least one children institution', function() {
+            expect(instLinksCtrl.hasChildrenInst()).toBeTruthy();
+        });
+
+        it('hasChildrenInst() should return false if not has at least one children institution', function() {
+            instLinksCtrl.childrenInstitutions = [];
+            expect(instLinksCtrl.hasChildrenInst()).toBeFalsy();
+        });
+
+        afterEach(function() {
+            instLinksCtrl.parent_institution = parent_institution_test;
+            instLinksCtrl.children_institutions = children_institutions_test;
+        });
+    });
+}));

--- a/frontend/test/specs/institutionLinksControllerSpec.js
+++ b/frontend/test/specs/institutionLinksControllerSpec.js
@@ -6,27 +6,30 @@
 
     var INSTITUTIONS_URI = "/api/institutions/";
 
-    var parent_institution_test = {
+    var parentInstitutionTest = {
         name: 'parentInst',
         key: 'parentKey',
+        state: 'active'
     };
 
-    var children_institutions_test = [
+    var childrenInstitutionsTest = [
         {
             name: 'childrenInst1',
-            key: 'chldKey1'
+            key: 'chldKey1',
+            state: 'active'
         },
         {
             name: 'childrenInst2',
-            key: 'chldKey2'
+            key: 'chldKey2',
+            state: 'active'
         }
     ];
 
     var institution = {
         acronym: 'institution',
         key: '987654321',
-        parent_institution: parent_institution_test,
-        children_institutions: children_institutions_test
+        parent_institution: parentInstitutionTest,
+        children_institutions: childrenInstitutionsTest
     };
 
     beforeEach(module('app'));
@@ -39,10 +42,6 @@
         institutionService = InstitutionService;
 
         httpBackend.expect('GET', INSTITUTIONS_URI + institution.key).respond(institution);
-        httpBackend.when('GET', 'institution/institution_page.html').respond(200);
-        httpBackend.when('GET', 'institution/removeInstDialog.html').respond(200);
-        httpBackend.when('GET', "main/main.html").respond(200);
-        httpBackend.when('GET', "home/home.html").respond(200);
 
         createCtrl = function() {
             return $controller('InstitutionLinksController',
@@ -69,54 +68,60 @@
         });
 
         it('Should has parent institution', function() {
-            expect(instLinksCtrl.parentInstitution).toEqual(parent_institution_test);
+            expect(instLinksCtrl.parentInstitution).toEqual(parentInstitutionTest);
         });
 
         it('Should has two children institutions', function() {
             expect(instLinksCtrl.childrenInstitutions.length).toEqual(2);
         });
-
     });
 
     describe('InstitutionLinksController functions', function() {
 
-        it('goToInst() should call window.open', function() {
-            spyOn(window, 'open');
-            instLinksCtrl.goToInst(parent_institution_test.key);
-            expect(window.open).toHaveBeenCalledWith('/institution/' + parent_institution_test.key + '/home', '_blank');
+        describe('goToInst()', function() {
+
+            it('should call window.open', function() {
+                spyOn(window, 'open');
+                instLinksCtrl.goToInst(parentInstitutionTest.key);
+                expect(window.open).toHaveBeenCalledWith('/institution/' + parentInstitutionTest.key + '/home', '_blank');
+            });
         });
 
-        it('hasInstitutions() should return true if has parent institution or has children institution', function() {
-            expect(instLinksCtrl.hasInstitutions()).toBeTruthy();
+        describe('hasInstitutions()', function() {
+
+            it('should return true if has parent institution or has children institution', function() {
+                expect(instLinksCtrl.hasInstitutions()).toBeTruthy();
+            });
+
+            it('should return false if no has parent institution and no has children institutions', function() {
+                instLinksCtrl.parentInstitution = {};
+                instLinksCtrl.childrenInstitutions = [];
+                expect(instLinksCtrl.hasInstitutions()).toBeFalsy();
+            });
         });
 
-        it('hasInstitutions() should return false if no has parent institution and no has children institutions', function() {
-            instLinksCtrl.parentInstitution = {};
-            instLinksCtrl.childrenInstitutions = [];
-            expect(instLinksCtrl.hasInstitutions()).toBeFalsy();
+        describe('hasParentInst()', function() {
+
+            it('should return true if has parent institution', function() {
+                expect(instLinksCtrl.hasParentInst()).toBeTruthy();
+            });
+
+            it('should return false if not has parent institution', function() {
+                instLinksCtrl.parentInstitution = {};
+                expect(instLinksCtrl.hasParentInst()).toBeFalsy();
+            });
         });
 
-        it('hasParentInst() should return true if has parent institution', function() {
-            expect(instLinksCtrl.hasParentInst()).toBeTruthy();
-        });
+        describe('hasChildrenInst()', function() {
 
-        it('hasParentInst() should return false if not has parent institution', function() {
-            instLinksCtrl.parentInstitution = {};
-            expect(instLinksCtrl.hasParentInst()).toBeFalsy();
-        });
+            it('hasChildrenInst() should return true if has at least one children institution', function() {
+                expect(instLinksCtrl.hasChildrenInst()).toBeTruthy();
+            });
 
-        it('hasChildrenInst() should return true if has at least one children institution', function() {
-            expect(instLinksCtrl.hasChildrenInst()).toBeTruthy();
-        });
-
-        it('hasChildrenInst() should return false if not has at least one children institution', function() {
-            instLinksCtrl.childrenInstitutions = [];
-            expect(instLinksCtrl.hasChildrenInst()).toBeFalsy();
-        });
-
-        afterEach(function() {
-            instLinksCtrl.parent_institution = parent_institution_test;
-            instLinksCtrl.children_institutions = children_institutions_test;
+            it('hasChildrenInst() should return false if not has at least one children institution', function() {
+                instLinksCtrl.childrenInstitutions = [];
+                expect(instLinksCtrl.hasChildrenInst()).toBeFalsy();
+            });
         });
     });
 }));


### PR DESCRIPTION
**Feature/Bug description:** Enabling option in the left menu of institution page to go to the institutional links page. And creating this page.

**Solution:** Adding a short controller to show the information of institutional links and making a view to this.

![screenshot from 2018-04-16 16-27-23](https://user-images.githubusercontent.com/20300259/38831086-b899ef62-4194-11e8-8d17-d79e0346dd20.png)


![screenshot from 2018-04-16 16-28-08](https://user-images.githubusercontent.com/20300259/38831091-bdf8fc32-4194-11e8-88f3-c70e8656dcb8.png)


![screenshot from 2018-04-16 16-28-24](https://user-images.githubusercontent.com/20300259/38831093-c3c57802-4194-11e8-98c7-bdd2a3e8aa93.png)


![screenshot from 2018-04-16 16-30-03](https://user-images.githubusercontent.com/20300259/38831099-c8612b2c-4194-11e8-9ed4-9fe2496bfce6.png)

![screenshot from 2018-04-17 15-10-03](https://user-images.githubusercontent.com/20300259/38888495-2c9eed5a-4252-11e8-8cf7-bfa933278fcf.png)



**TODO/FIXME:** n/a