### PR TITLE
Fix link's checking between institutions

### DIFF
--- a/backend/models/request.py
+++ b/backend/models/request.py
@@ -10,15 +10,16 @@ class Request(Invite):
     @staticmethod
     def isLinked(institution_key, institution_requested):
         institution = institution_key.get()
+        
         is_parent_from_top_down_perspective = institution_requested.key in institution.children_institutions
         is_parent_from_bottom_up_perspective = institution_key == institution_requested.parent_institution
         is_parent = is_parent_from_top_down_perspective and is_parent_from_bottom_up_perspective
 
         is_child_from_bottom_up_perspective = institution.parent_institution == institution_requested.key
         is_child_from_top_down_perspective = institution_key in institution_requested.children_institutions
-        is_children = is_child_from_bottom_up_perspective and is_child_from_top_down_perspective
-        
-        return is_parent or is_children
+        is_child = is_child_from_bottom_up_perspective and is_child_from_top_down_perspective
+
+        return is_parent or is_child
 
     @staticmethod
     def isRequested(sender_inst_key, institution_requested_key):

--- a/backend/models/request.py
+++ b/backend/models/request.py
@@ -9,10 +9,16 @@ class Request(Invite):
 
     @staticmethod
     def isLinked(institution_key, institution_requested):
-        isParent = institution_key == institution_requested.parent_institution
-        isChildren = institution_key in institution_requested.children_institutions
+        institution = institution_key.get()
+        is_parent_from_top_down_perspective = institution_requested.key in institution.children_institutions
+        is_parent_from_bottom_up_perspective = institution_key == institution_requested.parent_institution
+        is_parent = is_parent_from_top_down_perspective and is_parent_from_bottom_up_perspective
 
-        return isParent or isChildren
+        is_child_from_bottom_up_perspective = institution.parent_institution == institution_requested.key
+        is_child_from_top_down_perspective = institution_key in institution_requested.children_institutions
+        is_children = is_child_from_bottom_up_perspective and is_child_from_top_down_perspective
+        
+        return is_parent or is_children
 
     @staticmethod
     def isRequested(sender_inst_key, institution_requested_key):
@@ -32,7 +38,7 @@ class Request(Invite):
         if not institution_requested:
             raise FieldException("The request require institution_requested")
         if Request.isLinked(institution_key, institution_requested):
-            raise FieldException("The institutions is already a linked")
+            raise FieldException("The institutions has already been connected.")
         if Request.isRequested(institution_key, institution_requested.key):
             raise FieldException("The sender is already invited")
 

--- a/backend/test/model_test/request_institution_test.py
+++ b/backend/test/model_test/request_institution_test.py
@@ -75,7 +75,7 @@ class RequestInstitutionParentTest(TestBase):
             'The sender is already invited')
 
     def test_create_request_for_institution_linked(self):
-        """Test cretae invalid request."""
+        """Test create invalid request."""
         with self.assertRaises(FieldException) as ex:
             data = {
                 'sender_key': self.other_user.key.urlsafe(),
@@ -89,9 +89,9 @@ class RequestInstitutionParentTest(TestBase):
             RequestInstitutionParent.create(data)
 
         self.assertEqual(
-            'The institutions is already a linked',
+            'The institutions has already been connected.',
             str(ex.exception),
-            'Expected message is The institutions is already a linked')
+            'Expected message is The institutions has already been connected')
 
     def test_make_request_parent_institution(self):
         """Test method make por parent institution request."""

--- a/frontend/invites/suggestInstitutionController.js
+++ b/frontend/invites/suggestInstitutionController.js
@@ -84,12 +84,12 @@
                 institution_requested.parent_institution.key === suggestInstCtrl.institution.key);
             const isParent = isParentFromTopDownPerspective && isParentForBottomUpPerspective;
 
-            const isChildrenFromTopDownPerspective = _.includes(_.map(institution_requested.children_institutions, getKeyFromInst), suggestInstCtrl.institution.key);
-            const isChildrenFromBottomUpPerspective = (suggestInstCtrl.institution.parent_institution !== null &&
+            const isChildFromTopDownPerspective = _.includes(_.map(institution_requested.children_institutions, getKeyFromInst), suggestInstCtrl.institution.key);
+            const isChildFromBottomUpPerspective = (suggestInstCtrl.institution.parent_institution !== null &&
                 suggestInstCtrl.institution.parent_institution.key === suggestInstCtrl.chosen_institution);
-            const isChildren = isChildrenFromBottomUpPerspective && isChildrenFromTopDownPerspective;
-            
-            if (isParent || isChildren) {
+            const isChild = isChildrenFromBottomUpPerspective && isChildrenFromTopDownPerspective;
+
+            if (isParent || isChild) {
                 MessageService.showToast('As instituições já estão conectadas');
                 return true;
             }

--- a/frontend/invites/suggestInstitutionController.js
+++ b/frontend/invites/suggestInstitutionController.js
@@ -79,13 +79,17 @@
         }
 
         function isLinked(institution_requested) {
-            var isParent = _.includes(_.map(suggestInstCtrl.institution.children_institutions, getKeyFromInst), suggestInstCtrl.chosen_institution);
-            var isChildren = (suggestInstCtrl.institution.parent_institution !== null &&
-                    suggestInstCtrl.institution.parent_institution.key === suggestInstCtrl.chosen_institution);
-            var selfIsParent = (institution_requested.parent_institution !== null &&
-                    institution_requested.parent_institution.key === suggestInstCtrl.institution.key);
-            var selfIsChildren = _.includes(_.map(institution_requested.children_institutions, getKeyFromInst), suggestInstCtrl.institution.key);
-            if (isParent || isChildren || selfIsParent || selfIsChildren) {
+            const isParentFromTopDownPerspective = _.includes(_.map(suggestInstCtrl.institution.children_institutions, getKeyFromInst), suggestInstCtrl.chosen_institution);
+            const isParentForBottomUpPerspective = (institution_requested.parent_institution !== null &&
+                institution_requested.parent_institution.key === suggestInstCtrl.institution.key);
+            const isParent = isParentFromTopDownPerspective && isParentForBottomUpPerspective;
+
+            const isChildrenFromTopDownPerspective = _.includes(_.map(institution_requested.children_institutions, getKeyFromInst), suggestInstCtrl.institution.key);
+            const isChildrenFromBottomUpPerspective = (suggestInstCtrl.institution.parent_institution !== null &&
+                suggestInstCtrl.institution.parent_institution.key === suggestInstCtrl.chosen_institution);
+            const isChildren = isChildrenFromBottomUpPerspective && isChildrenFromTopDownPerspective;
+            
+            if (isParent || isChildren) {
                 MessageService.showToast('As instituições já estão conectadas');
                 return true;
             }


### PR DESCRIPTION
**Feature/Bug description:**
When an institution reject a link and the other keeps that link, the first one can't try to make the link again. The system says they are already linked.

**Solution:**
I've checked the link from both sides instead of just one.

**TODO/FIXME:** n/a