### PR TITLE
Fix concurrence problem in reply comment.

### DIFF
--- a/backend/handlers/reply_comment_handler.py
+++ b/backend/handlers/reply_comment_handler.py
@@ -40,7 +40,6 @@ class ReplyCommentHandler(BaseHandler):
 
     @json_response
     @login_required
-    @ndb.transactional(xg=True)
     def post(self, user, post_key, comment_id):
         """Handle Post Comments requests."""
         data = json.loads(self.request.body)

--- a/backend/handlers/reply_comment_handler.py
+++ b/backend/handlers/reply_comment_handler.py
@@ -55,7 +55,6 @@ class ReplyCommentHandler(BaseHandler):
 
         reply = Comment.create(reply_data, user)
         post.reply_comment(reply, comment_id)
-        post.put()
 
         entity_type = 'COMMENT'
 

--- a/backend/models/post.py
+++ b/backend/models/post.py
@@ -265,12 +265,14 @@ class Post(PolyModel):
         del self.comments[comment.get('id')]
         self.put()
 
+    @ndb.transactional(retries=10)
     def reply_comment(self, reply, comment_id):
         comment = self.get_comment(comment_id)
         Utils._assert(
             not comment, "This comment has been deleted.", EntityException)
         replies = comment.get('replies')
         replies[reply.id] = Utils.toJson(reply)
+        self.put()
 
     def get_like(self, author_key):
         """Get a like by author key."""

--- a/backend/test/like_reply_handler_test.py
+++ b/backend/test/like_reply_handler_test.py
@@ -161,7 +161,6 @@ def init(cls):
     # add reply to comment
     cls.post = cls.post.key.get()
     cls.post.reply_comment(cls.reply, cls.comment.id)
-    cls.post.put()
 
     cls.uri = '/api/posts/%s/comments/%s/replies/%s/likes' % (
             cls.post.key.urlsafe(), cls.comment.id, cls.reply.id


### PR DESCRIPTION
**Feature/Bug description:** When many users reply the comment in the same moment, returns concurrence error.

**Solution:** Added ndb.transactional in the method that adds the reply.

**TODO/FIXME:** n/a