### PR TITLE
Fix institution removal notification process

### DIFF
--- a/backend/handlers/institution_handler.py
+++ b/backend/handlers/institution_handler.py
@@ -16,7 +16,6 @@ from custom_exceptions.entityException import EntityException
 from models.institution import Institution
 from util.json_patch import JsonPatch
 from service_entities import enqueue_task
-from send_email_hierarchy.remove_institution_email_sender import RemoveInstitutionEmailSender
 
 from handlers.base_handler import BaseHandler
 
@@ -203,17 +202,6 @@ class InstitutionHandler(BaseHandler):
         }
 
         enqueue_task('remove-inst', params)
-
-        email_params = {
-            "justification": self.request.get('justification'),
-            "body": """Lamentamos informar que a instituição %s foi removida
-            pelo administrador %s """ % (institution.name, user.name),
-            "subject": "Remoção de instituição",
-            "inst_key": institution_key
-        }
-        
-        email_sender = RemoveInstitutionEmailSender(**email_params)
-        email_sender.send_email()
 
         notification_entity = {
             'key': institution_key,

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -110,9 +110,6 @@ def setup_current_institution(user, request):
     try:
         institution_header = request.headers['Institution-Authorization']
         institution_key = ndb.Key(urlsafe=institution_header)
-        Utils._assert(not user.is_member(institution_key),
-            "Invalid Current Institution! User is not an active member.",
-            NotAuthorizedException)
         user.current_institution = institution_key
     except KeyError as error:
         user.current_institution = None

--- a/frontend/notification/notificationDirective.js
+++ b/frontend/notification/notificationDirective.js
@@ -272,7 +272,6 @@
         }
 
         function refreshUserInstitutions (notification) {
-            notificationCtrl.user.goToDifferentInstitution(notification.entity.key, notification.entity.remove_hierarchy);
             UserService.load().then(function success(response) {
                 notificationCtrl.user.institutions = response.institutions;
                 notificationCtrl.user.follows = response.follows;

--- a/frontend/notification/notificationDirective.js
+++ b/frontend/notification/notificationDirective.js
@@ -22,7 +22,7 @@
                 icon: "clear",
                 action: function (properties, notification, event) {
                     if (notification.status !== 'READ') {
-                        return refreshUser(notification, true);
+                        return refreshUser(notification);
                     }
                 }
             },
@@ -30,7 +30,7 @@
                 icon: "clear",
                 action: function (properties, notification, event) {
                     if (notification.status !== 'READ') {
-                        return refreshUser(notification, true);
+                        return refreshUser(notification);
                     }
                 }
             },

--- a/frontend/test/specs/userSpec.js
+++ b/frontend/test/specs/userSpec.js
@@ -289,46 +289,6 @@
             });
         });
 
-        describe('goToDifferentInstitution', function () {
-          it('should change current institution', function () {
-            var user = new User({
-              institutions: [inst, other_inst],
-              current_institution: inst
-            });
-            
-            expect(user.current_institution).toBe(inst);
-
-            user.goToDifferentInstitution(inst.key);
-
-            expect(user.current_institution).toBe(other_inst);
-          });
-
-          it('should not change the current institution', function() {
-            var user = new User({
-              institutions: [inst],
-              current_institution: inst
-            });
-
-            expect(user.current_institution).toBe(inst);
-
-            user.goToDifferentInstitution(inst.key);
-
-            expect(user.current_institution).toBe(inst);
-          });
-
-          it('should go to a non child institution', function() {
-            var test_inst = {name: 'TEST'};
-            var user = new User({
-              institutions: [inst, other_inst, test_inst],
-              current_institution: inst
-            });
-
-            user.goToDifferentInstitution(inst.key, "true");
-
-            expect(user.current_institution).toBe(test_inst);
-          });
-        });
-
         describe('addPermissions', function () {
           it('should add the permissions', function () {
             var user = new User({permissions: {}});

--- a/frontend/user/user.js
+++ b/frontend/user/user.js
@@ -171,19 +171,6 @@ User.prototype.updateInstProfile = function updateInstProfile(institution) {
     this.institution_profiles[index].institution.photo_url = institution.photo_url;
 };
 
-User.prototype.goToDifferentInstitution = function goToDifferentInstitution(previousKey, removeHierarchy) {
-    var user = this;
-    _.forEach(this.institutions, function(institution) {
-        if(institution.key !== previousKey) {
-            const institutionHasBeenDeleted = removeHierarchy === "true" && institution.parent_institution === previousKey;
-            if (!(institutionHasBeenDeleted)) {
-                user.current_institution = institution;
-                window.localStorage.userInfo = JSON.stringify(this);
-            }
-        }
-    });
-};
-
 User.prototype.getProfileColor = function getProfileColor() {
     const instKey = this.current_institution.key;
     return this.institution_profiles.reduce(


### PR DESCRIPTION
**Feature/Bug description:**
There was a problem with setup_current_institution because it was verifying if the user was a member. So, when a DELETED_INSTITUTION notification was raised and the user clicked on it, the notification's action should change the current institution before make the request to refresh the institution because of the setup_current_institution's verification, once the user was no longer member of the deleted institution.
**Solution:**
I've removed the verification, removed the method that should change the current institution and notified the users properly.

**TODO/FIXME:** n/a