### PR TITLE
Fix add-admin-permissions

### DIFF
--- a/backend/worker.py
+++ b/backend/worker.py
@@ -327,7 +327,7 @@ class AddAdminPermissionsInInstitutionHierarchy(BaseHandler):
         """Add admins' permissions, to the first institution and its children,
         to all admins, going up in the hierarchy."""
         institution = ndb.Key(urlsafe=institution_key).get()
-        admins = get_all_parent_admins(institution)
+        admins = get_all_parent_admins(institution, [])
             
         for permission in DEFAULT_ADMIN_PERMISSIONS:
             for admin in admins:


### PR DESCRIPTION
**Feature/Bug description:**
For a unknown reason, the get_all_parent_admins method was keeping the array's reference between queue's calls.

**Solution:**
I've passed an empty array in the addAdminPermissions handler.

**TODO/FIXME:** n/a