### PR TITLE
Moving the institution's removal to the queue.

### DIFF
--- a/backend/handlers/institution_handler.py
+++ b/backend/handlers/institution_handler.py
@@ -110,6 +110,7 @@ class InstitutionHandler(BaseHandler):
                               institution_key)
 
         data = self.request.body
+        print data
         institution = ndb.Key(urlsafe=institution_key).get()
 
         Utils._assert(institution.state == 'inactive',
@@ -193,14 +194,13 @@ class InstitutionHandler(BaseHandler):
 
         Utils._assert(not type(institution) is Institution,
                       "Key is not an institution", EntityException)
-        """TODO: Move this call to a queue
-        @author: Raoni Smaneoto 02/04/2018
-        """
+
         institution.remove_institution(remove_hierarchy, user)
 
         params = {
             'institution_key': institution_key,
-            'remove_hierarchy': remove_hierarchy
+            'remove_hierarchy': remove_hierarchy,
+            'user_key': user.key.urlsafe() 
         }
 
         enqueue_task('remove-inst', params)

--- a/backend/handlers/institution_handler.py
+++ b/backend/handlers/institution_handler.py
@@ -110,7 +110,6 @@ class InstitutionHandler(BaseHandler):
                               institution_key)
 
         data = self.request.body
-        print data
         institution = ndb.Key(urlsafe=institution_key).get()
 
         Utils._assert(institution.state == 'inactive',

--- a/backend/models/institution.py
+++ b/backend/models/institution.py
@@ -202,7 +202,7 @@ class Institution(ndb.Model):
         """
         has_permission = user.has_permission('remove_inst', self.key.urlsafe(
         )) or user.has_permission('remove_insts', self.key.urlsafe())
-        
+
         if(has_permission):
             self.state = "inactive"
             user.remove_institution(self.key)
@@ -210,6 +210,15 @@ class Institution(ndb.Model):
     
     @ndb.transactional(xg=True)
     def handle_hierarchy_removal(self, remove_hierarchy, user):
+        """This method allows this procedure to be done in a queue.
+        It handles the hierarchy removal once it is called by every child
+        institution.
+
+        Keyword arguments:
+        remove_hierarchy -- works as a flag that indicates the institution's hierarchy removal
+        user -- the user who started the institution's removal process. So, it may not be the admin
+        of self.
+        """
         # Remove the hierarchy
         if remove_hierarchy == "true":
             self.remove_institution_hierarchy(remove_hierarchy, user)
@@ -260,7 +269,7 @@ class Institution(ndb.Model):
 
     @ndb.transactional(xg=True)
     def remove_institution_from_users(self, remove_hierarchy):
-        """Remove institution from members/followers list.
+        """Remove institution from members/followers list when an institution is deleted.
 
         This method allows this procedure to be done in a queue.
         """

--- a/backend/test/remove_institution_handler_test.py
+++ b/backend/test/remove_institution_handler_test.py
@@ -4,6 +4,8 @@
 from test_base_handler import TestBaseHandler
 from worker import RemoveInstitutionHandler
 import mocks
+from permissions import DEFAULT_ADMIN_PERMISSIONS
+from test_base_handler import has_permissions
 
 
 class RemoveInstitutionHandlerTest(TestBaseHandler):
@@ -28,26 +30,37 @@ class RemoveInstitutionHandlerTest(TestBaseHandler):
         admin = mocks.create_user()
         common_user = mocks.create_user()
         institution = mocks.create_institution()
+        child_institution = mocks.create_institution()
         institution.address = mocks.create_address()
         admin.institutions_admin = [institution.key]
         admin.add_institution(institution.key)
         admin.follows = [institution.key]
         institution.members = [admin.key, common_user.key]
         institution.set_admin(admin.key)
+        child_institution.parent_institution = institution.key
+        child_institution.admin = common_user.key
+        common_user.institutions_admin = [child_institution.key]
+        institution.children_institutions.append(child_institution.key)
         institution.put()
+        child_institution.put()
         common_user.add_institution(institution.key)
         common_user.follows = [institution.key]
         admin.put()
         common_user.put()
         self.assertTrue(institution.key in admin.institutions)
         self.assertTrue(institution.key in common_user.institutions)
+        admin.add_permissions(DEFAULT_ADMIN_PERMISSIONS, institution.key.urlsafe())
+        admin.add_permissions(DEFAULT_ADMIN_PERMISSIONS,
+                              child_institution.key.urlsafe())
         # Call the post method
-        self.testapp.post('/api/queue/remove-inst?institution_key=%s&remove_hierarchy=true'
-                          % (institution.key.urlsafe()))
+        self.testapp.post('/api/queue/remove-inst?institution_key=%s&remove_hierarchy=true&user_key=%s'
+                          % (institution.key.urlsafe(), admin.key.urlsafe()))
         # Retrieving the entities
         admin = admin.key.get()
         common_user = common_user.key.get()
+        child_institution = child_institution.key.get()
         # Check if the method worked as expected
-        self.assertTrue(institution.key not in admin.institutions)
-        self.assertTrue(institution.key not in common_user.institutions)
-        self.assertTrue(institution.key not in admin.institutions_admin)
+        self.assertFalse(has_permissions(admin, institution.key.urlsafe(), DEFAULT_ADMIN_PERMISSIONS))
+        self.assertFalse(has_permissions(
+            admin, child_institution.key.urlsafe(), DEFAULT_ADMIN_PERMISSIONS))
+        self.assertTrue(child_institution.state == 'inactive')

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -82,11 +82,10 @@ def get_all_parent_admins(child_institution, admins=[]):
     The admins' list starts empty and as passed by reference is the same over the recursion's stack.
     child_institution is used to get the parent and so on go up in the hierarchy.
     """
+    admins.append(child_institution.admin.get())
     parent_institution = child_institution.parent_institution
     if parent_institution:
         parent_institution = parent_institution.get()
-        admin = parent_institution.admin
-        admins.append(admin.get())
         get_all_parent_admins(parent_institution, admins)
     return admins
 
@@ -187,12 +186,14 @@ class RemoveInstitutionHandler(BaseHandler):
         institution_key = self.request.get('institution_key')
         remove_hierarchy = self.request.get('remove_hierarchy')
         institution = ndb.Key(urlsafe=institution_key).get()
-        institution.handle_hierarchy_removal(remove_hierarchy)
+        user = ndb.Key(urlsafe=self.request.get('user_key')).get()
+
         @ndb.transactional(xg=True, retries=10)
-        def apply_remove_operation(remove_hierarchy, institution):
-            remove_permissions(remove_hierarchy, institution)
+        def apply_remove_operation(remove_hierarchy, institution, user):
+            institution.handle_hierarchy_removal(remove_hierarchy, user)
             institution.remove_institution_from_users(remove_hierarchy)
-        apply_remove_operation(remove_hierarchy, institution)
+            remove_permissions(remove_hierarchy, institution)
+        apply_remove_operation(remove_hierarchy, institution, user)
 
 
 class PostNotificationHandler(BaseHandler):

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -187,7 +187,7 @@ class RemoveInstitutionHandler(BaseHandler):
         institution_key = self.request.get('institution_key')
         remove_hierarchy = self.request.get('remove_hierarchy')
         institution = ndb.Key(urlsafe=institution_key).get()
-
+        institution.handle_hierarchy_removal(remove_hierarchy)
         @ndb.transactional(xg=True, retries=10)
         def apply_remove_operation(remove_hierarchy, institution):
             remove_permissions(remove_hierarchy, institution)


### PR DESCRIPTION
**Feature/Bug description:**
The institution's removal process wasn't being done in a queue. Sometimes the code was going down in the hierarchy right inside of the handler, making this kind of request very slow. Besides, the get_all_parent_admins method was wrong.

**Solution:**
I've refactored the remove_institution method what allowed me to move the hierarchy removal to the queue.
I've fixed the get_all_parent_admins method.

**TODO/FIXME:** n/a