### PR TITLE
Fix invite members passing empty emails

### DIFF
--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -110,7 +110,7 @@
                 emails: emails
             }
             
-            if (manageMemberCtrl.isValidAllEmails() && manageMemberCtrl.isUserInviteValid(invite)) {
+            if (manageMemberCtrl.isValidAllEmails(emails) && manageMemberCtrl.isUserInviteValid(invite)) {
                 manageMemberCtrl.isLoadingInvite = true;
                 var promise = InviteService.sendInvite(requestBody);
                 promise.then(function success(response) {
@@ -277,10 +277,13 @@
             return _.uniq(emailsNotMembersAndNotInvited);
         }
 
-        manageMemberCtrl.isValidAllEmails = function isValidAllEmails() {
-            var emails = manageMemberCtrl.emails.map(email => email.email);
+        manageMemberCtrl.isValidAllEmails = function isValidAllEmails(emails) {
+            if(_.size(emails) === 0 ){
+                MessageService.showToast("Insira pelo menos um email.");
+                return false;
+            }
+    
             var correctArray = manageMemberCtrl.removePendingAndMembersEmails(emails);
-
             if(!_.isEqual(correctArray, emails)){
                 MessageService.showToast("E-mails selecionados já foram convidados, " +
                                 "requisitaram ser membro ou pertencem a algum" +
@@ -357,7 +360,7 @@
         };
 
         function getEmails(loadedEmails) {
-            if(loadedEmails && loadedEmails.length > 0) return loadedEmails;
+            if(!_.isUndefined(loadedEmails) && loadedEmails.length > 0) return loadedEmails;
             var emails = [];
             _.each(manageMemberCtrl.emails, function (email) {
                 if (!_.isEmpty(email.email)) {

--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -360,7 +360,7 @@
         };
 
         function getEmails(loadedEmails) {
-            if(!_.isUndefined(loadedEmails) && loadedEmails.length > 0) return loadedEmails;
+            if(loadedEmails && loadedEmails.length > 0) return loadedEmails;
             var emails = [];
             _.each(manageMemberCtrl.emails, function (email) {
                 if (!_.isEmpty(email.email)) {

--- a/frontend/test/specs/managementMembersControllerSpec.js
+++ b/frontend/test/specs/managementMembersControllerSpec.js
@@ -196,7 +196,7 @@
                                             institution_key: '987654321',
                                             admin_key: '12345'});
                 manageMemberCtrl.emails = [{'email' : "testuser@example.com"}];
-                expect(manageMemberCtrl.isValidAllEmails()).toBe(false);
+                expect(manageMemberCtrl.isValidAllEmails(["testuser@example.com"])).toBe(false);
             });
 
             it('should be false when the invitee was already member', function() {
@@ -205,7 +205,7 @@
                                             admin_key: '12345'});
 
                  manageMemberCtrl.emails = [{'email' :"member@gmail.com"}];
-                expect(manageMemberCtrl.isValidAllEmails()).toBe(false);
+                expect(manageMemberCtrl.isValidAllEmails(["member@gmail.com"])).toBe(false);
             });
 
             it('should be false when the email was written more then one times', function() {
@@ -214,7 +214,7 @@
                                             admin_key: '12345'});
 
                 manageMemberCtrl.emails = [{'email': "new@gmail.com"}, {'email': "new@gmail.com"}];
-                expect(manageMemberCtrl.isValidAllEmails()).toBe(false);
+                expect(manageMemberCtrl.isValidAllEmails(["new@gmail.com", "new@gmail.com"])).toBe(false);
             });
 
             it('should be false when the invitee requested an invitation', function() {
@@ -223,7 +223,7 @@
                                             admin_key: '12345'});
 
                  manageMemberCtrl.emails = [{'email': 'request@gmail.com'}];
-                expect(manageMemberCtrl.isValidAllEmails()).toBe(false);
+                expect(manageMemberCtrl.isValidAllEmails(['request@gmail.com'])).toBe(false);
             });
 
            it('should be true', function() {
@@ -232,7 +232,7 @@
                                             admin_key: '12345'});
 
                  manageMemberCtrl.emails = [{'email': 'email@gmail.com'}];
-                expect(manageMemberCtrl.isValidAllEmails()).toBe(true);
+                expect(manageMemberCtrl.isValidAllEmails(['email@gmail.com'])).toBe(true);
             });
         });
 


### PR DESCRIPTION
**Feature/Bug description:** The user at this moment can send the invite when emails fields are empty.

**Solution:** Added verification in the method isValidAllEmails.

**TODO/FIXME:** n/a

![screenshot from 2018-04-18 10-50-12](https://user-images.githubusercontent.com/18709274/38936552-69a3d56c-42f7-11e8-8082-ec5268d50dc7.png)
