### PR TITLE
Improving inst's name in management page

### DIFF
--- a/frontend/institution/management_institution_page.html
+++ b/frontend/institution/management_institution_page.html
@@ -20,7 +20,11 @@
               <div class="info" 
               md-colors="{background: institutionCtrl.user.getProfileColor()+'-600'}">
                 <div class="desc">
-                  <div class="md-title">{{ institutionCtrl.institution.name }}</div>
+                  <div class="md-title">
+                    <a style="color: #FFFFFF" href ng-click="institutionCtrl.goToInstitution(institutionCtrl.institution.key)">
+                      {{ institutionCtrl.institution.name }}
+                    </a>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/institution/management_institution_page.html
+++ b/frontend/institution/management_institution_page.html
@@ -14,7 +14,7 @@
             md-colors="{background: institutionCtrl.user.getProfileColor()+'-800'}">
               <div class="cardheader">
                 <div class="avatar">
-                  <img alt="Foto da Instituição" ng-src="{{ institutionCtrl.institution.photo_url || '/app/images/institution.png' }}">
+                  <img ng-click="institutionCtrl.goToInstitution(institutionCtrl.institution.key)" alt="Foto da Instituição" ng-src="{{ institutionCtrl.institution.photo_url || '/app/images/institution.png' }}">
                 </div>
               </div>
               <div class="info" 


### PR DESCRIPTION
**Feature/Bug description:**
The institution name wasn't clickable in its management's page.
**Solution:**
I've added a <a> tag with the properly properties.

![screenshot from 2018-04-17 07-57-32](https://user-images.githubusercontent.com/23387866/38866034-049bc21a-4216-11e8-997e-4ae260e9d0c3.png)


**TODO/FIXME:** n/a