### PR TITLE
Fix remove admin permissions handler

### DIFF
--- a/backend/handlers/institution_hierarchy_handler.py
+++ b/backend/handlers/institution_hierarchy_handler.py
@@ -60,9 +60,10 @@ class InstitutionHierarchyHandler(BaseHandler):
         admin = institution_link.admin
 
         if is_parent == "true":
-            enqueue_task('remove-admin-permissions', {'institution_key': institution.key.urlsafe(), 'user': admin.urlsafe()})
+            enqueue_task('remove-admin-permissions', {
+                         'institution_key': institution.key.urlsafe(), 'parent_key': institution_link.key.urlsafe()})
         else:
-            enqueue_task('remove-admin-permissions', {'institution_key': institution_link.key.urlsafe(), 'user': user.key.urlsafe()})
+            enqueue_task('remove-admin-permissions', {'institution_key': institution_link.key.urlsafe(), 'parent_key': institution.key.urlsafe()})
         
         entity_type = 'INSTITUTION'
         send_message_notification(

--- a/backend/test/remove_admin_permissions_hierarchy_test.py
+++ b/backend/test/remove_admin_permissions_hierarchy_test.py
@@ -92,7 +92,7 @@ class RemoveAdminPermissionsInInstitutionHierarchyTest(TestBaseHandler):
         first_user.follows.append(first_inst.key)
         first_user.put()
 
-        params = '?institution_key=%s&&user=%s' % (second_inst.key.urlsafe(), first_user.key.urlsafe())
+        params = '?institution_key=%s&&parent_key=%s' % (second_inst.key.urlsafe(), first_inst.key.urlsafe())
         self.testapp.post(
             REMOVE_ADMIN_PERMISSIONS_URI + params
         )
@@ -107,3 +107,260 @@ class RemoveAdminPermissionsInInstitutionHierarchyTest(TestBaseHandler):
             first_user, third_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
         self.assertTrue(has_permissions(
             first_user, fourth_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+    
+    def test_no_permissions_removal(self):
+        """Test the post method."""
+        # Verify the members
+        """Test remove admin permissions in institution hierarchy."""
+        first_user = mocks.create_user()
+
+        first_inst = mocks.create_institution()
+        second_inst = mocks.create_institution()
+        third_inst = mocks.create_institution()
+        fourth_inst = mocks.create_institution()
+
+        first_inst.add_member(first_user)
+        first_inst.set_admin(first_user.key)
+        second_inst.add_member(first_user)
+        second_inst.set_admin(first_user.key)
+        third_inst.add_member(first_user)
+        third_inst.set_admin(first_user.key)
+        fourth_inst.add_member(first_user)
+        fourth_inst.set_admin(first_user.key)
+
+        first_user.institutions_admin.append(first_inst.key)
+        first_user.institutions_admin.append(second_inst.key)
+        first_user.institutions_admin.append(third_inst.key)
+        first_user.institutions_admin.append(fourth_inst.key)
+        
+        # Hierarchy
+        #   first_inst -> second_inst -> third_inst -> fourth_inst
+        #   (first_user)  (first_user)   (first_user)  (first_user)
+        second_inst.parent_institution = first_inst.key
+        third_inst.parent_institution = second_inst.key
+        fourth_inst.parent_institution = third_inst.key
+
+        first_inst.children_institutions.append(second_inst.key)
+        second_inst.children_institutions.append(third_inst.key)
+        third_inst.children_institutions.append(fourth_inst.key)
+
+        first_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, first_inst.key.urlsafe())
+        first_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, second_inst.key.urlsafe())
+        first_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, third_inst.key.urlsafe())
+        first_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, fourth_inst.key.urlsafe())
+
+        first_inst.put()
+        second_inst.put()
+        third_inst.put()
+        fourth_inst.put()
+
+        first_user.put()
+
+        self.assertTrue(has_permissions(
+            first_user, first_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+        self.assertTrue(has_permissions(
+            first_user, second_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+        self.assertTrue(has_permissions(
+            first_user, third_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+        self.assertTrue(has_permissions(
+            first_user, fourth_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+
+        first_user.institutions.append(first_inst.key)
+        first_user.follows.append(first_inst.key)
+        first_user.put()
+
+        params = '?institution_key=%s&&parent_key=%s' % (
+            third_inst.key.urlsafe(), second_inst.key.urlsafe())
+        self.testapp.post(
+            REMOVE_ADMIN_PERMISSIONS_URI + params
+        )
+
+        first_user = first_user.key.get()
+
+        self.assertTrue(has_permissions(
+            first_user, first_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+        self.assertTrue(has_permissions(
+            first_user, second_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+        self.assertTrue(has_permissions(
+            first_user, third_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+        self.assertTrue(has_permissions(
+            first_user, fourth_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+    
+    def test_with_permissions_removal_in_the_top_of_the_hierarchy(self):
+        """Test the post method."""
+        # Verify the members
+        """Test remove admin permissions in institution hierarchy."""
+        first_user = mocks.create_user()
+        second_user = mocks.create_user()
+        third_user = mocks.create_user()
+
+        first_inst = mocks.create_institution()
+        second_inst = mocks.create_institution()
+        third_inst = mocks.create_institution()
+        fourth_inst = mocks.create_institution()
+
+        first_inst.add_member(first_user)
+        first_inst.set_admin(first_user.key)
+        third_inst.add_member(second_user)
+        third_inst.set_admin(second_user.key)
+
+        second_inst.add_member(second_user)
+        second_inst.set_admin(second_user.key)
+
+        fourth_inst.add_member(third_user)
+        fourth_inst.set_admin(third_user.key)
+
+        first_user.institutions_admin.append(first_inst.key)
+        second_user.institutions_admin.append(second_inst.key)
+        second_user.institutions_admin.append(third_inst.key)
+        third_user.institutions_admin.append(fourth_inst.key)
+
+        # Hierarchy
+        #   first_inst -> second_inst -> third_inst -> fourth_inst
+        #   (first_user)  (second_user)   (second_user)  (third_user)
+        second_inst.parent_institution = first_inst.key
+        fourth_inst.parent_institution = third_inst.key
+
+        first_inst.children_institutions.append(second_inst.key)
+        second_inst.children_institutions.append(third_inst.key)
+        third_inst.children_institutions.append(fourth_inst.key)
+
+        first_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, first_inst.key.urlsafe())
+        first_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, second_inst.key.urlsafe())
+        first_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, third_inst.key.urlsafe())
+        first_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, fourth_inst.key.urlsafe())
+
+        second_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, second_inst.key.urlsafe())
+        second_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, third_inst.key.urlsafe())
+        second_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, fourth_inst.key.urlsafe())
+
+        third_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, fourth_inst.key.urlsafe())
+
+        first_inst.put()
+        second_inst.put()
+        third_inst.put()
+        fourth_inst.put()
+
+        first_user.put()
+        second_user.put()
+        third_user.put()
+        params = '?institution_key=%s&&parent_key=%s' % (
+            third_inst.key.urlsafe(), second_inst.key.urlsafe())
+        self.testapp.post(
+            REMOVE_ADMIN_PERMISSIONS_URI + params
+        )
+
+        first_user = first_user.key.get()
+        second_user = second_user.key.get()
+        third_user = third_user.key.get()
+
+        self.assertTrue(has_permissions(
+            first_user, first_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+        self.assertTrue(has_permissions(
+            first_user, second_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+        self.assertFalse(has_permissions(
+            first_user, third_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+        self.assertFalse(has_permissions(
+            first_user, fourth_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+
+        self.assertTrue(has_permissions(
+            second_user, second_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+        self.assertTrue(has_permissions(
+            second_user, third_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+        self.assertTrue(has_permissions(
+            second_user, fourth_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+        
+        self.assertTrue(has_permissions(
+            third_user, fourth_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+
+    def test_simple_test(self):
+        """Test the post method."""
+        # Verify the members
+        """Test remove admin permissions in institution hierarchy."""
+        first_user = mocks.create_user()
+        second_user = mocks.create_user()
+        third_user = mocks.create_user()
+
+        first_inst = mocks.create_institution()
+        second_inst = mocks.create_institution()
+        third_inst = mocks.create_institution()
+
+        first_inst.add_member(first_user)
+        first_inst.set_admin(first_user.key)
+        third_inst.add_member(third_user)
+        third_inst.set_admin(third_user.key)
+
+        second_inst.add_member(second_user)
+        second_inst.set_admin(second_user.key)
+
+        first_user.institutions_admin.append(first_inst.key)
+        second_user.institutions_admin.append(second_inst.key)
+        third_user.institutions_admin.append(third_inst.key)
+
+        # Hierarchy
+        #   first_inst -> second_inst -> third_inst
+        #   (first_user)  (second_user)   (third_user)
+        second_inst.parent_institution = first_inst.key
+        third_inst.parent_institution = second_inst.key
+
+        first_inst.children_institutions.append(second_inst.key)
+        second_inst.children_institutions.append(third_inst.key)
+
+        first_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, first_inst.key.urlsafe())
+        first_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, second_inst.key.urlsafe())
+        first_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, third_inst.key.urlsafe())
+
+        second_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, second_inst.key.urlsafe())
+        second_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, third_inst.key.urlsafe())
+
+        third_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, third_inst.key.urlsafe())
+
+        first_inst.put()
+        second_inst.put()
+        third_inst.put()
+
+        first_user.put()
+        second_user.put()
+        third_user.put()
+        params = '?institution_key=%s&&parent_key=%s' % (
+            second_inst.key.urlsafe(), first_inst.key.urlsafe())
+        self.testapp.post(
+            REMOVE_ADMIN_PERMISSIONS_URI + params
+        )
+
+        first_user = first_user.key.get()
+        second_user = second_user.key.get()
+        third_user = third_user.key.get()
+
+        self.assertTrue(has_permissions(
+            first_user, first_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+        self.assertFalse(has_permissions(
+            first_user, second_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+        self.assertFalse(has_permissions(
+            first_user, third_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+
+        self.assertTrue(has_permissions(
+            second_user, second_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+        self.assertTrue(has_permissions(
+            second_user, third_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+
+        self.assertTrue(has_permissions(
+            third_user, third_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))

--- a/backend/test/remove_admin_permissions_hierarchy_test.py
+++ b/backend/test/remove_admin_permissions_hierarchy_test.py
@@ -450,3 +450,101 @@ class RemoveAdminPermissionsInInstitutionHierarchyTest(TestBaseHandler):
             second_user, third_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
         self.assertTrue(has_permissions(
             second_user, fourth_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+
+    
+    def test_to_keep_permissions_information(self):
+        """apokdpos."""
+        first_user = mocks.create_user()
+        second_user = mocks.create_user()
+        third_user = mocks.create_user()
+
+        first_inst = mocks.create_institution()
+        second_inst = mocks.create_institution()
+        third_inst = mocks.create_institution()
+        fourth_inst = mocks.create_institution()
+
+        first_inst.add_member(first_user)
+        first_inst.set_admin(first_user.key)
+        third_inst.add_member(second_user)
+        third_inst.set_admin(second_user.key)
+
+        second_inst.add_member(third_user)
+        second_inst.set_admin(third_user.key)
+
+        fourth_inst.add_member(third_user)
+        fourth_inst.set_admin(third_user.key)
+
+        first_user.institutions_admin = [first_inst.key]
+        third_user.institutions_admin.append(second_inst.key)
+        second_user.institutions_admin.append(third_inst.key)
+        third_user.institutions_admin.append(fourth_inst.key)
+
+        # Hierarchy
+        #   first_inst -> second_inst -> third_inst -> fourth_inst
+        #   (first_user)  (third_user)   (second_user)  (third_user)
+        second_inst.parent_institution = first_inst.key
+        fourth_inst.parent_institution = third_inst.key
+
+        first_inst.children_institutions.append(second_inst.key)
+        second_inst.children_institutions.append(third_inst.key)
+        third_inst.children_institutions.append(fourth_inst.key)
+
+        first_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, first_inst.key.urlsafe())
+        first_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, second_inst.key.urlsafe())
+        first_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, third_inst.key.urlsafe())
+        first_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, fourth_inst.key.urlsafe())
+
+        second_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, third_inst.key.urlsafe())
+        second_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, fourth_inst.key.urlsafe())
+        
+        third_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, second_inst.key.urlsafe())
+        third_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, third_inst.key.urlsafe())
+        third_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, fourth_inst.key.urlsafe())
+
+        first_inst.put()
+        second_inst.put()
+        third_inst.put()
+        fourth_inst.put()
+
+        first_user.put()
+        second_user.put()
+        third_user.put()
+        params = '?institution_key=%s&&parent_key=%s' % (
+            third_inst.key.urlsafe(), second_inst.key.urlsafe())
+        self.testapp.post(
+            REMOVE_ADMIN_PERMISSIONS_URI + params
+        )
+
+        first_user = first_user.key.get()
+        second_user = second_user.key.get()
+        third_user = third_user.key.get()
+
+        self.assertTrue(has_permissions(
+            first_user, first_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+        self.assertTrue(has_permissions(
+            first_user, second_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+        self.assertFalse(has_permissions(
+            first_user, third_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+        self.assertFalse(has_permissions(
+            first_user, fourth_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+
+        self.assertTrue(has_permissions(
+            second_user, third_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+        self.assertTrue(has_permissions(
+            second_user, fourth_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+        
+        self.assertTrue(has_permissions(
+            third_user, second_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+        self.assertFalse(has_permissions(
+            third_user, third_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+        self.assertTrue(has_permissions(
+            third_user, fourth_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))

--- a/backend/test/remove_admin_permissions_hierarchy_test.py
+++ b/backend/test/remove_admin_permissions_hierarchy_test.py
@@ -364,3 +364,89 @@ class RemoveAdminPermissionsInInstitutionHierarchyTest(TestBaseHandler):
 
         self.assertTrue(has_permissions(
             third_user, third_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+
+    def test(self):
+        """Test the post method."""
+        # Verify the members
+        """Test remove admin permissions in institution hierarchy."""
+        first_user = mocks.create_user()
+        second_user = mocks.create_user()
+
+        first_inst = mocks.create_institution()
+        second_inst = mocks.create_institution()
+        third_inst = mocks.create_institution()
+        fourth_inst = mocks.create_institution()
+
+        first_inst.add_member(first_user)
+        first_inst.set_admin(first_user.key)
+        third_inst.add_member(second_user)
+        third_inst.set_admin(second_user.key)
+
+        second_inst.add_member(second_user)
+        second_inst.set_admin(second_user.key)
+
+        fourth_inst.add_member(first_user)
+        fourth_inst.set_admin(first_user.key)
+
+        first_user.institutions_admin.append(first_inst.key)
+        second_user.institutions_admin.append(second_inst.key)
+        second_user.institutions_admin.append(third_inst.key)
+        first_user.institutions_admin.append(fourth_inst.key)
+
+        # Hierarchy
+        #   first_inst -> second_inst -> third_inst -> fourth_inst
+        #   (first_user)  (second_user)   (second_user)  (first_user)
+        second_inst.parent_institution = first_inst.key
+        fourth_inst.parent_institution = third_inst.key
+
+        first_inst.children_institutions.append(second_inst.key)
+        second_inst.children_institutions.append(third_inst.key)
+        third_inst.children_institutions.append(fourth_inst.key)
+
+        first_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, first_inst.key.urlsafe())
+        first_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, second_inst.key.urlsafe())
+        first_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, third_inst.key.urlsafe())
+        first_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, fourth_inst.key.urlsafe())
+
+        second_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, second_inst.key.urlsafe())
+        second_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, third_inst.key.urlsafe())
+        second_user.add_permissions(
+            permissions.DEFAULT_ADMIN_PERMISSIONS, fourth_inst.key.urlsafe())
+
+        first_inst.put()
+        second_inst.put()
+        third_inst.put()
+        fourth_inst.put()
+
+        first_user.put()
+        second_user.put()
+        params = '?institution_key=%s&&parent_key=%s' % (
+            third_inst.key.urlsafe(), second_inst.key.urlsafe())
+        self.testapp.post(
+            REMOVE_ADMIN_PERMISSIONS_URI + params
+        )
+
+        first_user = first_user.key.get()
+        second_user = second_user.key.get()
+
+        self.assertTrue(has_permissions(
+            first_user, first_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+        self.assertTrue(has_permissions(
+            first_user, second_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+        self.assertFalse(has_permissions(
+            first_user, third_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+        self.assertTrue(has_permissions(
+            first_user, fourth_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+
+        self.assertTrue(has_permissions(
+            second_user, second_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+        self.assertTrue(has_permissions(
+            second_user, third_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
+        self.assertTrue(has_permissions(
+            second_user, fourth_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -361,11 +361,11 @@ class RemoveAdminPermissionsInInstitutionHierarchy(BaseHandler):
         child_admin_key = institution.admin
 
         @ndb.transactional(xg=True, retries=10)
-        def apply_remove_operation(parent_admin, institution, should_remove):
+        def apply_remove_operation(parent_admin, institution, should_remove, child_admin_key):
             """This method is responsible for getting the permissions involved
             in the link and go up in the hierarchy removing the permissions from
             the admins that have to lose it, based in a condition that checks if 
-            the current_admin is different of the current_admin.  
+            the current_admin is different of the child_admin.  
             """
             parent_admins = get_all_parent_admins(parent_institution, [])
             for current_admin in parent_admins:
@@ -374,7 +374,7 @@ class RemoveAdminPermissionsInInstitutionHierarchy(BaseHandler):
                         get_all=False, admin_key=current_admin.key)
                     self.removeAdminPermissions(
                         current_admin, permissions)
-        apply_remove_operation(parent_admin, institution, is_not_admin)
+        apply_remove_operation(parent_admin, institution, is_not_admin, child_admin_key)
 
 class AddPostInInstitution(BaseHandler):
     

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -368,15 +368,12 @@ class RemoveAdminPermissionsInInstitutionHierarchy(BaseHandler):
             the current_admin is different of the current_admin.  
             """
             parent_admins = get_all_parent_admins(parent_institution, [])
-            permissions = institution.get_hierarchy_admin_permissions(
-                get_all=False, admin_key=parent_admin.key)
             for current_admin in parent_admins:
                 if current_admin.key != child_admin_key:
-                    current_permissions = filter_permissions_to_remove(
-                        current_admin, permissions, institution.key, should_remove
-                    )
+                    permissions = institution.get_hierarchy_admin_permissions(
+                        get_all=False, admin_key=current_admin.key)
                     self.removeAdminPermissions(
-                        current_admin, current_permissions)
+                        current_admin, permissions)
         apply_remove_operation(parent_admin, institution, is_not_admin)
 
 class AddPostInInstitution(BaseHandler):

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -372,7 +372,7 @@ class RemoveAdminPermissionsInInstitutionHierarchy(BaseHandler):
                 get_all=False, admin_key=parent_admin.key)
             for current_admin in parent_admins:
                 if current_admin.key != child_admin_key:
-                    current_permissions = permissions = filter_permissions_to_remove(
+                    current_permissions = filter_permissions_to_remove(
                         current_admin, permissions, institution.key, should_remove
                     )
                     self.removeAdminPermissions(


### PR DESCRIPTION
**Feature/Bug description:**
The method wasn't going up in the hierarchy removing the permissions.
**Solution:**
I've got the parent_admins and iterate over them removing the permissions when it should be removed.

**TODO/FIXME:** n/a