### PR TITLE
Refactoring static methods in institution

### DIFF
--- a/backend/models/institution.py
+++ b/backend/models/institution.py
@@ -138,7 +138,7 @@ class Institution(ndb.Model):
         self.put()
 
         institution_children = invite.institution_key.get()
-        institution_children.parent_institution = institution.key
+        institution_children.parent_institution = self.key
         institution_children.put()
 
     @ndb.transactional(xg=True)
@@ -148,7 +148,7 @@ class Institution(ndb.Model):
         self.put()
 
         parent_institution = invite.institution_key.get()
-        parent_institution.children_institutions.append(institution.key)
+        parent_institution.children_institutions.append(self.key)
         parent_institution.put()
 
     @staticmethod

--- a/backend/models/institution.py
+++ b/backend/models/institution.py
@@ -131,31 +131,25 @@ class Institution(ndb.Model):
         self.invite = invite.key
         self.put()
 
-    @staticmethod
     @ndb.transactional(xg=True)
-    def create_parent_connection(institution, invite):
+    def create_parent_connection(self, invite):
         """Make connections between parent and daughter institution."""
-        institution.children_institutions = [invite.institution_key]
-        institution.put()
+        self.children_institutions = [invite.institution_key]
+        self.put()
 
         institution_children = invite.institution_key.get()
         institution_children.parent_institution = institution.key
         institution_children.put()
 
-        return institution
-
-    @staticmethod
     @ndb.transactional(xg=True)
-    def create_children_connection(institution, invite):
+    def create_children_connection(self, invite):
         """Make connections between daughter and parent institution."""
-        institution.parent_institution = invite.institution_key
-        institution.put()
+        self.parent_institution = invite.institution_key
+        self.put()
 
         parent_institution = invite.institution_key.get()
         parent_institution.children_institutions.append(institution.key)
         parent_institution.put()
-
-        return institution
 
     @staticmethod
     @ndb.transactional(xg=True)

--- a/backend/models/invite_institution_children.py
+++ b/backend/models/invite_institution_children.py
@@ -1,7 +1,5 @@
 """Invite institution children model."""
 from invite_institution import InviteInstitution
-from models.institution import Institution
-
 
 class InviteInstitutionChildren(InviteInstitution):
     """Model of invite institution children."""
@@ -16,7 +14,7 @@ class InviteInstitutionChildren(InviteInstitution):
 
     def create_conection_institution(self, institution):
         """Method of creating connection between invitation and institution children."""
-        Institution.create_children_connection(institution, self)
+        institution.create_children_connection(self)
 
     def make(self):
         """Create json of invite to children institution."""

--- a/backend/models/invite_institution_parent.py
+++ b/backend/models/invite_institution_parent.py
@@ -1,7 +1,5 @@
 """Invite institution parent model."""
 from invite_institution import InviteInstitution
-from models.institution import Institution
-
 
 class InviteInstitutionParent(InviteInstitution):
     """Model of invite institution parent."""
@@ -16,7 +14,7 @@ class InviteInstitutionParent(InviteInstitution):
 
     def create_conection_institution(self, institution):
         """Method of creating connection between invitation and institution parent."""
-        Institution.create_parent_connection(institution, self)
+        institution.create_parent_connection(self)
 
     def make(self):
         """Create json of invite to parent institution."""


### PR DESCRIPTION
**Feature/Bug description:** The methods "create_children_connection" and "create_parent_connection" are unnecessary static.

**Solution:** Removing from static these methods and refactoring the handler and tests that use these methods.

**TODO/FIXME:** n/a