### PR TITLE
Forbid hierarchical loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -541,3 +541,4 @@ backend/google_appengine
 backend/Pipfile
 
 .env_cleaned
+.vscode/settings.json

--- a/backend/handlers/institution_children_request_collection_handler.py
+++ b/backend/handlers/institution_children_request_collection_handler.py
@@ -9,6 +9,7 @@ from utils import Utils
 from custom_exceptions.entityException import EntityException
 from custom_exceptions.notAuthorizedException import NotAuthorizedException
 from . import BaseHandler
+from models.institution import Institution
 from models.factory_invites import InviteFactory
 from models.request_institution_children import RequestInstitutionChildren
 
@@ -52,11 +53,22 @@ class InstitutionChildrenRequestCollectionHandler(BaseHandler):
             EntityException
         )
 
+        parent_key = data.get('institution_key')
+        parent_key = ndb.Key(urlsafe=parent_key)
+        requested_inst_key = data.get('institution_requested_key')
+        requested_inst_key = ndb.Key(urlsafe=requested_inst_key)
+        
+        Utils._assert(
+            Institution.has_connection_between(parent_key, requested_inst_key),
+            "Circular hierarchy not allowed",
+            EntityException
+        )
+
         request = InviteFactory.create(data, type_of_invite)
         request.put()
 
-        institution_parent = request.institution_key.get()
-        institution_parent.children_institutions.append(request.institution_requested_key)
+        institution_parent = parent_key.get()
+        institution_parent.children_institutions.append(requested_inst_key)
         institution_parent.put()
 
         request.send_invite(host, user.current_institution)

--- a/backend/models/institution.py
+++ b/backend/models/institution.py
@@ -379,3 +379,16 @@ class Institution(ndb.Model):
         #Means that institution_to_verify is self's parent
         child_link = self.parent_institution == institution_to_verify.key and self.key in institution_to_verify.children_institutions
         return child_link or parent_link
+
+
+    @staticmethod
+    def has_connection_between(institution_key, superior_inst_key):
+
+        def has_connection(parent_key):
+            if not parent_key:
+                return False
+
+            connection_found = parent_key == superior_inst_key
+            return connection_found or has_connection(parent_key.get().parent_institution)
+
+        return has_connection(institution_key.get().parent_institution)

--- a/backend/models/institution.py
+++ b/backend/models/institution.py
@@ -187,7 +187,7 @@ class Institution(ndb.Model):
     def remove_institution(self, remove_hierarchy, user):
         """Remove an institution.
 
-        Keyword arguments:
+        Params:
         remove_hierarchy -- string the represents if the institution's hiearchy
         will be removed
         user -- the admin of the institution.
@@ -206,7 +206,7 @@ class Institution(ndb.Model):
         It handles the hierarchy removal once it is called by every child
         institution.
 
-        Keyword arguments:
+        Params:
         remove_hierarchy -- works as a flag that indicates the institution's hierarchy removal
         user -- the user who started the institution's removal process. So, it may not be the admin
         of self.
@@ -319,7 +319,7 @@ class Institution(ndb.Model):
         the admin permissions of all institutions belonging 
         to the child hierarchy.
 
-        Arguments:
+        Params:
         get_all (Optional)-- If true, get all permissions from institutions 
         admin_key (Optional) -- admin that requested to unlink the institutions
         hierarchically above the first child with the same admin
@@ -352,7 +352,7 @@ class Institution(ndb.Model):
         The type permission is only possible when the institution is super institution.
         Returns a dict containing the super user permissions.
 
-        Arguments:
+        Params:
         permissions(Optional) -- Dict of previous permissions added for add more permissons. 
         If not passed, creates new dict of permissions
         """
@@ -382,13 +382,21 @@ class Institution(ndb.Model):
 
 
     @staticmethod
-    def has_connection_between(institution_key, superior_inst_key):
+    def has_connection_between(possible_child_key, possible_parent_key):
+        """
+        It makes a bottom-up verification to check if these institutions are connected.
 
+        Params:
+        possible_child_key -- key of institution that is belived 
+            to be the child, if the connection exists
+        possible_parent_key -- key of institution that is belived 
+            to be the parent, if the connection exists
+        """
         def has_connection(parent_key):
             if not parent_key:
                 return False
 
-            connection_found = parent_key == superior_inst_key
+            connection_found = parent_key == possible_parent_key
             return connection_found or has_connection(parent_key.get().parent_institution)
 
-        return has_connection(institution_key.get().parent_institution)
+        return has_connection(possible_child_key.get().parent_institution)

--- a/backend/test/institution_children_request_collection_handler_test.py
+++ b/backend/test/institution_children_request_collection_handler_test.py
@@ -159,3 +159,80 @@ class InstitutionChildrenRequestCollectionHandlerTest(TestBaseHandler):
             "Error! User is not allowed to send request",
             exception_message,
             "Expected error message is Error! User is not allowed to send request")
+
+    
+    @patch('utils.verify_token', return_value=USER)
+    def test_post_circular_hierarchy(self, verify_token):
+        """
+        Test post request when the user tries to create
+        a circular hierarchy between institutions using
+        a child request."""
+
+        # Hierarchy: inst_a -> inst_b -> inst_c
+        inst_a = mocks.create_institution()
+        inst_b = mocks.generate_child_to_parent(inst_a)
+        inst_c = mocks.generate_child_to_parent(inst_b)
+
+        # verifies the hierarchy
+        self.assertEquals(
+            inst_a.parent_institution, None,
+            "inst_a should not have a parent"
+        )
+        self.assertTrue(
+            inst_b.key in inst_a.children_institutions,
+            "inst_b should be in inst_a children institutions"
+        )
+        self.assertEquals(
+            inst_b.parent_institution, inst_a.key,
+            "inst_a should be parent of inst_b"
+        )
+        self.assertTrue(
+            inst_c.key in inst_b.children_institutions,
+            "inst_c should be in inst_b children institutions"
+        )
+        self.assertEquals(
+            inst_c.parent_institution, inst_b.key,
+            "inst_b should be parent of inst_c"
+        )
+        self.assertEquals(
+            inst_c.children_institutions, [],
+            "inst_c should not have children institutions"
+        )
+
+        admin = mocks.create_user(USER['email'])
+        admin.institutions_admin = [inst_c.key]
+        admin.add_institution(inst_c.key)
+        inst_c.admin = admin.key
+        admin.add_permission("send_link_inst_request", inst_c.key.urlsafe())
+        admin.put()
+        inst_c.put()
+
+        admin_requested = mocks.create_user(ADMIN['email'])
+        admin_requested.institutions_admin = [inst_a.key]
+        admin_requested.add_institution(inst_a.key)
+        admin_requested.add_permission("send_link_inst_request", inst_a.key.urlsafe())
+        inst_a.admin = admin_requested.key
+        admin_requested.put()
+        inst_a.put()
+
+        data = {
+            'sender_key': admin.key.urlsafe(),
+            'is_request': True,
+            'admin_key': admin_requested.key.urlsafe(),
+            'institution_key': inst_c.key.urlsafe(),
+            'institution_requested_key': inst_a.key.urlsafe(),
+            'type_of_invite': 'REQUEST_INSTITUTION_CHILDREN'
+        }
+
+        with self.assertRaises(Exception) as ex:
+            self.testapp.post_json(
+                "/api/institutions/" + inst_c.key.urlsafe() + "/requests/institution_children",
+                data)
+
+        
+        exception_message = self.get_message_exception(ex.exception.message)
+        expected_message = "Error! Circular hierarchy not allowed"
+        self.assertEqual(
+            expected_message, exception_message,
+            "The expected error message is not equal to the exception one")
+        

--- a/backend/test/institution_parent_request_collection_handler_test.py
+++ b/backend/test/institution_parent_request_collection_handler_test.py
@@ -158,3 +158,79 @@ class InstitutionParentRequestCollectionHandlerTest(TestBaseHandler):
             "Error! User is not allowed to send request",
             exception_message,
             "Expected error message is Error! User is not allowed to send request")
+
+
+    @patch('utils.verify_token', return_value=USER)
+    def test_post_circular_hierarchy(self, verify_token):
+        """
+        Test post request when the user tries to create
+        a circular hierarchy between institutions using
+        a parent request."""
+
+        # Hierarchy: inst_a -> inst_b -> inst_c
+        inst_a = mocks.create_institution()
+        inst_b = mocks.generate_child_to_parent(inst_a)
+        inst_c = mocks.generate_child_to_parent(inst_b)
+
+        # verifies the hierarchy
+        self.assertEquals(
+            inst_a.parent_institution, None,
+            "inst_a should not have a parent"
+        )
+        self.assertTrue(
+            inst_b.key in inst_a.children_institutions,
+            "inst_b should be in inst_a children institutions"
+        )
+        self.assertEquals(
+            inst_b.parent_institution, inst_a.key,
+            "inst_a should be parent of inst_b"
+        )
+        self.assertTrue(
+            inst_c.key in inst_b.children_institutions,
+            "inst_c should be in inst_b children institutions"
+        )
+        self.assertEquals(
+            inst_c.parent_institution, inst_b.key,
+            "inst_b should be parent of inst_c"
+        )
+        self.assertEquals(
+            inst_c.children_institutions, [],
+            "inst_c should not have children institutions"
+        )
+
+        admin = mocks.create_user(USER['email'])
+        admin.institutions_admin = [inst_a.key]
+        admin.add_institution(inst_a.key)
+        inst_a.admin = admin.key
+        admin.add_permission("send_link_inst_request", inst_a.key.urlsafe())
+        admin.put()
+        inst_a.put()
+
+        admin_requested = mocks.create_user(ADMIN['email'])
+        admin_requested.institutions_admin = [inst_c.key]
+        admin_requested.add_institution(inst_c.key)
+        admin_requested.add_permission("send_link_inst_request", inst_c.key.urlsafe())
+        inst_c.admin = admin_requested.key
+        admin_requested.put()
+        inst_c.put()
+
+        data = {
+            'sender_key': admin.key.urlsafe(),
+            'is_request': True,
+            'admin_key': admin_requested.key.urlsafe(),
+            'institution_key': inst_a.key.urlsafe(),
+            'institution_requested_key': inst_c.key.urlsafe(),
+            'type_of_invite': 'REQUEST_INSTITUTION_PARENT'
+        }
+
+        with self.assertRaises(Exception) as ex:
+            self.testapp.post_json(
+                "/api/institutions/" + inst_a.key.urlsafe() + "/requests/institution_parent",
+                data)
+
+        
+        exception_message = self.get_message_exception(ex.exception.message)
+        expected_message = "Error! Circular hierarchy not allowed"
+        self.assertEqual(
+            expected_message, exception_message,
+            "The expected error message is not equal to the exception one")

--- a/backend/test/mocks.py
+++ b/backend/test/mocks.py
@@ -10,6 +10,8 @@ from models.post import Post
 from models.post import Comment
 from models.event import Event
 from models.factory_invites import InviteFactory
+from permissions import DEFAULT_ADMIN_PERMISSIONS
+from models.request_institution_parent import RequestInstitutionParent
 
 
 def getHash(obj):
@@ -115,3 +117,23 @@ def create_invite(admin, institution_key, type_of_invite, invitee_key=None):
     invite.sender_name = invite_hash
     invite.put()
     return invite
+
+def generate_child_to_parent(parent, child_admin=None):
+    """Create a child for the parent."""
+    admin = create_user() if child_admin is None else child_admin
+    child = create_institution()
+    child.add_member(admin)
+    child.set_admin(admin.key)
+    admin.add_permissions(DEFAULT_ADMIN_PERMISSIONS, child.key.urlsafe())
+    data = {
+        'sender_key': admin.key.urlsafe(),
+        'institution_requested_key': parent.key.urlsafe(),
+        'admin_key': admin.key.urlsafe(),
+        'institution_key': child.key.urlsafe()
+    }
+    parent_invite = RequestInstitutionParent.create(data)
+    # link child_a to institution
+    Institution.create_parent_connection(parent, parent_invite)
+    #  update child
+    child = child.key.get()
+    return child

--- a/backend/test/model_test/institution_test.py
+++ b/backend/test/model_test/institution_test.py
@@ -8,6 +8,25 @@ from permissions import DEFAULT_ADMIN_PERMISSIONS
 
 from .. import mocks
 
+def generate_child_to_parent(parent, child_admin=None):
+    # create child and parent invite
+    admin = mocks.create_user() if child_admin is None else child_admin
+    child = mocks.create_institution()
+    child.add_member(admin)
+    child.set_admin(admin.key)
+    admin.add_permissions(DEFAULT_ADMIN_PERMISSIONS, child.key.urlsafe())
+    data = {
+        'sender_key': admin.key.urlsafe(),
+        'institution_requested_key': parent.key.urlsafe(),
+        'admin_key': admin.key.urlsafe(),
+        'institution_key': child.key.urlsafe()
+    }
+    parent_invite = RequestInstitutionParent.create(data)
+    # link child_a to institution
+    Institution.create_parent_connection(parent, parent_invite)
+    #  update child
+    child = child.key.get()
+    return child
 
 class InstitutionTest(TestBase):
     """Test the institution model."""
@@ -86,25 +105,6 @@ class InstitutionTest(TestBase):
                     permissions.update({permission: {institution_key_url: True}})
             return permissions
 
-        def generate_child_to_parent(parent, child_admin=None):
-            # create child and parent invite
-            admin = mocks.create_user() if child_admin is None else child_admin
-            child = mocks.create_institution()
-            child.add_member(admin)
-            child.set_admin(admin.key)
-            admin.add_permissions(DEFAULT_ADMIN_PERMISSIONS, child.key.urlsafe())
-            data = {
-                'sender_key': admin.key.urlsafe(),
-                'institution_requested_key': parent.key.urlsafe(),
-                'admin_key': admin.key.urlsafe(),
-                'institution_key': child.key.urlsafe()
-            }
-            parent_invite = RequestInstitutionParent.create(data)
-            # link child_a to institution
-            Institution.create_parent_connection(parent, parent_invite)
-            child.put()
-            return child
-
         # Case 1: Get all permission and the admin has just one institution
         # Institution(admin) -> x
         expected_permissions = generate_permissions(self.institution.key.urlsafe(), {})
@@ -156,3 +156,66 @@ class InstitutionTest(TestBase):
         self.assertEquals(actual_permissions, expected_permissions,
             "The admin does not have the expected permissions"
         )
+
+    def test_has_connection_between(self):
+        #  create hierarchy
+        # institution -> child_a -> child_b -> child_c
+        child_a = generate_child_to_parent(self.institution)
+        child_b = generate_child_to_parent(child_a)
+        child_c = generate_child_to_parent(child_b)
+        independent_instituion = mocks.create_institution()
+
+        # update institution
+        self.institution = self.institution.key.get() 
+
+        # verifies the hierarchy
+        self.assertEquals(
+            self.institution.parent_institution, None,
+            "institution should not have a parent"
+        )
+        self.assertEquals(
+            child_a.parent_institution, self.institution.key,
+            "institution should be parent of child_a"
+        )
+        self.assertEquals(
+            child_b.parent_institution, child_a.key,
+            "child_a should be parent of child_b"
+        )
+        self.assertEquals(
+            child_c.parent_institution, child_b.key,
+            "child_b should be parent of child_c"
+        )
+        self.assertEquals(
+            independent_instituion.parent_institution, None,
+            "independent_institution should not have a parent"
+        )
+        self.assertEquals(
+            independent_instituion.children_institutions, [],
+            "independent_institution should not have children"
+        )
+
+        # verifies the connections
+        # Case 1: institutions directly connected
+        self.assertTrue(
+            Institution.has_connection_between(child_a.key, self.institution.key),
+            "The connection between child_a and institution should be true"
+        )
+        # Case 2: institutions indirectly connected
+        self.assertTrue(
+            Institution.has_connection_between(child_b.key, self.institution.key),
+            "The connection between child_b and institution should be true"
+        )
+        self.assertTrue(
+            Institution.has_connection_between(child_c.key, self.institution.key),
+            "The connection between child_c and institution should be true"
+        )
+        # Case 3: institutions disconnected
+        self.assertFalse(
+            Institution.has_connection_between(independent_instituion.key, self.institution.key),
+            "The connection between independent_instituion and institution should be false"
+        )
+        self.assertFalse(
+            Institution.has_connection_between(self.institution.key, independent_instituion.key),
+            "The connection between institution and independent_instituion should be false"
+        )
+

--- a/backend/test/model_test/institution_test.py
+++ b/backend/test/model_test/institution_test.py
@@ -8,25 +8,6 @@ from permissions import DEFAULT_ADMIN_PERMISSIONS
 
 from .. import mocks
 
-def generate_child_to_parent(parent, child_admin=None):
-    # create child and parent invite
-    admin = mocks.create_user() if child_admin is None else child_admin
-    child = mocks.create_institution()
-    child.add_member(admin)
-    child.set_admin(admin.key)
-    admin.add_permissions(DEFAULT_ADMIN_PERMISSIONS, child.key.urlsafe())
-    data = {
-        'sender_key': admin.key.urlsafe(),
-        'institution_requested_key': parent.key.urlsafe(),
-        'admin_key': admin.key.urlsafe(),
-        'institution_key': child.key.urlsafe()
-    }
-    parent_invite = RequestInstitutionParent.create(data)
-    # link child_a to institution
-    Institution.create_parent_connection(parent, parent_invite)
-    #  update child
-    child = child.key.get()
-    return child
 
 class InstitutionTest(TestBase):
     """Test the institution model."""
@@ -117,7 +98,7 @@ class InstitutionTest(TestBase):
         # Case 2: Get all permission and the admin has one institution and 
         # one child that he is not admin  
         # Institution(admin) -> child_a(other_admin) -> x
-        child_a = generate_child_to_parent(self.institution)
+        child_a = mocks.generate_child_to_parent(self.institution)
         self.institution = self.institution.key.get()
         expected_permissions = generate_permissions(self.institution.key.urlsafe(), {})
         expected_permissions = generate_permissions(child_a.key.urlsafe(), expected_permissions)
@@ -130,8 +111,8 @@ class InstitutionTest(TestBase):
         # Case 3: Get all permission and the admin has one institution and 
         # one child that he is not admin  
         # Institution(admin) -> child_a(other_admin) -> child_b(admin) -> child_c(other_admin) -> x
-        child_b = generate_child_to_parent(child_a, self.admin)
-        child_c = generate_child_to_parent(child_b, child_a.admin.get())
+        child_b = mocks.generate_child_to_parent(child_a, self.admin)
+        child_c = mocks.generate_child_to_parent(child_b, child_a.admin.get())
         self.institution = self.institution.key.get()
         expected_permissions = generate_permissions(self.institution.key.urlsafe(), {})
         expected_permissions = generate_permissions(child_a.key.urlsafe(), expected_permissions)
@@ -160,9 +141,9 @@ class InstitutionTest(TestBase):
     def test_has_connection_between(self):
         #  create hierarchy
         # institution -> child_a -> child_b -> child_c
-        child_a = generate_child_to_parent(self.institution)
-        child_b = generate_child_to_parent(child_a)
-        child_c = generate_child_to_parent(child_b)
+        child_a = mocks.generate_child_to_parent(self.institution)
+        child_b = mocks.generate_child_to_parent(child_a)
+        child_c = mocks.generate_child_to_parent(child_b)
         independent_instituion = mocks.create_institution()
 
         # update institution

--- a/frontend/invites/inviteInstHierarchieController.js
+++ b/frontend/invites/inviteInstHierarchieController.js
@@ -104,15 +104,8 @@
             invite.institution_requested_key = institution_requested_key;
             invite.sender_key = inviteInstHierCtrl.user.key;
             var deferred = $q.defer();
-            var promise;
-            if (invite.type_of_invite === INSTITUTION_PARENT) {
-                invite.type_of_invite = REQUEST_PARENT;
-                promise = RequestInvitationService.sendRequestToParentInst(invite, invite.institution_key);
-            } else {
-                invite.type_of_invite = REQUEST_CHILDREN;
-                promise = RequestInvitationService.sendRequestToChildrenInst(invite, invite.institution_key);
-            }
-            promise.then(function success() {
+            
+            sendRequest(invite).then(function success() {
                 MessageService.showToast('Convite enviado com sucesso!');
                 addInviteToRequests(invite);
                 if (invite.type_of_invite === REQUEST_PARENT) {
@@ -126,8 +119,19 @@
             }, function error() {
                 deferred.reject();
             });
+            
             return deferred.promise;
         };
+
+        function sendRequest(invite) {
+            if (invite.type_of_invite === INSTITUTION_PARENT) {
+                invite.type_of_invite = REQUEST_PARENT;
+                return RequestInvitationService.sendRequestToParentInst(invite, invite.institution_key);
+            } else {
+                invite.type_of_invite = REQUEST_CHILDREN;
+                return RequestInvitationService.sendRequestToChildrenInst(invite, invite.institution_key);
+            }
+        }
 
         /*
         * Add a stub link between institution that's who invited (child) and the institution that's been invitee (parent).

--- a/frontend/invites/invite_institution_hierarchie.html
+++ b/frontend/invites/invite_institution_hierarchie.html
@@ -117,7 +117,7 @@
                 </div>
               </div>
               <div ng-if="inviteInstHierCtrl.isActive(institution)" layout="row">
-                <md-button ng-click="inviteInstHierCtrl.removeLink(event, institution, false)">
+                <md-button ng-click="inviteInstHierCtrl.removeLink(institution, false, event)">
                   <md-icon md-colors="{color: 'red-700'}" title="Remover conexão">link</md-icon>
                 </md-button>
                 <md-button ng-if="inviteInstHierCtrl.canRemoveInst(institution)" ng-click="inviteInstHierCtrl.removeChild(institution)">

--- a/frontend/invites/suggestInstitutionController.js
+++ b/frontend/invites/suggestInstitutionController.js
@@ -71,9 +71,13 @@
             InstitutionService.getInstitution(suggestInstCtrl.chosen_institution).then(function(response) {
                 if (!(isLinked(response.data) || isSelf() || isPedingRequest() || isInvited())) {
                     invite.requested_inst_name = response.data.name;
-                    inviteController.sendRequestToExistingInst(invite, suggestInstCtrl.chosen_institution).then(function() {
-                        suggestInstCtrl.cancel();
-                    });
+                    inviteController.sendRequestToExistingInst(invite, suggestInstCtrl.chosen_institution).then(
+                        function success() {
+                            suggestInstCtrl.cancel();
+                        }, function error() {
+                            $mdDialog.cancel();
+                        }
+                    );
                 }
             });
         }

--- a/frontend/utils/messageService.js
+++ b/frontend/utils/messageService.js
@@ -32,7 +32,8 @@
             "Error! The sender is already invited": "O usuário já foi convidado para ser membro dessa instituição.",
             "Error! User is not allowed to send invites": "O usuário não tem permissão para enviar convites",
             "Error! The event has been deleted.": "Esse evento foi removido",
-            "Error! User is not allowed to remove institution": "O usuário não tem permissão para remover essa instituição."
+            "Error! User is not allowed to remove institution": "O usuário não tem permissão para remover essa instituição.",
+            "Error! Circular hierarchy not allowed": "Não é permitido criar dependencia circular entre instituições"
         };
 
         service.showToast = function showToast(message) {


### PR DESCRIPTION
**Feature/Bug description:** It was possible to create a hierarchical loop. For example, a hierarchically higher institution could invite one of its subordinated institutions to be its parent.

**Solution:** It was created a verification, at the handlers responsible for the creation of parent and child request, to identify and forbid the creation possible hierarchical loop requests.

**TODO/FIXME:** n/a