### PR TITLE
Check event's actions with permissions

### DIFF
--- a/backend/handlers/event_collection_handler.py
+++ b/backend/handlers/event_collection_handler.py
@@ -54,5 +54,7 @@ class EventCollectionHandler(BaseHandler):
 
         event = Event.create(data, user, institution)
         event.put()
+        user.add_permissions(['remove_post', 'edit_post'], event.key.urlsafe())
+        user.put()
 
         self.response.write(json.dumps(Utils.toJson(Event.make(event), host=self.request.host)))

--- a/backend/handlers/event_handler.py
+++ b/backend/handlers/event_handler.py
@@ -54,7 +54,7 @@ class EventHandler(BaseHandler):
         event = event_key.get()
 
         is_admin = user.has_permission("remove_posts", event.institution_key.urlsafe())
-        is_author = user.key == event.author_key
+        is_author = user.has_permission("remove_post", event.key.urlsafe())
         
         Utils._assert(not is_admin and not is_author,
                       "The user can not remove this event", NotAuthorizedException)

--- a/backend/test/event_collection_handler_test.py
+++ b/backend/test/event_collection_handler_test.py
@@ -55,6 +55,9 @@ class EventCollectionHandlerTest(TestBaseHandler):
         self.assertEqual(event_obj.text,
                          'testing new event',
                          "The post's text is not the expected one")
+        self.assertTrue(self.user.has_permission('remove_post', event_obj.key.urlsafe()))
+        self.assertTrue(self.user.has_permission(
+            'edit_post', event_obj.key.urlsafe()))
 
         # Check if raise exception when the end time of event is before the start time
         with self.assertRaises(Exception) as raises_context:

--- a/frontend/event/eventController.js
+++ b/frontend/event/eventController.js
@@ -388,6 +388,7 @@
                     $mdDialog.hide();
                     dialogCtrl.events.push(response.data);
                     MessageService.showToast('Evento criado com sucesso!');
+                    dialogCtrl.user.addPermissions(['edit_post', 'remove_post'], response.data.key);
                 }, function error(response) {
                     dialogCtrl.loading = false;
                     dialogCtrl.blockReturnButton = false;

--- a/frontend/event/eventDetailsDirective.js
+++ b/frontend/event/eventDetailsDirective.js
@@ -59,12 +59,15 @@
         };
 
         eventCtrl.canChange = function canChange(event) {
-            if(event)
-                return eventCtrl.isEventAuthor(event) || isInstitutionAdmin(event);
+            if(event) {
+                const hasInstitutionPermission = eventCtrl.user.hasPermission('remove_posts', event.institution_key);
+                const hasEventPermission = eventCtrl.user.hasPermission('remove_post', event.key);
+                return hasInstitutionPermission || hasEventPermission;
+            }
         };
 
         eventCtrl.canEdit = function canEdit(event) {
-            return eventCtrl.isEventAuthor(event);
+            return eventCtrl.user.hasPermission('edit_post', event.key);
         };
 
         eventCtrl.editEvent = function editEvent(ev, event) {

--- a/frontend/test/specs/eventDetailsControllerSpec.js
+++ b/frontend/test/specs/eventDetailsControllerSpec.js
@@ -168,4 +168,56 @@
             expect(result).toBeFalsy();
         });
     });
+
+    describe('canChange()', function() {
+        
+        it('should return true', function () {
+            let institution = { key: 'opkaspdapos-OPKSDOAKO' };
+            event.key = 'okaspoda-AOPKOSPFKDOP';
+            event.institution_key = institution.key;
+            eventCtrl.user.permissions = {};
+            eventCtrl.user.permissions['remove_post'] = {};
+            eventCtrl.user.permissions['remove_post'][event.key] = true;
+
+            let returnedValue = eventCtrl.canChange(event);
+            expect(returnedValue).toBeTruthy();
+
+            eventCtrl.user.permissions = {};
+            eventCtrl.user.permissions['remove_posts'] = {};
+            eventCtrl.user.permissions['remove_posts'][event.institution_key] = true;
+
+            returnedValue = eventCtrl.canChange(event);
+            expect(returnedValue).toBeTruthy();
+        });
+        
+        it('should return false', function() {
+            let institution = { key: 'opkaspdapos-OPKSDOAKO' };
+            event.key = 'okaspoda-AOPKOSPFKDOP';
+            event.institution_key = institution.key;
+            eventCtrl.user.permissions = {};
+            let returnedValue = eventCtrl.canChange(event);
+            expect(returnedValue).toBeFalsy();
+        });
+    });
+
+    describe('canEdit()', function () {
+
+        it('should return true', function() {
+            event.key = 'opaksdpo-SIKFSPA';
+            eventCtrl.user.permissions = {};
+            eventCtrl.user.permissions['edit_post'] = {};
+            eventCtrl.user.permissions['edit_post'][event.key] = true;
+
+            let returnedValue = eventCtrl.canEdit(event);
+            expect(returnedValue).toBeTruthy();
+        });
+
+        it('should return false', function() {
+            event.key = 'opaksdpo-SIKFSPA';
+            eventCtrl.user.permissions = {};
+
+            let returnedValue = eventCtrl.canEdit(event);
+            expect(returnedValue).toBeFalsy();
+        });
+    });
 }));

--- a/frontend/test/specs/eventDialogCtrlSpec.js
+++ b/frontend/test/specs/eventDialogCtrlSpec.js
@@ -128,11 +128,18 @@
     describe('save()', function() {
 
       it('should eventService.createEvent be called', function() {
-        spyOn(eventService, 'createEvent').and.returnValue(deferred.promise);
-        deferred.resolve(event);
+        spyOn(eventService, 'createEvent').and.callFake(function () {
+          return {
+            then: function (callback) {
+              return callback({data: {key: 'oaksp-OAKDSOP'}});
+            }
+          };
+        });
+        spyOn(controller.user, 'addPermissions');
+        controller.user.permissions = {};
         controller.save();
-        scope.$apply();
         expect(eventService.createEvent).toHaveBeenCalledWith(event_convert_date);
+        expect(controller.user.addPermissions).toHaveBeenCalled();
       });
 
       it('should call eventService.editEvent', function() {


### PR DESCRIPTION
**Feature/Bug description:** 
The event's actions checking wasn't using permissions.

**Solution:**
I've used permissions to check some actions in events.

**TODO/FIXME:** n/a