### PR TITLE
Add home button in institution's management  page

### DIFF
--- a/frontend/institution/management_institution_page.html
+++ b/frontend/institution/management_institution_page.html
@@ -55,6 +55,12 @@
                     <b>Remover Instituição</b>
                   </md-button>
                 </md-menu-item>
+                <md-menu-item>
+                  <md-button ng-click="institutionCtrl.goToHome()" ng-class="institutionCtrl.getSelectedItemClass('remove_inst')">
+                    <md-icon>arrow_back</md-icon>
+                    <b>Voltar</b>
+                  </md-button>
+                </md-menu-item>
               </md-menu-content>
             </div>
         </div>


### PR DESCRIPTION
**Feature/Bug description:**
There was no button to go home from institution's management page

**Solution:**
Add another md-menu-item with the button

![screenshot from 2018-04-17 08-10-55](https://user-images.githubusercontent.com/23387866/38866485-5c67dca8-4217-11e8-8d30-b870d0c25830.png)


**TODO/FIXME:** n/a