### PR TITLE
Show accept request dialog when click in request on manage member page

### DIFF
--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -67,6 +67,20 @@
             }, function error() {});
         };
 
+        manageMemberCtrl.openAcceptRequestDialog = function openAcceptRequestDialog(requestKey) {
+            $mdDialog.show({
+                controller: "RequestProcessingController",
+                controllerAs: "requestCtrl",
+                templateUrl: "app/requests/request_processing.html" ,
+                parent: angular.element(document.body),
+                targetEvent: event,
+                clickOutsideToClose:true,
+                locals: {key: requestKey},
+                openFrom: '#fab-new-post',
+                closeTo: angular.element(document.querySelector('#fab-new-post'))
+            });
+        };
+
         manageMemberCtrl.removeMember = function removeMember(member_obj) {
             _.remove(manageMemberCtrl.members, function(member) {
                 return member.key === member_obj.key;

--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -78,7 +78,19 @@
                 locals: {key: requestKey},
                 openFrom: '#fab-new-post',
                 closeTo: angular.element(document.querySelector('#fab-new-post'))
+            }).then(function success(processedRequest) {
+                console.log(processedRequest);
+                const request = manageMemberCtrl.requests.reduce(
+                    (found, request) => (request.key === processedRequest.key) ? request : found, 
+                    {}
+                );
+                request.status = processedRequest.status;
+            }, function error() {
             });
+        };
+
+        manageMemberCtrl.isSentRequest = function isSentRequest(request) {
+            return request.status === 'sent';
         };
 
         manageMemberCtrl.removeMember = function removeMember(member_obj) {

--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -132,49 +132,6 @@
             });
         }
 
-        manageMemberCtrl.acceptRequest = function acceptRequest(request) {
-            var promise = RequestInvitationService.acceptRequest(request.key);
-
-            promise.then(function success(response) {
-                manageMemberCtrl.members.push(response);
-                request.status = 'accepted';
-                _.remove(manageMemberCtrl.requests, function (each) {
-                    return each.key === request.key;
-                });
-                MessageService.showToast("Pedido aceito!");
-            });
-            return promise;
-        };
-
-        manageMemberCtrl.rejectRequest = function rejectInvite(request, event){
-                var promise = RequestInvitationService.showRejectDialog(event);
-                promise.then(function() {
-                    deleteRequest(request);
-                }, function() {
-                    MessageService.showToast('Rejeição de pedido cancelada!');
-                });
-                return promise;
-        };
-
-        function deleteRequest(request) {
-            var promise = RequestInvitationService.rejectRequest(request.key);
-            promise.then(function success() {
-                removeRejectedRequest(request);
-                MessageService.showToast("O pedido foi rejeitado!");
-            }, function error(response) {
-                MessageService.showToast(response.data.msg);
-            });
-            return promise;
-        }
-
-        function removeRejectedRequest(request) {
-            request.status = 'rejected';
-            manageMemberCtrl.requests = manageMemberCtrl.requests.filter(function(req) {
-                return req.key !== request.key;
-            });
-            manageMemberCtrl.showRequests = manageMemberCtrl.requests.length > 0;
-        }
-
         manageMemberCtrl.clearInvite = function clearInvite() {
             manageMemberCtrl.emails = [_.clone(empty_email)];
             manageMemberCtrl.invite = {};

--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -79,7 +79,6 @@
                 openFrom: '#fab-new-post',
                 closeTo: angular.element(document.querySelector('#fab-new-post'))
             }).then(function success(processedRequest) {
-                console.log(processedRequest);
                 const request = manageMemberCtrl.requests.reduce(
                     (found, request) => (request.key === processedRequest.key) ? request : found, 
                     {}

--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -80,7 +80,7 @@
                 closeTo: angular.element(document.querySelector('#fab-new-post'))
             }).then(function success(requestKey) {
                 manageMemberCtrl.requests = manageMemberCtrl.requests.filter(
-                    request => (request.key === requestKey) ? false : true
+                    request => request.key !== requestKey
                 );
             }, function error() {
             });

--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -67,7 +67,7 @@
             }, function error() {});
         };
 
-        manageMemberCtrl.openAcceptRequestDialog = function openAcceptRequestDialog(requestKey) {
+        manageMemberCtrl.openAcceptRequestDialog = function openAcceptRequestDialog(requestKey, event) {
             $mdDialog.show({
                 controller: "RequestProcessingController",
                 controllerAs: "requestCtrl",
@@ -78,18 +78,12 @@
                 locals: {key: requestKey},
                 openFrom: '#fab-new-post',
                 closeTo: angular.element(document.querySelector('#fab-new-post'))
-            }).then(function success(processedRequest) {
-                const request = manageMemberCtrl.requests.reduce(
-                    (found, request) => (request.key === processedRequest.key) ? request : found, 
-                    {}
+            }).then(function success(requestKey) {
+                manageMemberCtrl.requests = manageMemberCtrl.requests.filter(
+                    request => (request.key === requestKey) ? false : true
                 );
-                request.status = processedRequest.status;
             }, function error() {
             });
-        };
-
-        manageMemberCtrl.isSentRequest = function isSentRequest(request) {
-            return request.status === 'sent';
         };
 
         manageMemberCtrl.removeMember = function removeMember(member_obj) {

--- a/frontend/institution/management_members.html
+++ b/frontend/institution/management_members.html
@@ -227,7 +227,7 @@
       <md-card-content ng-show="manageMemberCtrl.showRequests"
           style="overflow: auto; max-height: 270px;" class="custom-scrollbar">
         <md-list flex>
-          <md-list-item ng-repeat="request in manageMemberCtrl.requests" ng-click="manageMemberCtrl.openAcceptRequestDialog(request.key)" class="md-3-line">
+          <md-list-item ng-repeat="request in manageMemberCtrl.requests | filter: manageMemberCtrl.isSentRequest" ng-click="manageMemberCtrl.openAcceptRequestDialog(request.key)" class="md-3-line">
             <md-icon class="md-avatar-icon"
             md-colors="{background: 'light-green-500', color: 'grey-50'}">account_box</md-icon>
             <div class="md-list-item-text" layout="column">

--- a/frontend/institution/management_members.html
+++ b/frontend/institution/management_members.html
@@ -227,7 +227,7 @@
       <md-card-content ng-show="manageMemberCtrl.showRequests"
           style="overflow: auto; max-height: 270px;" class="custom-scrollbar">
         <md-list flex>
-          <md-list-item ng-repeat="request in manageMemberCtrl.requests | filter: manageMemberCtrl.isSentRequest" ng-click="manageMemberCtrl.openAcceptRequestDialog(request.key)" class="md-3-line">
+          <md-list-item ng-repeat="request in manageMemberCtrl.requests" ng-click="manageMemberCtrl.openAcceptRequestDialog(request.key, $event)" class="md-3-line">
             <md-icon class="md-avatar-icon"
             md-colors="{background: 'light-green-500', color: 'grey-50'}">account_box</md-icon>
             <div class="md-list-item-text" layout="column">

--- a/frontend/institution/management_members.html
+++ b/frontend/institution/management_members.html
@@ -235,8 +235,6 @@
               <h4>Cargo atual: {{ request.office}}</h4>
               <p>Email institucional: {{ request.institutional_email}}</p>
             </div>
-            <md-icon class="md-secondary md-hue-3" title="Rejeitar" ng-click="manageMemberCtrl.rejectRequest(request, $event)">close</md-icon>
-            <md-icon class="md-secondary" title="Aceitar membro" ng-click="manageMemberCtrl.acceptRequest(request)">send</md-icon>
           </md-list-item>
         </md-list>
       </md-card-content>

--- a/frontend/institution/management_members.html
+++ b/frontend/institution/management_members.html
@@ -227,7 +227,7 @@
       <md-card-content ng-show="manageMemberCtrl.showRequests"
           style="overflow: auto; max-height: 270px;" class="custom-scrollbar">
         <md-list flex>
-          <md-list-item ng-repeat="request in manageMemberCtrl.requests" ng-click="null" class="md-3-line">
+          <md-list-item ng-repeat="request in manageMemberCtrl.requests" ng-click="manageMemberCtrl.openAcceptRequestDialog(request.key)" class="md-3-line">
             <md-icon class="md-avatar-icon"
             md-colors="{background: 'light-green-500', color: 'grey-50'}">account_box</md-icon>
             <div class="md-list-item-text" layout="column">

--- a/frontend/requests/requestProcessingController.js
+++ b/frontend/requests/requestProcessingController.js
@@ -42,19 +42,6 @@
 
         requestController.rejectRequest = function rejectInvite(event){
             requestController.isRejecting = true;
-            /*var promise = RequestInvitationService.showRejectDialog(event);
-
-            promise.then(function() {
-                deleteRequest().then(function success() {
-                    MessageService.showToast("Solicitação rejeitada!");
-                    requestController.hideDialog();
-                }, function error(response) {
-                    MessageService.showToast(response.data.msg);
-                });
-            }, function() {
-                MessageService.showToast('Cancelado');
-            });
-            return promise;*/
         };
 
         requestController.confirmReject = function confirmReject() {
@@ -92,7 +79,7 @@
         };
 
         requestController.getSizeGtSmDialog = function getSizeGtSmDialog() {
-            return requestController.request && requestController.request.status === 'sent' ? '45' : '25';
+            return requestController.request && (requestController.request.status === 'sent' && !requestController.isRejecting) ? '45' : '25';
         };
 
         function loadInstitution(institutionKey) {

--- a/frontend/requests/requestProcessingController.js
+++ b/frontend/requests/requestProcessingController.js
@@ -9,6 +9,7 @@
 
         requestController.institution = null;
         requestController.requestKey = key;
+        requestController.isRejecting = false;
 
         var REQUEST_PARENT = "REQUEST_INSTITUTION_PARENT";
         var REQUEST_CHILDREN = "REQUEST_INSTITUTION_CHILDREN";
@@ -22,6 +23,7 @@
         requestController.acceptRequest = function acceptRequest() {
             resolveRequest().then(function success() {
                 MessageService.showToast("Solicitação aceita!");
+                requestController.request.status = 'accepted';
                 requestController.hideDialog();
             }, function error(response) {
                 MessageService.showToast(response.data.msg);
@@ -39,7 +41,8 @@
         }
 
         requestController.rejectRequest = function rejectInvite(event){
-            var promise = RequestInvitationService.showRejectDialog(event);
+            requestController.isRejecting = true;
+            /*var promise = RequestInvitationService.showRejectDialog(event);
 
             promise.then(function() {
                 deleteRequest().then(function success() {
@@ -51,7 +54,22 @@
             }, function() {
                 MessageService.showToast('Cancelado');
             });
-            return promise;
+            return promise;*/
+        };
+
+        requestController.confirmReject = function confirmReject() {
+            deleteRequest().then(function success() {
+                MessageService.showToast("Solicitação rejeitada!");
+                requestController.request.status = 'rejected';
+                requestController.hideDialog();
+            }, function error(response) {
+                MessageService.showToast(response.data.msg);
+            });
+        };
+
+        requestController.cancelReject = function cancelReject() {
+            $mdDialog.cancel();
+            MessageService.showToast('Cancelado');
         };
 
         requestController.getFullAddress = function getFullAddress(institution) {
@@ -70,7 +88,7 @@
         }
 
         requestController.hideDialog = function hideDialog() {
-            $mdDialog.hide();
+            $mdDialog.hide(requestController.request);
         };
 
         requestController.getSizeGtSmDialog = function getSizeGtSmDialog() {

--- a/frontend/requests/requestProcessingController.js
+++ b/frontend/requests/requestProcessingController.js
@@ -75,7 +75,7 @@
         }
 
         requestController.hideDialog = function hideDialog() {
-            $mdDialog.hide(requestController.request);
+            $mdDialog.hide(requestController.request.key);
         };
 
         requestController.getSizeGtSmDialog = function getSizeGtSmDialog() {

--- a/frontend/requests/request_processing.html
+++ b/frontend/requests/request_processing.html
@@ -38,7 +38,7 @@
   <md-dialog-actions ng-if="!requestCtrl.isRejecting" layout="row" layout-align="end center" layout-wrap>
     <md-button ng-click="requestCtrl.rejectRequest($event)" class="md-primary" 
       md-colors="{color: 'default-teal-500'}" ng-if="requestCtrl.isSentRequest">
-      Cancelar
+      Rejeitar
     </md-button>
     <md-button ng-click="requestCtrl.acceptRequest()" class="md-primary"
       md-colors="{color: 'default-teal-500'}" ng-if="requestCtrl.isSentRequest">
@@ -51,7 +51,8 @@
   </md-dialog-actions>
 
   <md-card-content ng-if="requestCtrl.isRejecting" class="md-dialog-content">
-    Deseja rejeitar o convite?
+    <h4 style="margin: 0;">Rejeitar Vínculo</h4>
+    <p>Tem certeza que deseja rejeitar?</p>
   </md-card-content>
   <md-dialog-actions ng-if="requestCtrl.isRejecting" layout="row" layout-align="end center" layout-wrap>
     <md-button class="md-primary" ng-click="requestCtrl.cancelReject()"

--- a/frontend/requests/request_processing.html
+++ b/frontend/requests/request_processing.html
@@ -1,5 +1,5 @@
 <md-dialog flex-gt-sm="{{requestCtrl.getSizeGtSmDialog()}}" flex-sm="80" flex-xs="100">
-  <md-dialog-content class="md-dialog-content" layout-gt-sm="column" 
+  <md-dialog-content ng-if="!requestCtrl.isRejecting" class="md-dialog-content" layout-gt-sm="column" 
     ng-if="requestCtrl.isSentRequest" layout-padding>
     <h4 style="margin: 0;">Confirmar Vínculo</h4>
     <p style="margin: 0;">Um usuário da plataforma solicitou vincular-se a uma das instituições que você administra. Clique em confirmar para aceitar ou cancelar para recusar vinculo.</p>
@@ -35,7 +35,7 @@
   <div ng-if="!requestCtrl.isSentRequest" style="padding: 15px 0 0 40px">
       <b>Você já resolveu esta solicitação.</b>
   </div>
-  <md-dialog-actions layout="row" layout-align="end center" layout-wrap>
+  <md-dialog-actions ng-if="!requestCtrl.isRejecting" layout="row" layout-align="end center" layout-wrap>
     <md-button ng-click="requestCtrl.rejectRequest($event)" class="md-primary" 
       md-colors="{color: 'default-teal-500'}" ng-if="requestCtrl.isSentRequest">
       Cancelar
@@ -46,6 +46,20 @@
     </md-button>
     <md-button ng-click="requestCtrl.hideDialog()" class="md-primary" 
       md-colors="{color: 'default-teal-500'}" ng-if="!requestCtrl.isSentRequest">
+        OK
+    </md-button>
+  </md-dialog-actions>
+
+  <md-card-content ng-if="requestCtrl.isRejecting" class="md-dialog-content">
+    Deseja rejeitar o convite?
+  </md-card-content>
+  <md-dialog-actions ng-if="requestCtrl.isRejecting" layout="row" layout-align="end center" layout-wrap>
+    <md-button class="md-primary" ng-click="requestCtrl.cancelReject()"
+      md-colors="{color: 'default-teal-500'}">
+      Cancelar
+    </md-button>
+    <md-button class="md-primary" ng-click="requestCtrl.confirmReject()"
+      md-colors="{color: 'default-teal-500'}">
         OK
     </md-button>
   </md-dialog-actions>

--- a/frontend/test/specs/managementMembersControllerSpec.js
+++ b/frontend/test/specs/managementMembersControllerSpec.js
@@ -304,5 +304,23 @@
                 expect(manageMemberCtrl.disableTransferAdminButton()).toBeFalsy();
             });
         });
+    
+        describe('openAcceptRequestDialog', function() {
+            beforeEach(function() {
+                spyOn(mdDialog, 'show').and.callFake(function() {
+                    return {
+                        then: function(callback) {
+                            callback(request.key);
+                        }
+                    };
+                });
+            });
+
+            it('Should remove request', function() {
+                expect(manageMemberCtrl.requests).toEqual([request]);
+                manageMemberCtrl.openAcceptRequestDialog(request, 'event');
+                expect(manageMemberCtrl.requests).toEqual([]);
+            });  
+        });
     });
 }));

--- a/frontend/test/specs/managementMembersControllerSpec.js
+++ b/frontend/test/specs/managementMembersControllerSpec.js
@@ -281,21 +281,6 @@
             });
         });
 
-        describe('acceptRequest', function() {
-            it('should remove the request from the array', function() {
-                spyOn(requestInvitationService, 'acceptRequest').and.callFake(function () {
-                    return {
-                        then: function (callback) {
-                            return callback();
-                        }
-                    };
-                });
-                manageMemberCtrl.acceptRequest(request);
-                expect(request.status).toEqual('accepted');
-                expect(manageMemberCtrl.requests).toEqual([]);
-            })
-        });
-
         describe('disableTransferAdminButton', function() {
 
             it('Should return true if invitation sent', function() {


### PR DESCRIPTION
**Feature/Bug description:**  When you receive a request to be a member of an institution and enter the membership management page to accept, the form of acceptance is different from when the user clicks on the notification.

![screenshot from 2018-04-17 10-56-36](https://user-images.githubusercontent.com/18005317/38874331-371ab81e-422e-11e8-91fa-be73e0e3111a.png)

**Solution:** I've changed how to accept requests to be a member of the member management page so that it complies with the notification.

![screenshot from 2018-04-17 10-55-05](https://user-images.githubusercontent.com/18005317/38874329-33d44bb6-422e-11e8-9329-65547ec136b2.png)

**TODO/FIXME:** n/a