### PR TITLE
Fix share event notification

### DIFF
--- a/backend/handlers/post_collection_handler.py
+++ b/backend/handlers/post_collection_handler.py
@@ -96,7 +96,7 @@ class PostCollectionHandler(BaseHandler):
             enqueue_task('post-notification', params)
         elif post.shared_event:
             shared_event = post.shared_event.get()
-            if shared_event.author_key != user.key.urlsafe():
+            if shared_event.author_key != user.key:
                 send_message_notification(
                     shared_event.author_key.urlsafe(),
                     user.key.urlsafe(),

--- a/backend/test/post_collection_handler_test.py
+++ b/backend/test/post_collection_handler_test.py
@@ -224,7 +224,7 @@ class PostCollectionHandlerTest(TestBaseHandler):
     def test_post_shared_event(self, verify_token, send_message_notification, enqueue_task):
         """Test the post_collection_handler's post method in case that post is shared_event."""
         # create an event
-        event = mocks.create_event(self.user, self.institution)
+        event = mocks.create_event(self.other_user, self.institution)
         event.text = "Description of new Event"
         event.put()
         # Make the request and assign the answer to post
@@ -258,8 +258,8 @@ class PostCollectionHandlerTest(TestBaseHandler):
                          self.institution.key.urlsafe(),
                          "The post's institution expected is %s" % self.institution.key.urlsafe())
         self.assertEqual(shared_event_obj['author_key'],
-                         self.user.key.urlsafe(),
-                         "The post's institution expected is %s" % self.user.key.urlsafe())
+                         self.other_user.key.urlsafe(),
+                         "The post's institution expected is %s" % self.other_user.key.urlsafe())
         self.assertEqual(shared_event_obj['text'],
                          event.text,
                          "The post's text expected is %s" % event.text)


### PR DESCRIPTION
**Feature/Bug description:** Event author shouldn't receive notification when herself share the event.

**Solution:** Fix verification

**TODO/FIXME:** n/a