### PR TITLE
Fix request child institution

### DIFF
--- a/backend/handlers/institution_children_request_collection_handler.py
+++ b/backend/handlers/institution_children_request_collection_handler.py
@@ -56,7 +56,7 @@ class InstitutionChildrenRequestCollectionHandler(BaseHandler):
         request.put()
 
         institution_parent = request.institution_key.get()
-        institution_parent.children_institutions.append(request.institution_requested_key)
+        institution_parent.add_child(request.institution_requested_key)
         institution_parent.put()
 
         request.send_invite(host, user.current_institution)

--- a/backend/handlers/institution_children_request_collection_handler.py
+++ b/backend/handlers/institution_children_request_collection_handler.py
@@ -69,7 +69,6 @@ class InstitutionChildrenRequestCollectionHandler(BaseHandler):
 
         institution_parent = parent_key.get()
         institution_parent.add_child(requested_inst_key)
-        institution_parent.put()
 
         request.send_invite(host, user.current_institution)
 

--- a/backend/models/institution.py
+++ b/backend/models/institution.py
@@ -136,7 +136,6 @@ class Institution(ndb.Model):
     def create_parent_connection(self, invite):
         """Make connections between parent and daughter institution."""
         self.add_child(invite.institution_key)
-        self.put()
 
         institution_children = invite.institution_key.get()
         institution_children.parent_institution = self.key

--- a/backend/models/institution.py
+++ b/backend/models/institution.py
@@ -131,10 +131,15 @@ class Institution(ndb.Model):
         self.invite = invite.key
         self.put()
 
+    def add_child(self, child_key):
+        """Add a new child to children_institutions."""
+        if child_key not in self.children_institutions:
+            self.children_institutions.append(child_key)
+
     @ndb.transactional(xg=True)
     def create_parent_connection(self, invite):
         """Make connections between parent and daughter institution."""
-        self.children_institutions.append(invite.institution_key)
+        self.add_child(invite.institution_key)
         self.put()
 
         institution_children = invite.institution_key.get()
@@ -148,7 +153,7 @@ class Institution(ndb.Model):
         self.put()
 
         parent_institution = invite.institution_key.get()
-        parent_institution.children_institutions.append(self.key)
+        parent_institution.add_child(self.key)
         parent_institution.put()
 
     @staticmethod

--- a/backend/models/institution.py
+++ b/backend/models/institution.py
@@ -130,6 +130,7 @@ class Institution(ndb.Model):
         """Add a new child to children_institutions."""
         if child_key not in self.children_institutions:
             self.children_institutions.append(child_key)
+            self.put()
 
     @ndb.transactional(xg=True)
     def create_parent_connection(self, invite):
@@ -149,7 +150,6 @@ class Institution(ndb.Model):
 
         parent_institution = invite.institution_key.get()
         parent_institution.add_child(self.key)
-        parent_institution.put()
 
     @staticmethod
     @ndb.transactional(xg=True)

--- a/backend/models/request.py
+++ b/backend/models/request.py
@@ -41,7 +41,7 @@ class Request(Invite):
         if Request.isLinked(institution_key, institution_requested):
             raise FieldException("The institutions has already been connected.")
         if Request.isRequested(institution_key, institution_requested.key):
-            raise FieldException("The sender is already invited")
+            raise FieldException("The requested institution has already been invited")
 
     def make(self):
         """Create json of request to institution."""

--- a/backend/test/model_test/institution_test.py
+++ b/backend/test/model_test/institution_test.py
@@ -33,6 +33,29 @@ class InstitutionTest(TestBase):
         """Deactivate the test."""
         cls.test.deactivate()
 
+    def test_add_child(self):
+        
+        self.assertEquals(
+            self.institution.children_institutions, [],
+            "Instituion should not have children"
+        )
+
+        new_inst = mocks.create_institution();
+        self.institution.add_child(new_inst.key)
+        self.institution = self.institution.key.get()
+
+        self.assertEquals(
+            self.institution.children_institutions, [new_inst.key],
+            "Instituion should have new_inst as child"
+        )
+
+        self.institution.add_child(new_inst.key)
+        
+        self.assertEquals(
+            self.institution.children_institutions, [new_inst.key],
+            "Instituion should have repeated children"
+        )    
+        
     
     def test_follow(self):
         # case in which the user is not a follower

--- a/backend/test/model_test/request_institution_test.py
+++ b/backend/test/model_test/request_institution_test.py
@@ -70,9 +70,9 @@ class RequestInstitutionParentTest(TestBase):
             RequestInstitutionParent.create(data)
 
         self.assertEqual(
-            'The sender is already invited',
+            'The requested institution has already been invited',
             str(ex.exception),
-            'The sender is already invited')
+            'The exception message is not equal to the expected one')
 
     def test_create_request_for_institution_linked(self):
         """Test create invalid request."""

--- a/frontend/institution/institution.js
+++ b/frontend/institution/institution.js
@@ -53,13 +53,9 @@ Institution.prototype.addChildInst = function addChildInst(institution){
     const childIndex = this.children_institutions.reduce((childIndex, inst, index) => {
         return inst.key === institution.key ? index : childIndex;
     }, INVALID_INDEX);
-    const hasThisChild = childIndex != INVALID_INDEX;
+    const childIsNew = childIndex == INVALID_INDEX;
 
-    if(hasThisChild) {
-        this.children_institutions.splice(childIndex, 1, institution);
-    } else {
-        this.children_institutions.push(institution);
-    }  
+    childIsNew ? this.children_institutions.push(institution) : null;
 };
 
 Institution.prototype.getFullAddress = function getFullAddress() {

--- a/frontend/institution/institution.js
+++ b/frontend/institution/institution.js
@@ -48,8 +48,18 @@ Institution.prototype.addParentInst = function addParentInst(institution){
     this.parent_institution = institution;
 };
 
-Institution.prototype.addChildrenInst = function addChildrenInst(institution){
-    this.children_institutions.push(institution);
+Institution.prototype.addChildInst = function addChildInst(institution){
+    const INVALID_INDEX = -1;
+    const childIndex = this.children_institutions.reduce((childIndex, inst, index) => {
+        return inst.key === institution.key ? index : childIndex;
+    }, INVALID_INDEX);
+    const hasThisChild = childIndex != INVALID_INDEX;
+
+    if(hasThisChild) {
+        this.children_institutions.splice(childIndex, 1, institution);
+    } else {
+        this.children_institutions.push(institution);
+    }  
 };
 
 Institution.prototype.getFullAddress = function getFullAddress() {

--- a/frontend/invites/inviteInstHierarchieController.js
+++ b/frontend/invites/inviteInstHierarchieController.js
@@ -336,7 +336,6 @@
                 inviteInstHierCtrl.institution.addParentInst(stub);
                 inviteInstHierCtrl.hasParent = true;
             } else {
-                console.log(stub);
                 inviteInstHierCtrl.institution.addChildInst(stub);
             }
             inviteInstHierCtrl.showSendInvite = false;

--- a/frontend/invites/inviteInstHierarchieController.js
+++ b/frontend/invites/inviteInstHierarchieController.js
@@ -155,7 +155,7 @@
         function addChildrenInstitution(institution_requested_key) {
             var promise = InstitutionService.getInstitution(institution_requested_key);
             promise.then(function(response) {
-                inviteInstHierCtrl.institution.addChildrenInst(response.data);
+                inviteInstHierCtrl.institution.addChildInst(response.data);
             });
             return promise;
         }
@@ -171,7 +171,7 @@
             var promise = InstitutionService.getInstitution(sending_inst_key);
             promise.then(function(response) {
                if (type_of_invite === REQUEST_PARENT) {
-                    inviteInstHierCtrl.institution.addChildrenInst(response.data);
+                    inviteInstHierCtrl.institution.addChildInst(response.data);
                } else {
                     inviteInstHierCtrl.institution.addParentInst(response.data);
                     inviteInstHierCtrl.hasParent = true;
@@ -336,7 +336,8 @@
                 inviteInstHierCtrl.institution.addParentInst(stub);
                 inviteInstHierCtrl.hasParent = true;
             } else {
-                inviteInstHierCtrl.institution.addChildrenInst(stub);
+                console.log(stub);
+                inviteInstHierCtrl.institution.addChildInst(stub);
             }
             inviteInstHierCtrl.showSendInvite = false;
         }

--- a/frontend/invites/suggestInstitutionController.js
+++ b/frontend/invites/suggestInstitutionController.js
@@ -121,7 +121,7 @@
             _.forEach(suggestInstCtrl.institution.sent_invitations, function(invite) {
                 if ((invite.type_of_invite === "REQUEST_INSTITUTION_PARENT" || invite.type_of_invite === "REQUEST_INSTITUTION_CHILDREN") &&
                     invite.institution_requested_key === suggestInstCtrl.chosen_institution && invite.status === "sent") {
-                    MessageService.showToast('Esta instituição já foi convidada e seu convite está pendente');
+                    MessageService.showToast('Esta instituição já foi convidada, mas seu convite está pendente');
                     result = true;
                 }
             });

--- a/frontend/test/specs/institutionSpec.js
+++ b/frontend/test/specs/institutionSpec.js
@@ -182,10 +182,23 @@ describe('Test Institution Model:', function() {
 
     describe('addChildInst()', function() {
 
-        it('should increse children_institutions list of institution in +1', function() {
+        it('should increse children_institutions list of institution in one', function() {
             expect(institution.children_institutions.length).toEqual(0);
             institution.addChildInst(testInst);
             expect(institution.children_institutions.length).toEqual(1);
+        });
+
+        it('should not add the same institution again', function() {
+            testInst.name = "original";
+            institution.addChildInst(testInst);
+            expect(institution.children_institutions.length).toEqual(1);
+            expect(institution.children_institutions[0].name).toEqual("original");
+            
+            var sameInst = Object.assign({}, testInst);
+            sameInst.name = "replaced";
+            institution.addChildInst(sameInst);
+            expect(institution.children_institutions.length).toEqual(1);
+            expect(institution.children_institutions[0].name).toEqual("replaced");
         });
     });
 });

--- a/frontend/test/specs/institutionSpec.js
+++ b/frontend/test/specs/institutionSpec.js
@@ -189,16 +189,12 @@ describe('Test Institution Model:', function() {
         });
 
         it('should not add the same institution again', function() {
-            testInst.name = "original";
             institution.addChildInst(testInst);
             expect(institution.children_institutions.length).toEqual(1);
-            expect(institution.children_institutions[0].name).toEqual("original");
             
             var sameInst = Object.assign({}, testInst);
-            sameInst.name = "replaced";
             institution.addChildInst(sameInst);
             expect(institution.children_institutions.length).toEqual(1);
-            expect(institution.children_institutions[0].name).toEqual("replaced");
         });
     });
 });

--- a/frontend/test/specs/institutionSpec.js
+++ b/frontend/test/specs/institutionSpec.js
@@ -180,11 +180,11 @@ describe('Test Institution Model:', function() {
         });
     });
 
-    describe('addChildrenInst()', function() {
+    describe('addChildInst()', function() {
 
         it('should increse children_institutions list of institution in +1', function() {
             expect(institution.children_institutions.length).toEqual(0);
-            institution.addChildrenInst(testInst);
+            institution.addChildInst(testInst);
             expect(institution.children_institutions.length).toEqual(1);
         });
     });

--- a/frontend/utils/messageService.js
+++ b/frontend/utils/messageService.js
@@ -30,10 +30,11 @@
             "Error! An invitation is already being processed for this institution!": "Um convite desse mesmo tipo já está sendo processado para essa instituição.",
             "Error! The sender is already a member": "O usuário já é um membro.",
             "Error! The sender is already invited": "O usuário já foi convidado para ser membro dessa instituição.",
-            "Error! User is not allowed to send invites": "O usuário não tem permissão para enviar convites",
-            "Error! The event has been deleted.": "Esse evento foi removido",
+            "Error! User is not allowed to send invites": "O usuário não tem permissão para enviar convites.",
+            "Error! The event has been deleted.": "Esse evento foi removido.",
             "Error! User is not allowed to remove institution": "O usuário não tem permissão para remover essa instituição.",
-            "Error! Circular hierarchy not allowed": "Não é permitido criar dependencia circular entre instituições"
+            "Error! Circular hierarchy not allowed": "Não é permitido criar dependencia circular entre instituições.",
+            "Error! The requested institution has already been invited": "Esta instituição já foi convidada, mas seu convite está pendente",
         };
 
         service.showToast = function showToast(message) {


### PR DESCRIPTION
**Feature/Bug description:** Previously, when a already rejected child request and tries to send the same invite again, the request is duplicated in the list. Besides that, the requested institution was added again as a children institution.

![inite2](https://user-images.githubusercontent.com/13683704/39998176-afca9986-575b-11e8-8708-27ce65a76303.gif)

**Solution:** On client, I added a verification to the method addChildInst, to check if that institution is already a child, if so, it is not added to the list. On server, I created a method to add a child, at Institution model, to prevent the same institution be added twice to the children institutions.

![invite](https://user-images.githubusercontent.com/13683704/39998368-4329f82a-575c-11e8-9bde-ba0286fc7772.gif)

**TODO/FIXME:** n/a