### PR TITLE
Refact remove institution link notification

### DIFF
--- a/backend/handlers/institution_hierarchy_handler.py
+++ b/backend/handlers/institution_hierarchy_handler.py
@@ -65,7 +65,7 @@ class InstitutionHierarchyHandler(BaseHandler):
         else:
             enqueue_task('remove-admin-permissions', {'institution_key': institution_link.key.urlsafe(), 'parent_key': institution.key.urlsafe()})
         
-        notification_type = 'INSTITUTION'
+        notification_type = 'REMOVE_INSTITUTION_LINK'
 
         notification_message = institution.create_notification_message(user_key=user.key, current_institution_key=user.current_institution, 
             receiver_institution_key=institution_link.key, sender_institution_key=institution.key)

--- a/backend/test/institution_hierarchy_handler_test.py
+++ b/backend/test/institution_hierarchy_handler_test.py
@@ -87,7 +87,7 @@ class InstitutionHierarchyHandlerTest(TestBaseHandler):
         # assert the notification was sent
         send_message_notification.assert_called_with(
             receiver_key=otheruser.key.urlsafe(),
-            notification_type="INSTITUTION",
+            notification_type="REMOVE_INSTITUTION_LINK",
             entity_key=otherinst.key.urlsafe(),
             message=json.dumps(message)
         )
@@ -142,7 +142,7 @@ class InstitutionHierarchyHandlerTest(TestBaseHandler):
         # assert the notification was sent
         send_message_notification.assert_called_with(
             receiver_key=admin.key.urlsafe(),
-            notification_type="INSTITUTION",
+            notification_type="REMOVE_INSTITUTION_LINK",
             entity_key=institution.key.urlsafe(),
             message=json.dumps(message)
         )

--- a/frontend/notification/notificationDirective.js
+++ b/frontend/notification/notificationDirective.js
@@ -50,9 +50,8 @@
                 icon: "people",
                 state: "new_invite"
             },
-            "INSTITUTION": {
-                icon: "account_balance",
-                state: "app.post"
+            "REMOVE_INSTITUTION_LINK": {
+                icon: "account_balance"
             },
             "REPLY_COMMENT": {
                 icon: "reply",

--- a/frontend/notification/notificationDirective.js
+++ b/frontend/notification/notificationDirective.js
@@ -209,10 +209,8 @@
         };
 
         notificationCtrl.goTo = function goTo(notification) {
-            if(notification.entity_type !== 'INSTITUTION') {
-                var state = type_data[notification.entity_type].state;
-                $state.go(state, {key: notification.entity.key});
-            }
+            var state = type_data[notification.entity_type].state;
+            $state.go(state, {key: notification.entity.key});
         };
 
         notificationCtrl.action = function action(notification, event) {

--- a/frontend/notification/notificationService.js
+++ b/frontend/notification/notificationService.js
@@ -22,7 +22,7 @@
             'SURVEY_POST': messageCreator('Publicou uma nova enquete de ', SINGLE_INST),
             'SHARED_POST': messageCreator('Compartilhou um post de ', SINGLE_INST),
             'INVITE': messageCreator('Te enviou um novo convite via ', SINGLE_INST),
-            'INSTITUTION': messageCreator('Removeu a conexão entre ', DOUBLE_INST),
+            'REMOVE_INSTITUTION_LINK': messageCreator('Removeu a conexão entre ', DOUBLE_INST),
             'DELETED_INSTITUTION': messageCreator('Removeu ', SINGLE_INST),
             'REQUEST_USER': messageCreator('Solicitou ser membro de ', SINGLE_INST),
             'REQUEST_INSTITUTION_PARENT': messageCreator('Solicitou um novo vínculo entre ', DOUBLE_INST),


### PR DESCRIPTION
**Feature/Bug description:** The name of the link removal notification between institutions is bad, and the action when clicking on the notification is wrong, as there is a state.go that is pointing to the post page.

**Solution:** Change the notification name from INSTITUTION to REMOVE_INSTITUTION_LINK and remove the state.go

**TODO/FIXME:** n/a