### PR TITLE
Fix the notification in wrong option of left menu on home page

### DIFF
--- a/frontend/main/mainController.js
+++ b/frontend/main/mainController.js
@@ -11,8 +11,8 @@
         mainCtrl.search_keyword = "";
         mainCtrl.user = AuthService.getCurrentUser();
 
-        mainCtrl.pending_manager_member = 0;
-        mainCtrl.pending_inst_invitations = 0;
+        mainCtrl.pendingManagerMember = 0;
+        mainCtrl.pendingInstInvitations = 0;
         mainCtrl.pendingInstLinksInvitations = 0;
 
         mainCtrl.APP_VERSION = Config.APP_VERSION;
@@ -115,7 +115,7 @@
         };
 
         function increaseInstInvitationsNumber(response) {
-            mainCtrl.pending_inst_invitations += response.length;
+            mainCtrl.pendingInstInvitations += response.length;
         }
 
         function increaseInstLinksInvitationsNumber(response) {
@@ -123,12 +123,12 @@
         }
 
         mainCtrl.getPendingTasks = function getPendingTasks() {
-            mainCtrl.pending_manager_member = 0;
-            mainCtrl.pending_inst_invitations = 0;
+            mainCtrl.pendingManagerMember = 0;
+            mainCtrl.pendingInstInvitations = 0;
 
             RequestInvitationService.getRequests(mainCtrl.user.current_institution.key).then(
                 function success(response) {
-                    mainCtrl.pending_manager_member = response.length;
+                    mainCtrl.pendingManagerMember = response.length;
                 }, function error() {}
             );
 

--- a/frontend/main/mainController.js
+++ b/frontend/main/mainController.js
@@ -13,6 +13,7 @@
 
         mainCtrl.pending_manager_member = 0;
         mainCtrl.pending_inst_invitations = 0;
+        mainCtrl.pendingInstLinksInvitations = 0;
 
         mainCtrl.APP_VERSION = Config.APP_VERSION;
 
@@ -117,6 +118,10 @@
             mainCtrl.pending_inst_invitations += response.length;
         }
 
+        function increaseInstLinksInvitationsNumber(response) {
+            mainCtrl.pendingInstLinksInvitations += response.length;
+        }
+
         mainCtrl.getPendingTasks = function getPendingTasks() {
             mainCtrl.pending_manager_member = 0;
             mainCtrl.pending_inst_invitations = 0;
@@ -128,10 +133,10 @@
             );
 
             RequestInvitationService.getParentRequests(mainCtrl.user.current_institution.key).then(
-                increaseInstInvitationsNumber, function error() {}
+                increaseInstLinksInvitationsNumber, function error() {}
             );
             RequestInvitationService.getChildrenRequests(mainCtrl.user.current_institution.key).then(
-                increaseInstInvitationsNumber, function error() {}
+                increaseInstLinksInvitationsNumber, function error() {}
             );
 
             if(mainCtrl.isSuperUser()) {

--- a/frontend/user/left_nav.html
+++ b/frontend/user/left_nav.html
@@ -71,7 +71,7 @@
                   <md-menu-item ng-if="mainCtrl.isSuperUser()">
                     <md-button ng-click="homeCtrl.goInvite()"
                       ng-class="homeCtrl.getSelectedItemClass('invite_inst')">
-                      <md-icon ng-class="mainCtrl.pending_inst_invitations? 'notification-badge': ''"
+                      <md-icon ng-class="mainCtrl.pendingInstInvitations? 'notification-badge': ''"
                         data-badge>
                         mail_outline</md-icon>
                       <b>Convites</b>
@@ -92,7 +92,7 @@
                   </md-menu-item>
                   <md-menu-item>
                     <md-button  ng-click="mainCtrl.goToManageMembers()">
-                      <md-icon ng-class="mainCtrl.pending_manager_member? 'notification-badge': ''"
+                      <md-icon ng-class="mainCtrl.pendingManagerMember? 'notification-badge': ''"
                         data-badge>account_circle</md-icon>
                       <b>Gerenciar Membros</b>
                   </md-menu-item>

--- a/frontend/user/left_nav.html
+++ b/frontend/user/left_nav.html
@@ -98,7 +98,7 @@
                   </md-menu-item>
                   <md-menu-item>
                     <md-button ng-click="mainCtrl.goToManageInstitutions()">
-                      <md-icon ng-class="mainCtrl.pending_inst_invitations? 'notification-badge': ''"
+                      <md-icon ng-class="mainCtrl.pendingInstLinksInvitations? 'notification-badge': ''"
                         data-badge>account_balance</md-icon>
                       <b>Vínculos Institucionais</b>
                     </md-button>


### PR DESCRIPTION
**Feature/Bug description:** When a user sent request to create an institution the notification is displayed to admin in two options of left menu on the homepage.

**Solution:** Fix the counting of invitations to a specific variable for links between institutions.
Showing only in invites or only in institutional links (except if has the two types of request)

![screenshot from 2018-05-10 16-43-30](https://user-images.githubusercontent.com/20300259/39890977-d3b980d2-5472-11e8-8d89-3a22cd834551.png)

![screenshot from 2018-05-10 16-44-58](https://user-images.githubusercontent.com/20300259/39890980-d77ac82a-5472-11e8-883e-fb667eea424f.png)



**TODO/FIXME:** n/a