### PR TITLE
Fix delete specific institution button for children.

### DIFF
--- a/frontend/invites/inviteInstHierarchieController.js
+++ b/frontend/invites/inviteInstHierarchieController.js
@@ -350,8 +350,9 @@
                 angular.element($cancelButton).addClass('md-primary');
         }
 
-        inviteInstHierCtrl.canRemoveInst = function canRemoveInst(institution_key) {
-            return inviteInstHierCtrl.user.permissions.remove_inst[institution_key];
+        inviteInstHierCtrl.canRemoveInst = function canRemoveInst(institution) {
+            var hasChildrenLink = institution.parent_institution === inviteInstHierCtrl.institution.key;
+            return inviteInstHierCtrl.user.permissions.remove_inst[institution.key] && hasChildrenLink;
         };
 
         inviteInstHierCtrl.linkParentStatus = function linkParentStatus() {

--- a/frontend/invites/invite_institution_hierarchie.html
+++ b/frontend/invites/invite_institution_hierarchie.html
@@ -118,7 +118,7 @@
                 <md-button ng-click="inviteInstHierCtrl.removeLink(event, institution, false)">
                   <md-icon md-colors="{color: 'red-700'}" title="Remover conexão">link</md-icon>
                 </md-button>
-                <md-button ng-if="inviteInstHierCtrl.canRemoveInst(institution.key)" ng-click="inviteInstHierCtrl.removeChild(institution)">
+                <md-button ng-if="inviteInstHierCtrl.canRemoveInst(institution)" ng-click="inviteInstHierCtrl.removeChild(institution)">
                   <md-icon md-colors="{color: 'red-700'}" title="Remover institutição">delete</md-icon>
                 </md-button>
               </div>

--- a/frontend/test/inviteInstHierarchieControllerSpec.js
+++ b/frontend/test/inviteInstHierarchieControllerSpec.js
@@ -223,6 +223,43 @@
         });
     });
 
+    describe('canRemoveInst', function() {
+        it('should be true', function() {
+            var children_institution = {
+                key: 'key-1234',
+                state: 'active',
+                parent_institution: institution.key
+            };
+            user.permissions['remove_inst'] = _.set({}, children_institution.key, true);
+            institution.children_institutions = [children_institution.key] 
+            
+            expect(inviteInstHierarchieCtrl.canRemoveInst(children_institution)).toBeTruthy();
+        });
+
+        it("should be false, because don't have parent inst", function() {
+            var children_institution = {
+                key: 'key-1234',
+                state: 'active'
+            };
+            user.permissions['remove_inst'] = _.set({}, children_institution.key, true);
+            institution.children_institutions = [] 
+            
+            expect(inviteInstHierarchieCtrl.canRemoveInst(children_institution)).toBeFalsy();
+        });
+
+        it('should be false, because the user dont have permission', function() {
+            var children_institution = {
+                key: 'key-1234',
+                state: 'active',
+                parent_institution: institution.key
+            };
+            user.permissions.remove_inst[children_institution.key] = false;
+            institution.children_institutions = [children_institution.key] 
+            
+            expect(inviteInstHierarchieCtrl.canRemoveInst(children_institution)).toBeFalsy();
+        });
+    });
+
     describe('removeLink()', function () {
         var otherInst;
 


### PR DESCRIPTION
**Feature/Bug description:** When removes the link between institutions if the super-institution admin is admin of substitution too, the user can see the button to delete substitution. 

**Solution:** Show button when the user has permission and has the link between institutions.

**TODO/FIXME:** n/a

![screenshot from 2018-04-18 15-52-18](https://user-images.githubusercontent.com/18709274/38952050-bdd15eba-4320-11e8-8e31-a335fc82d829.png)
![screenshot from 2018-04-18 15-52-51](https://user-images.githubusercontent.com/18709274/38952051-bdf14d92-4320-11e8-8c49-dd9db808bb35.png)
