### PR TITLE
Fix notification of delete post

### DIFF
--- a/backend/handlers/post_handler.py
+++ b/backend/handlers/post_handler.py
@@ -71,7 +71,7 @@ class PostHandler(BaseHandler):
 
         if(is_admin and not is_author):
             send_message_notification(post.author.urlsafe(), user.key.urlsafe(), 
-                'DELETED_POST', post.key.urlsafe(), entity=json.dumps(post.make(self.request.host)))
+                'DELETED_POST', post.key.urlsafe(), user.current_institution, entity=json.dumps(post.make(self.request.host)))
 
     @json_response
     @login_required


### PR DESCRIPTION
**Feature/Bug description:** When a user deletes a post, the notification sent does not have the current institution.

![screenshot from 2018-04-20 10-36-40](https://user-images.githubusercontent.com/18005317/39054050-00c2ac8a-4487-11e8-9d81-fcda31b3ced3.png)

**Solution:** I sent the user's current institution along with the notification that the post was deleted.

![screenshot from 2018-04-20 10-36-33](https://user-images.githubusercontent.com/18005317/39054062-03faaa74-4487-11e8-9e20-81c4f86b7c22.png)

**TODO/FIXME:** n/a