### PR TITLE
Fix notification page

### DIFF
--- a/frontend/notification/notifications_page.html
+++ b/frontend/notification/notifications_page.html
@@ -1,4 +1,4 @@
-<div flex layout="row" layout-align="center">
+<div layout="row" layout-align="center">
     <md-card flex="95">
         <md-toolbar md-colors="{background: 'teal-500'}" layout="row">
             <div class="md-toolbar-tools">
@@ -17,15 +17,15 @@
                     </md-input-container>
                 </form>
             </div>
-            <md-content class="custom-scrollbar">
-                <md-list style="padding: 10px;">
+            <md-content class="custom-scrollbar" flex>
+                <md-list style="padding: 10px;" flex>
                     <md-list-item title="{{notificationCtrl.format(notification)}}" class="md-3-line" md-colors="{background: 'grey-200'}" style="margin-bottom: 5px; padding: 3 0 3 0;"
                         ng-repeat="notification in notificationCtrl.allNotifications | orderBy:'-timestamp' | filter: notificationCtrl.keyword" 
-                        ng-click="notificationCtrl.action(notification, $event)">
+                        ng-click="notificationCtrl.action(notification, $event)" flex-xs>
                             <img ng-src="{{notification.from.photo_url}}" class="md-avatar" style="width: 60px; height: 60px;"/>
                             <div class="md-list-item-text" layout="column">
-                                <p><b style="font-size: 18px;">{{ notificationCtrl.limitString(notification.from.name, 85) }}</b></p>
-                                <p><b style="font-size: 15px; color: #009688;">{{ notificationCtrl.limitString(notification.from.institution_name, 85) }}</b></p>
+                                <p><b style="font-size: 18px;">{{ notification.from.name }}</b></p>
+                                <p><b style="font-size: 15px; color: #009688;">{{ notification.from.institution_name }}</b></p>
                                 <div layout="row">
                                     <div class="notification-icon-bg" hide show-gt-xs>
                                         <md-icon class="notification-icon">{{notificationCtrl.getIcon(notification.entity_type)}}</md-icon>
@@ -33,12 +33,15 @@
                                     <div class="notification-icon-bg" hide show-xs style="margin-top: 1em;">
                                         <md-icon class="notification-icon">{{notificationCtrl.getIcon(notification.entity_type)}}</md-icon>
                                     </div>
-                                    <div style="max-height: 3em; margin-left: 4px; margin-top: 10px">
+                                    <div style="max-height: 6em; margin-left: 4px; margin-top: 4px">
                                         <p style="font-size: 11px;">
-                                            <b>
-                                                {{ notificationCtrl.limitString(notificationCtrl.format(notification), 95) }} - 
+                                            <p style="font-size: 10px;">
                                                 {{ notification.timestamp | amUtc | amLocal | amCalendar:referenceTime:formats }}
-                                            </b>
+                                                </br>
+                                                <b style="font-size: 11px; margin-top: -10px;">
+                                                        {{ notificationCtrl.format(notification) }}
+                                                </b>
+                                            </p>
                                         </p>
                                     </div>
                                 </div>

--- a/frontend/notification/notifications_page.html
+++ b/frontend/notification/notifications_page.html
@@ -33,7 +33,7 @@
                                     <div class="notification-icon-bg" hide show-xs style="margin-top: 1em;">
                                         <md-icon class="notification-icon">{{notificationCtrl.getIcon(notification.entity_type)}}</md-icon>
                                     </div>
-                                    <div style="max-height: 6em; margin-left: 4px; margin-top: 4px">
+                                    <div style="max-height: 7em; margin-left: 4px; margin-top: 4px">
                                         <p style="font-size: 11px;">
                                             <p style="font-size: 10px;">
                                                 {{ notification.timestamp | amUtc | amLocal | amCalendar:referenceTime:formats }}


### PR DESCRIPTION
**Feature/Bug description:** The notifications page are broken card on Mozilla Firefox and don't show the full description in all browsers.

**Solution:** Changing the location of 'flex' in HTML and fixing the card to contain all notifications and adjusting the styles to display the full description of notifications.

The card now shows all notifications without broken in Mozilla Firefox.
![screenshot from 2018-04-17 16-56-15](https://user-images.githubusercontent.com/20300259/38893594-1ac6dab6-4261-11e8-89bf-829f385f18c7.png)

Displaying full description in small screens.
![screenshot from 2018-04-17 16-57-06](https://user-images.githubusercontent.com/20300259/38893620-355086de-4261-11e8-9cea-5e0b60fc3008.png)

Displaying full description in medium screens too.
![screenshot from 2018-04-17 16-57-45](https://user-images.githubusercontent.com/20300259/38893644-45ac4da6-4261-11e8-9399-a141dd254b91.png)

**TODO/FIXME:** n/a