### PR TITLE
Fix remove link between institution in firefox

### DIFF
--- a/frontend/invites/inviteInstHierarchieController.js
+++ b/frontend/invites/inviteInstHierarchieController.js
@@ -216,13 +216,13 @@
             inviteInstHierCtrl.requested_invites.push(invite);
         };
 
-        inviteInstHierCtrl.removeLink = function removeLink(institution, isParent) {
+        inviteInstHierCtrl.removeLink = function removeLink($event, institution, isParent) {
             var confirm = $mdDialog.confirm({onComplete: designOptions})
                 .clickOutsideToClose(true)
                 .title('Confirmar Remoção')
                 .textContent('Confirmar a remoção dessa conexão?')
                 .ariaLabel('Confirmar Remoção')
-                .targetEvent(event)
+                .targetEvent($event)
                 .ok('Sim')
                 .cancel('Não');
 

--- a/frontend/invites/invite_institution_hierarchie.html
+++ b/frontend/invites/invite_institution_hierarchie.html
@@ -73,7 +73,7 @@
               </div>
             </div>
             <div ng-if="inviteInstHierCtrl.isActive(inviteInstHierCtrl.institution.parent_institution)">
-              <md-button ng-click="inviteInstHierCtrl.removeLink(inviteInstHierCtrl.institution.parent_institution, true)">
+              <md-button ng-click="inviteInstHierCtrl.removeLink(event, inviteInstHierCtrl.institution.parent_institution, true)">
                 <md-icon md-colors="{color: 'red-700'}" title="Remover conexão">link</md-icon>
               </md-button>
             </div>
@@ -115,7 +115,7 @@
                 </div>
               </div>
               <div ng-if="inviteInstHierCtrl.isActive(institution)" layout="row">
-                <md-button ng-click="inviteInstHierCtrl.removeLink(institution, false)">
+                <md-button ng-click="inviteInstHierCtrl.removeLink(event, institution, false)">
                   <md-icon md-colors="{color: 'red-700'}" title="Remover conexão">link</md-icon>
                 </md-button>
                 <md-button ng-if="inviteInstHierCtrl.canRemoveInst(institution.key)" ng-click="inviteInstHierCtrl.removeChild(institution)">

--- a/frontend/test/inviteInstHierarchieControllerSpec.js
+++ b/frontend/test/inviteInstHierarchieControllerSpec.js
@@ -247,7 +247,7 @@
         });
 
         it('should remove parent link', function () {
-            inviteInstHierarchieCtrl.removeLink(otherInst, true);
+            inviteInstHierarchieCtrl.removeLink("event", otherInst, true);
             expect(mdDialog.confirm).toHaveBeenCalled();
             expect(mdDialog.show).toHaveBeenCalled();
             expect(instService.removeLink).toHaveBeenCalled();
@@ -258,7 +258,7 @@
         it('should remove child link', function() {
             inviteInstHierarchieCtrl.institution.children_institutions = [otherInst];
             expect(inviteInstHierarchieCtrl.institution.children_institutions).toEqual([otherInst]);
-            inviteInstHierarchieCtrl.removeLink(otherInst, false);
+            inviteInstHierarchieCtrl.removeLink("event", otherInst, false);
             expect(mdDialog.confirm).toHaveBeenCalled();
             expect(mdDialog.show).toHaveBeenCalled();
             expect(instService.removeLink).toHaveBeenCalled();


### PR DESCRIPTION
**Feature/Bug description:** When removeLink method is called it returns an error in Firefox, that event was undefined.

**Solution:** Pass event to the function by HTML.

**TODO/FIXME:** n/a