### PR TITLE
Refactoring the uses of assert with 'has_permission' directly to 'check_permission'

### DIFF
--- a/backend/handlers/event_handler.py
+++ b/backend/handlers/event_handler.py
@@ -40,10 +40,11 @@ class EventHandler(BaseHandler):
         event_key = ndb.Key(urlsafe=key)
         event = event_key.get()
 
-        exception_msg = "The user can not remove this event"
+        is_admin = user.has_permission("remove_posts", event.institution_key.urlsafe())
+        is_author = user.has_permission("remove_post", event.key.urlsafe())
 
-        user.check_permission("remove_posts", exception_msg, event.institution_key.urlsafe())
-        user.check_permission("remove_post", exception_msg, event.key.urlsafe())
+        Utils._assert(not is_admin and not is_author,
+                      "The user can not remove this event", NotAuthorizedException)
 
         event.state = 'deleted'
         event.last_modified_by = user.key
@@ -60,7 +61,7 @@ class EventHandler(BaseHandler):
 
         user.check_permission('edit_post',
             "The user can not edit this event",
-            NotAuthorizedException)
+            key)
 
         Utils._assert(event.state == 'deleted',
                       "The event has been deleted.", NotAuthorizedException)

--- a/backend/handlers/event_handler.py
+++ b/backend/handlers/event_handler.py
@@ -40,11 +40,10 @@ class EventHandler(BaseHandler):
         event_key = ndb.Key(urlsafe=key)
         event = event_key.get()
 
-        is_admin = user.has_permission("remove_posts", event.institution_key.urlsafe())
-        is_author = user.has_permission("remove_post", event.key.urlsafe())
-        
-        Utils._assert(not is_admin and not is_author,
-                      "The user can not remove this event", NotAuthorizedException)
+        exception_msg = "The user can not remove this event"
+
+        user.check_permission("remove_posts", exception_msg, event.institution_key.urlsafe())
+        user.check_permission("remove_post", exception_msg, event.key.urlsafe())
 
         event.state = 'deleted'
         event.last_modified_by = user.key
@@ -59,8 +58,9 @@ class EventHandler(BaseHandler):
 
         event = ndb.Key(urlsafe=key).get()
 
-        Utils._assert(not user.has_permission('edit_post', key), 
-            "The user can not edit this event", NotAuthorizedException)
+        user.check_permission('edit_post',
+            "The user can not edit this event",
+            NotAuthorizedException)
 
         Utils._assert(event.state == 'deleted',
                       "The event has been deleted.", NotAuthorizedException)

--- a/backend/handlers/invite_collection_handler.py
+++ b/backend/handlers/invite_collection_handler.py
@@ -44,10 +44,16 @@ class InviteCollectionHandler(BaseHandler):
                       "invitation type not allowed", NotAuthorizedException)
 
         institution = ndb.Key(urlsafe=invite['institution_key']).get()
-        can_invite_inst = user.has_permission(
-            "send_link_inst_invite", institution.key.urlsafe())
-        can_invite_members = user.has_permission(
-            "invite_members", institution.key.urlsafe())
+
+        can_not_send_invites_msg = "User is not allowed to send invites"
+
+        user.check_permission(
+            "send_link_inst_invite", can_not_send_invites_msg,
+            institution.key.urlsafe())
+
+        user.check_permission(
+            "invite_members", can_not_send_invites_msg,
+            institution.key.urlsafe())
 
         Utils._assert(not can_invite_inst and not can_invite_members,
                         "User is not allowed to send invites", NotAuthorizedException)

--- a/backend/handlers/invite_collection_handler.py
+++ b/backend/handlers/invite_collection_handler.py
@@ -44,16 +44,10 @@ class InviteCollectionHandler(BaseHandler):
                       "invitation type not allowed", NotAuthorizedException)
 
         institution = ndb.Key(urlsafe=invite['institution_key']).get()
-
-        can_not_send_invites_msg = "User is not allowed to send invites"
-
-        user.check_permission(
-            "send_link_inst_invite", can_not_send_invites_msg,
-            institution.key.urlsafe())
-
-        user.check_permission(
-            "invite_members", can_not_send_invites_msg,
-            institution.key.urlsafe())
+        can_invite_inst = user.has_permission(
+            "send_link_inst_invite", institution.key.urlsafe())
+        can_invite_members = user.has_permission(
+            "invite_members", institution.key.urlsafe())
 
         Utils._assert(not can_invite_inst and not can_invite_members,
                         "User is not allowed to send invites", NotAuthorizedException)

--- a/backend/handlers/post_handler.py
+++ b/backend/handlers/post_handler.py
@@ -62,11 +62,10 @@ class PostHandler(BaseHandler):
         obj_key = ndb.Key(urlsafe=key)
         post = obj_key.get()
 
-        is_admin = user.has_permission("remove_posts", post.institution.urlsafe())
-        is_author = user.has_permission("remove_post", key)
-        
-        Utils._assert(not is_admin and not is_author,
-                      "The user can not remove this post", NotAuthorizedException)
+        exception_msg = "The user can not remove this post"
+
+        user.check_permission("remove_posts", exception_msg, post.institution.urlsafe())
+        user.check_permission("remove_post", exception_msg, key)
 
         post.delete(user)
 

--- a/backend/handlers/post_handler.py
+++ b/backend/handlers/post_handler.py
@@ -62,10 +62,11 @@ class PostHandler(BaseHandler):
         obj_key = ndb.Key(urlsafe=key)
         post = obj_key.get()
 
-        exception_msg = "The user can not remove this post"
+        is_admin = user.has_permission("remove_posts", post.institution.urlsafe())
+        is_author = user.has_permission("remove_post", key)
 
-        user.check_permission("remove_posts", exception_msg, post.institution.urlsafe())
-        user.check_permission("remove_post", exception_msg, key)
+        Utils._assert(not is_admin and not is_author,
+                      "The user can not remove this post", NotAuthorizedException)
 
         post.delete(user)
 

--- a/backend/handlers/resend_invite_handler.py
+++ b/backend/handlers/resend_invite_handler.py
@@ -25,11 +25,9 @@ class ResendInviteHandler(BaseHandler):
         Utils._assert(invite.status != 'sent',
                       "The invite has already been used", NotAuthorizedException)
 
-        can_invite_members = user.has_permission(
-            "invite_members", invite.institution_key.urlsafe())
-
-        Utils._assert(not can_invite_members,
-            "User is not allowed to send invites", NotAuthorizedException)
+        user.check_permission("invite_members",
+                "User is not allowed to send invites",
+                invite.institution_key.urlsafe())
 
         institution = invite.institution_key.get()
         Utils._assert(institution.state == 'inactive',


### PR DESCRIPTION
**Feature/Bug description:** In some handlers the verification if the user has permission to do anything are with 'assert(not user.has_permission...)'. Using check_permission changes the responsibility to verify it has permission and throws the exception to the user model.

**Solution:** Changing the uses of has_permission with assert to check_permission only to enter into a pattern with the rest of code.

**TODO/FIXME:** n/a