### PR TITLE
Fix invite notifification click when is already read

### DIFF
--- a/frontend/invites/newInviteController.js
+++ b/frontend/invites/newInviteController.js
@@ -8,16 +8,12 @@
         var newInviteCtrl = this;
 
         newInviteCtrl.institution = null;
-
         newInviteCtrl.inviteKey = $state.params.key;
-
         newInviteCtrl.acceptedInvite = false;
-
         newInviteCtrl.user = AuthService.getCurrentUser();
-
         newInviteCtrl.phoneRegex = "[0-9]{2}[\\s][0-9]{4,5}[-][0-9]{4,5}";
-
         newInviteCtrl.loading = true;
+        newInviteCtrl.isAlreadyProcessed = false;
 
         var observer;
 
@@ -80,6 +76,10 @@
                 institutionKey: institutionKey,
                 inviteKey: newInviteCtrl.inviteKey
             });
+        };
+
+        newInviteCtrl.goToHome = function goToHome() {
+            $state.go("app.user.home");
         };
 
         newInviteCtrl.isInviteUser = function isInviteUser(){
@@ -164,8 +164,7 @@
                     institutionKey = (newInviteCtrl.invite.type_of_invite === "USER") ? newInviteCtrl.invite.institution_key : newInviteCtrl.invite.stub_institution.key;
                     newInviteCtrl.institution = newInviteCtrl.invite.institution;
                 } else {
-                    $state.go("app.user.home");
-                    MessageService.showToast("Você já utilizou este convite.");
+                    newInviteCtrl.isAlreadyProcessed = true;
                 }
                 newInviteCtrl.loading = false;
             }, function error(response) {

--- a/frontend/invites/new_invite_page.html
+++ b/frontend/invites/new_invite_page.html
@@ -3,7 +3,7 @@
     <div layout="row" layout-xs="column" layout-align="center center">
       <div layout="row" flex-sm="60" flex-gt-sm="40" layout-align="center center">
         <load-circle ng-show="newInviteCtrl.loading"></load-circle>
-        <md-card ng-if="true" ng-show="!newInviteCtrl.loading">
+        <md-card ng-if="!newInviteCtrl.isAlreadyProcessed" ng-show="!newInviteCtrl.loading">
           <md-card-content style="background-color:#FFFFFF;" layout="column" layout-align="center">
             <div align="center">
               <img src="app/images/logowithname.png" aria-label="e-CIS Logo" style="width: 50%;">
@@ -84,7 +84,7 @@
             </form>
           </md-card-content>
         </md-card>
-        <md-card ng-if="false" flex-xs="80" flex-sm="70" flex-gt-sm="50" style="margin: 0">
+        <md-card ng-if="newInviteCtrl.isAlreadyProcessed" flex-xs="80" flex-sm="70" flex-gt-sm="50" style="margin: 0">
           <md-card-content style="background-color:#FFFFFF;" layout="column" layout-align="center center">
               <div align="center">
                 <img src="app/images/logowithname.png" aria-label="e-CIS Logo" style="width: 50%;">
@@ -94,7 +94,7 @@
               </div>
           </md-card-content>
           <md-card-actions layout="row" layout-align="end center">
-            <md-button  md-colors="{background: 'teal-500'}">
+            <md-button ng-click="newInviteCtrl.goToHome()"  md-colors="{background: 'teal-500'}">
               VOLTAR
             </md-button>
           </md-card-actions>

--- a/frontend/invites/new_invite_page.html
+++ b/frontend/invites/new_invite_page.html
@@ -1,9 +1,9 @@
 <md-content layout-fill layout="row" layout-align="center center" md-colors="{background: 'teal-500'}">
   <div layout="column" layout-align="center center">
     <div layout="row" layout-xs="column" layout-align="center center">
-      <div flex-sm="60" flex-gt-sm="40" layout-align="center center">
+      <div layout="row" flex-sm="60" flex-gt-sm="40" layout-align="center center">
         <load-circle ng-show="newInviteCtrl.loading"></load-circle>
-        <md-card ng-show="!newInviteCtrl.loading">
+        <md-card ng-if="true" ng-show="!newInviteCtrl.loading">
           <md-card-content style="background-color:#FFFFFF;" layout="column" layout-align="center">
             <div align="center">
               <img src="app/images/logowithname.png" aria-label="e-CIS Logo" style="width: 50%;">
@@ -83,6 +83,21 @@
               </md-card-actions>
             </form>
           </md-card-content>
+        </md-card>
+        <md-card ng-if="false" flex-xs="80" flex-sm="70" flex-gt-sm="50" style="margin: 0">
+          <md-card-content style="background-color:#FFFFFF;" layout="column" layout-align="center center">
+              <div align="center">
+                <img src="app/images/logowithname.png" aria-label="e-CIS Logo" style="width: 50%;">
+              </div>
+              <div>
+                <p>Este convite já foi processado!</p>
+              </div>
+          </md-card-content>
+          <md-card-actions layout="row" layout-align="end center">
+            <md-button  md-colors="{background: 'teal-500'}">
+              VOLTAR
+            </md-button>
+          </md-card-actions>
         </md-card>
       </div>
     </div>

--- a/frontend/notification/notificationDirective.js
+++ b/frontend/notification/notificationDirective.js
@@ -210,8 +210,7 @@
         };
 
         notificationCtrl.goTo = function goTo(notification) {
-            const isAReadInviteNotification = notification.status === "READ" && notification.entity_type === "INVITE";
-            if(notification.entity_type !== 'INSTITUTION' && !isAReadInviteNotification) {
+            if(notification.entity_type !== 'INSTITUTION') {
                 var state = type_data[notification.entity_type].state;
                 $state.go(state, {key: notification.entity.key});
             }


### PR DESCRIPTION
**Feature/Bug description:** When an invitation to create an institution is sent and the user clicks the notification that arrives but does not accept or reject the invitation, it is prevented from clicking again to take the action.

**Solution:** I let the user click on the notification even though it has already been read and redirected it to the invitations page, and I've created a verification to see if the invitation has already been processed or not, if it does, it will display a message that it has already been processed.

![screenshot from 2018-05-10 16-22-07](https://user-images.githubusercontent.com/18005317/39889673-e53d9252-546e-11e8-9905-d82dc12ae213.png)

**TODO/FIXME:** n/a