### PR TITLE
Fix shared post notification

### DIFF
--- a/backend/handlers/post_collection_handler.py
+++ b/backend/handlers/post_collection_handler.py
@@ -88,10 +88,9 @@ class PostCollectionHandler(BaseHandler):
             params = {
                 'receiver_key': shared_post.author.urlsafe(),
                 'sender_key': user.key.urlsafe(),
-                'entity_key': post.key.urlsafe(),
+                'entity_key': shared_post.key.urlsafe(),
                 'entity_type': entity_type,
                 'current_institution': user.current_institution.urlsafe(),
-                'shared_entity_key': shared_post.key.urlsafe()
             }
 
             enqueue_task('post-notification', params)

--- a/backend/test/post_collection_handler_test.py
+++ b/backend/test/post_collection_handler_test.py
@@ -208,10 +208,9 @@ class PostCollectionHandlerTest(TestBaseHandler):
                 {
                     'receiver_key': self.post.author.urlsafe(),
                     'sender_key': self.user.key.urlsafe(),
-                    'entity_key': key_post.urlsafe(),
+                    'entity_key': self.post.key.urlsafe(),
                     'entity_type': 'SHARED_POST',
                     'current_institution': self.institution.key.urlsafe(),
-                    'shared_entity_key': self.post.key.urlsafe()
                 }
             )
         ]

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -219,7 +219,7 @@ class PostNotificationHandler(BaseHandler):
                     subscriber,
                     sender_key,
                     entity_type,
-                    post_key,
+                    shared_entity_key or post_key,
                     current_institution
                 )
 

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -205,11 +205,8 @@ class PostNotificationHandler(BaseHandler):
         post_key = self.request.get('entity_key')
         entity_type = self.request.get('entity_type')
         current_institution = ndb.Key(urlsafe=self.request.get('current_institution'))
-        shared_entity_key = self.request.get('shared_entity_key')
         post = ndb.Key(urlsafe=post_key).get()
-        subscribers = [
-            subscriber.urlsafe() for subscriber in ndb.Key(urlsafe=shared_entity_key).get().subscribers] if shared_entity_key else [
-            subscriber.urlsafe() for subscriber in post.subscribers]
+        subscribers =  [subscriber.urlsafe() for subscriber in post.subscribers]
 
         user_is_author = post_author_key == sender_key
         for subscriber in subscribers:
@@ -219,7 +216,7 @@ class PostNotificationHandler(BaseHandler):
                     subscriber,
                     sender_key,
                     entity_type,
-                    shared_entity_key or post_key,
+                    post_key,
                     current_institution
                 )
 


### PR DESCRIPTION
**Feature/Bug description:** When sharing a post the notification that is sent is wrong because the institution that is sent in the notification is not the institution in which the original post was created.

![screenshot from 2018-04-18 09-46-25](https://user-images.githubusercontent.com/18005317/38932863-c636be02-42ed-11e8-9be3-663a2a09a518.png)

**Solution:** In the send_message_Notification method used in postNotificationsHandler I pass the key of the post that was shared when it exists, if there is no key to the original post.

![screenshot from 2018-04-18 09-46-36](https://user-images.githubusercontent.com/18005317/38932870-c9cd0b48-42ed-11e8-9f17-2d28406ea611.png)

**TODO/FIXME:** n/a