### PR TITLE
Fix show message if edit post is fail

### DIFF
--- a/frontend/post/postDirective.js
+++ b/frontend/post/postDirective.js
@@ -304,7 +304,7 @@
                             MessageService.showToast(response.data.msg);
                         });
                     }, function error() {
-                        MessageService.showToast("Esse post não pode ser editado pois já possue atividade");
+                        MessageService.showToast("Esse post não pode ser editado pois já possui atividade");
                     });
                 } else {
                     MessageService.showToast('Edição inválida!');

--- a/frontend/post/postDirective.js
+++ b/frontend/post/postDirective.js
@@ -303,6 +303,8 @@
                             $mdDialog.cancel();
                             MessageService.showToast(response.data.msg);
                         });
+                    }, function error() {
+                        MessageService.showToast("Esse post não pode ser editado pois já possue atividade");
                     });
                 } else {
                     MessageService.showToast('Edição inválida!');


### PR DESCRIPTION
**Feature/Bug description:** When a user creates a post and opens the modal edit post and tries to edit it if the post already has action, this edition does not work and no message appears to the user informing that the operation did not work.

![screenshot from 2018-04-20 10-12-19](https://user-images.githubusercontent.com/18005317/39052782-83ae63e0-4483-11e8-83ed-4055bf2d6711.png)

**Solution:** I added an error message when the user can no longer edit the post and the post editing fails.

![screenshot from 2018-04-20 10-12-27](https://user-images.githubusercontent.com/18005317/39052795-8c06ea76-4483-11e8-99a6-d3168ee50c58.png)

**TODO/FIXME:** n/a