### PR TITLE
Creating email template to reject institution links

### DIFF
--- a/backend/handlers/institution_children_request_handler.py
+++ b/backend/handlers/institution_children_request_handler.py
@@ -54,4 +54,5 @@ class InstitutionChildrenRequestHandler(BaseHandler):
         request.put()
 
         request.send_response_notification(user.current_institution, user.key, 'REJECT')
+        request.send_response_email('REJECT')
         

--- a/backend/handlers/institution_parent_request_handler.py
+++ b/backend/handlers/institution_parent_request_handler.py
@@ -56,3 +56,4 @@ class InstitutionParentRequestHandler(BaseHandler):
         request.put()
 
         request.send_response_notification(user.current_institution, user.key, 'REJECT')
+        request.send_response_email('REJECT')

--- a/backend/models/request_institution_children.py
+++ b/backend/models/request_institution_children.py
@@ -39,6 +39,25 @@ class RequestInstitutionChildren(Request):
         })
         email_sender.send_email()
 
+    def send_response_email(self, operation, host=None):
+        parent_institution = self.institution_key.get()
+        child_institution = self.institution_requested_key.get()
+        if operation == "ACCEPT":
+            pass
+        else:
+            subject = get_subject('REJECT_LINK_EMAIL_SUBJECT')
+            email_sender = RequestLinkEmailSender(**{
+                'receiver': parent_institution.admin.get().email[0],
+                'subject': subject,
+                'institution_parent_name': parent_institution.name,
+                'institution_parent_email': parent_institution.institutional_email,
+                'institution_child_name': child_institution.name,
+                'institution_child_email': child_institution.institutional_email,
+                'institution_requested_key': child_institution.key.urlsafe(),
+                'html': 'reject_institutional_link.html'
+            })
+        email_sender.send_email()
+
     def send_notification(self, current_institution):
         """Method of send notification of request institution children."""
         notification_type = 'REQUEST_INSTITUTION_CHILDREN'

--- a/backend/models/request_institution_parent.py
+++ b/backend/models/request_institution_parent.py
@@ -39,6 +39,25 @@ class RequestInstitutionParent(Request):
         })
         email_sender.send_email()
 
+    def send_response_email(self, operation, host=None):
+        parent_institution = self.institution_requested_key.get()
+        child_institution = self.institution_key.get()
+        if operation == "ACCEPT":
+            pass
+        else:
+            subject = get_subject('REJECT_LINK_EMAIL_SUBJECT')
+            email_sender = RequestLinkEmailSender(**{
+                'receiver': child_institution.admin.get().email[0],
+                'subject': subject,
+                'institution_parent_name': parent_institution.name,
+                'institution_parent_email': parent_institution.institutional_email,
+                'institution_child_name': child_institution.name,
+                'institution_child_email': child_institution.institutional_email,
+                'institution_requested_key': parent_institution.key.urlsafe(),
+                'html': 'reject_institutional_link.html'
+            })
+        email_sender.send_email()
+
     def send_notification(self, current_institution):
         """Method of send notification of request institution parent."""
         notification_type = 'REQUEST_INSTITUTION_PARENT'

--- a/backend/send_email_hierarchy/request_link_email_sender.py
+++ b/backend/send_email_hierarchy/request_link_email_sender.py
@@ -16,6 +16,8 @@ class RequestLinkEmailSender(EmailSender):
         """
         super(RequestLinkEmailSender, self).__init__(**kwargs)
         self.html = 'request_link_email.html'
+        if 'html' in kwargs:
+            self.html = kwargs['html']
         self.institution_parent_name = self.crop_name(
             kwargs['institution_parent_name'], MAXIMUM_INSTITUTION_NAME)
         self.institution_parent_email = self.crop_name(

--- a/backend/templates/reject_institutional_link.html
+++ b/backend/templates/reject_institutional_link.html
@@ -1,0 +1,154 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html lang="en">
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <title></title>
+</head>
+<body style="margin:0; padding:0;">
+    <table width="100%" border="0" cellpadding="0" cellspacing="0" align="center">
+        <tr align="center">
+            <td align="center">
+
+                <table width="100%" border="0" cellpadding="0" cellspacing="0" align="center" style="background-color: #004D40;">
+                    <tr align="center">
+                        <td>
+                            <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2FLOGo.png?alt=media&token=fbb74261-4b24-42aa-b67f-be36577c48df"
+                                style="width: 50px; padding-top: 20px; height: 50px;" />
+                            <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2Fasset_09_logo_white.png?alt=media&token=5fa33bc3-140a-4f71-90ff-5d1e9203a196"
+                                style="width: 150px; padding-bottom: 10px;" />
+                        </td>
+                    </tr>
+                </table>
+
+                <table width="100%" height="100%" border="0" cellpadding="0" cellspacing="0" align="center">
+                    <tr>
+                        <td>
+                            <div style="height: 425px;">
+                                <div style="background-color: #009688; height: 65%;" align="center">
+                                    <div style="height: 25%; background-color: #004D40;">
+                                        <div style="width: 275px; height: 395px; margin-top: 10px; border: 1px solid #E1E1E1;  background: #fff;
+                                        border-radius: 5px; display: inline-block; position: relative;" align="center">
+                                            <div style="height: 35%; background-color: #EEEEEE; border-top-left-radius: 10px; border-top-right-radius: 10px;">
+                                                <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2FAsset_01_email.png?alt=media&token=8c9df98d-f75d-493f-a232-133e94da6fea"
+                                                    style="width: 100px; margin-top: 35px;" />
+                                            </div>
+                                            <div style="background-color: white; font-size: 15px;">
+                                                <b>SUA SOLICITAÇÃO DE VÍNCULO NÃO FOI APROVADA</b>
+                                                <hr width="80%;" />
+                                                <p style="color: gray">A SEGUINTE INSTITUIÇÃO NÃO APROVOU O SEU CONVITE:</p>
+                                                <div style="background-color: #E0E0E0; width: 90%; height: 45px; margin-top: 8px; margin-bottom: 5px;">
+                                                    <div>
+                                                        <div>
+                                                            <img align="left" src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2F2.png?alt=media&token=e19cea6d-ff42-44cb-ae55-4caa4230785b"
+                                                                style="height: 35px; width: 35px; margin-top: 5px; margin-left: 5px;"
+                                                            />
+                                                        </div>
+                                                        <div align="left" valign="middle" style="margin-left: 50px; padding-top: 4px;">
+                                                            <div style="height: 11px;">
+                                                                <b style="font-size: 12px; color: black;">{{institution_parent}}</b>
+                                                            </div>
+                                                            <div style="height: 10px; margin-top: 2px;">
+                                                                <span style="font-size: 9px; color: black;">{{institution_parent.email}}</span>
+                                                            </div>
+                                                            <div style="height: 10px; margin-top: 2px;">
+                                                                <span style="font-size: 9px; color: black;">Convidado por: {{institution_requested_email}}</span>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                <div style="background-color: #E0E0E0; width: 90%; height: 45px; margin-top: 10px; ">
+                                                    <div>
+                                                        <div style="float: left; background-color: #009688; width: 5px; height: 45px;">
+                                                        </div>
+                                                        <div>
+                                                            <img align="left" src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2Favatar.png?alt=media&token=c7ea2239-f178-424c-87be-16124c9f5933"
+                                                                style="height: 35px; width: 35px; margin-top: 5px; margin-left: 5px;" />
+                                                        </div>
+                                                        <div align="left" valign="middle" style="padding-top: 4px; margin-left: 50px;">
+                                                            <div style="height: 11px;">
+                                                                <b style="font-size: 12px; word-break: break-all">{{institution_children}}</b>
+                                                            </div>
+                                                            <div style="height: 10px; ">
+                                                                <span style="font-size: 9px; color: black;">{{user_email}}</span>
+                                                            </div>
+                                                            <div style="height: 10px; margin-top: 2px;">
+                                                                <span style="font-size: 9px; color: black;">Convidado por: {{institution_requested_email}}</span>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                <div style="margin-top: 8px;">
+                                                    <button style="background-color: #009688; width: 90%; height: 25px; border: none;" title="Ou copie e cole o link abaixo no seu navegador">
+                                                        <a href="http://frontend.plataformacis.org/institution/{{institution_requested_key}}/managementMembers" style="text-decoration: none;">
+                                                            <span style="text-align: center; font-size: 8px; color: #FFFFFF">GERENCIAR VÍNCULOS</span>
+                                                        </a>
+                                                    </button>    
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+
+                <table width="100%" border="0" cellpadding="0" cellspacing="0" align="center" style="margin-bottom: -5px;">
+                    <tr align="center">
+                        <td>
+                            <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2FLOGo.png?alt=media&token=fbb74261-4b24-42aa-b67f-be36577c48df"
+                                style="width: 50px; height: 50px;"/>
+                            <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2FAsset_09LOGO.png?alt=media&token=a33e8fc2-95d4-4b74-ae95-c6f50514645e"
+                                style="width: 150px; padding-bottom: 10px;"> 
+                        </td>
+                    </tr>
+                </table>
+
+                <table width="100%" border="0" cellpadding="0" cellspacing="0" align="center">
+                    <tr align="center">
+                        <td style="width: 100%;">
+                            <div style="width: 100%; height: 160px; position: relative; border-top: 1px solid #E0E0E0; border-bottom: 1px solid #E1E1E1; background: #fff;
+                            border-radius: 0px;
+                            display: inline-block; position: relative;" align="center">
+                                <div style="height: 50%; background-color: white;">
+                                    <div>
+                                        <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2Fufcg.png?alt=media&token=6edbaf3e-3c46-4e8a-8101-80d432d1ab6f"
+                                            style="width: 100px; margin-top: 5px;" />
+                                        <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2Fcis.png?alt=media&token=ccab7007-97b0-462b-a1d0-38b5da58a2ad"
+                                            style="width: 100px; margin-top: 5px; margin-left: 20px;" />
+                                    </div>
+                                    <div>
+                                        <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2Fopasoms.png?alt=media&token=a71b5c27-a317-417e-aa6e-3c744ed0e602"
+                                            style="width: 220px; margin-top: 5px;" />
+                                    </div>
+                                    <div>
+                                        <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2Fbr.png?alt=media&token=22012e23-60ad-4e63-969c-76e9000343f3"
+                                            style="width: 150px; margin-top: 10px;" />
+                                    </div>
+                                    <div style="margin-top: 23px; font-size: 10px;">
+                                        <span align="center" style="word-break: break-all; color: black;">
+                                            Copyright © 2017 Plataforma CIS - Ministério da Saúde.
+                                        </span>
+                                    </div>
+                                    <div>
+                                        <span style="font-size: 10px; color: black;">
+                                            Todos os direitos reservados.
+                                        </span>
+                                    </div>
+                                </div>
+                                <div style="height: 50%; background-color: white;">
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+
+</html>

--- a/backend/templates/reject_institutional_link.html
+++ b/backend/templates/reject_institutional_link.html
@@ -8,6 +8,7 @@
 
     <title></title>
 </head>
+
 <body style="margin:0; padding:0;">
     <table width="100%" border="0" cellpadding="0" cellspacing="0" align="center">
         <tr align="center">
@@ -31,16 +32,18 @@
                                 <div style="background-color: #009688; height: 65%;" align="center">
                                     <div style="height: 25%; background-color: #004D40;">
                                         <div style="width: 275px; height: 395px; margin-top: 10px; border: 1px solid #E1E1E1;  background: #fff;
-                                        border-radius: 5px; display: inline-block; position: relative;" align="center">
+                                        border-radius: 5px; display: inline-block; position: relative; padding-bottom: 50px;" align="center">
                                             <div style="height: 35%; background-color: #EEEEEE; border-top-left-radius: 10px; border-top-right-radius: 10px;">
-                                                <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2FAsset_01_email.png?alt=media&token=8c9df98d-f75d-493f-a232-133e94da6fea"
-                                                    style="width: 100px; margin-top: 35px;" />
+                                                <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2FAsset%207logo.png?alt=media&token=16461842-da00-4d7d-9dd8-621915951af7"
+                                                    style="width: 110px; margin-top: 35px;" />
                                             </div>
                                             <div style="background-color: white; font-size: 15px;">
-                                                <b>SUA SOLICITAÇÃO DE VÍNCULO NÃO FOI APROVADA</b>
-                                                <hr width="80%;" />
-                                                <p style="color: gray">A SEGUINTE INSTITUIÇÃO NÃO APROVOU O SEU CONVITE:</p>
-                                                <div style="background-color: #E0E0E0; width: 90%; height: 45px; margin-top: 8px; margin-bottom: 5px;">
+                                                <div style="color: #009688; font-family: Arial; margin-top: 10px; font-size: 20px;">
+                                                    <b>SUA SOLICITAÇÃO DE VÍNCULO NÃO FOI APROVADA</b>
+                                                </div>
+                                                <hr width="80%;" style="opacity: 0.5; margin-top: 12px;"/>
+                                                <p style="color: gray">A SEGUINTE INSTITUIÇÃO NÃO APROVOU SEU CONVITE:</p>
+                                                <div style="background-color: #E0E0E0; width: 90%; height: 45px; margin-top: 20px; margin-bottom: 5px;">
                                                     <div>
                                                         <div>
                                                             <img align="left" src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2F2.png?alt=media&token=e19cea6d-ff42-44cb-ae55-4caa4230785b"
@@ -49,45 +52,40 @@
                                                         </div>
                                                         <div align="left" valign="middle" style="margin-left: 50px; padding-top: 4px;">
                                                             <div style="height: 11px;">
-                                                                <b style="font-size: 12px; color: black;">{{institution_parent}}</b>
+                                                                <b style="font-size: 12px; color: black;">{{institution_parent_name}}</b>
                                                             </div>
                                                             <div style="height: 10px; margin-top: 2px;">
-                                                                <span style="font-size: 9px; color: black;">{{institution_parent.email}}</span>
-                                                            </div>
-                                                            <div style="height: 10px; margin-top: 2px;">
-                                                                <span style="font-size: 9px; color: black;">Convidado por: {{institution_requested_email}}</span>
+                                                                <span style="font-size: 9px; color: black;">{{institution_parent_email}}</span>
                                                             </div>
                                                         </div>
                                                     </div>
                                                 </div>
-                                                <div style="background-color: #E0E0E0; width: 90%; height: 45px; margin-top: 10px; ">
+                                                <div style="background-color: #E0E0E0; width: 90%; height: 45px; margin-top: 5px; ">
                                                     <div>
                                                         <div style="float: left; background-color: #009688; width: 5px; height: 45px;">
                                                         </div>
                                                         <div>
                                                             <img align="left" src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2Favatar.png?alt=media&token=c7ea2239-f178-424c-87be-16124c9f5933"
-                                                                style="height: 35px; width: 35px; margin-top: 5px; margin-left: 5px;" />
+                                                                style="height: 35px; width: 35px; margin-top: 5px; margin-left: 5px;"
+                                                            />
                                                         </div>
-                                                        <div align="left" valign="middle" style="padding-top: 4px; margin-left: 50px;">
+                                                        <div align="left" valign="middle" style="padding-top: 4px; margin-left: 55px;">
                                                             <div style="height: 11px;">
-                                                                <b style="font-size: 12px; word-break: break-all">{{institution_children}}</b>
+                                                                <b style="font-size: 12px; word-break: break-all">{{institution_child_name}}</b>
                                                             </div>
                                                             <div style="height: 10px; ">
-                                                                <span style="font-size: 9px; color: black;">{{user_email}}</span>
-                                                            </div>
-                                                            <div style="height: 10px; margin-top: 2px;">
-                                                                <span style="font-size: 9px; color: black;">Convidado por: {{institution_requested_email}}</span>
+                                                                <span style="font-size: 9px; color: black;">{{institution_child_email}}</span>
                                                             </div>
                                                         </div>
                                                     </div>
                                                 </div>
-                                                <div style="margin-top: 8px;">
-                                                    <button style="background-color: #009688; width: 90%; height: 25px; border: none;" title="Ou copie e cole o link abaixo no seu navegador">
-                                                        <a href="http://frontend.plataformacis.org/institution/{{institution_requested_key}}/managementMembers" style="text-decoration: none;">
-                                                            <span style="text-align: center; font-size: 8px; color: #FFFFFF">GERENCIAR VÍNCULOS</span>
-                                                        </a>
-                                                    </button>    
-                                                </div>
+                                                <a href="http://frontend.plataformacis.org/institution/{{institution_requested_key}}/inviteInstitution" style="text-decoration: none;">
+                                                    <div style="margin-top: 20px;">
+                                                        <button style="background-color: #009688; width: 90%; height: 25px; border: none;">
+                                                            <span style="text-align: center; font-size: 8px; color: #FFFFFF;">GERENCIAR VÍNCULOS</span>
+                                                        </button>
+                                                    </div>
+                                                </a>
                                             </div>
                                         </div>
                                     </div>
@@ -97,13 +95,13 @@
                     </tr>
                 </table>
 
-                <table width="100%" border="0" cellpadding="0" cellspacing="0" align="center" style="margin-bottom: -5px;">
+                <table width="100%" border="0" cellpadding="0" cellspacing="0" align="center" style="padding-top: 45px; margin-bottom: 10px;">
                     <tr align="center">
                         <td>
                             <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2FLOGo.png?alt=media&token=fbb74261-4b24-42aa-b67f-be36577c48df"
-                                style="width: 50px; height: 50px;"/>
+                                style="width: 50px; height: 50px;" />
                             <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2FAsset_09LOGO.png?alt=media&token=a33e8fc2-95d4-4b74-ae95-c6f50514645e"
-                                style="width: 150px; padding-bottom: 10px;"> 
+                                style="width: 150px; padding-bottom: 10px;">
                         </td>
                     </tr>
                 </table>

--- a/backend/util/strings_pt_br.py
+++ b/backend/util/strings_pt_br.py
@@ -6,7 +6,8 @@ SUBJECT_TRANSLATION = {
     'LINK_REMOVAL': 'Remoção de vínculo',
     'INSTITUION_REMOVAL': 'Remoção de instituição',
     'REQUEST_EMAIL_SUBJECT': """Solicitação de participação plataforma CIS""",
-    'REQUEST_LINK_EMAIL_SUBJECT': """Novo convite de vínculo na Plataforma Virtual CIS."""
+    'REQUEST_LINK_EMAIL_SUBJECT': """Novo convite de vínculo na Plataforma Virtual CIS.""",
+    'REJECT_LINK_EMAIL_SUBJECT': """Seu vínculo não foi aprovado."""
 }
 
 


### PR DESCRIPTION
**Feature/Bug description:** There are not email template to reject institution links on the platform.

**Solution:** Created HTML template based on design and adding new send_response_email to institution_parent and institution_children requests.

**Hotmail**
![screenshot from 2018-05-16 11-06-25](https://user-images.githubusercontent.com/20300259/40123017-864297b6-58fb-11e8-8ee0-de1bc6ebd109.png)

**Gmail**
![screenshot from 2018-05-16 11-12-18](https://user-images.githubusercontent.com/20300259/40123032-8d4391be-58fb-11e8-835e-548ce515f6e5.png)

**TODO/FIXME:** n/a