### PR TITLE
Fix like post when deleted post

### DIFF
--- a/backend/handlers/like_handler.py
+++ b/backend/handlers/like_handler.py
@@ -8,6 +8,7 @@ from utils import json_response
 from handlers.base_handler import BaseHandler
 from models.post import Like
 from custom_exceptions.notAuthorizedException import NotAuthorizedException
+from custom_exceptions.entityException import EntityException
 from service_entities import enqueue_task
 from service_messages import send_message_notification
 from utils import Utils
@@ -48,6 +49,8 @@ class LikeHandler(BaseHandler):
         """Handle POST Requests."""
         """This method is only meant to give like in post, comment or reply and send notification."""
         post = ndb.Key(urlsafe=post_key).get()
+        Utils._assert(post.state == 'deleted',
+                      "This post has been deleted", EntityException)
         if comment_id:            
             comment = post.like_comment(user, comment_id, reply_id)
 


### PR DESCRIPTION
**Feature/Bug description:** When a user creates a post and then deletes it, if another user who is viewing the post does not refresh the page, it still succeeds in like the post.

**Solution:** I added a check in the like_handler that checks if the post is deleted, if yes, does not let give like.

**TODO/FIXME:** n/a