### PR TITLE
Fix background of institution photo

### DIFF
--- a/frontend/institution/base_institution_page.html
+++ b/frontend/institution/base_institution_page.html
@@ -42,7 +42,7 @@
                 </div>
                 <div id="instName" md-colors="{background: 'teal-500'}" style="height: 4em;" layout-xs="column" layout="row"
                     layout-align-gt-xs="start center" layout-align-xs="center center">
-                    <img hide-xs style="height: 10em; width: 10em; margin: -7.5em 2em 0 3em; border-radius: 50%;
+                    <img hide-xs style="height: 10em; width: 10em; margin: -7.5em 2em 0 3em; border-radius: 50%; background: white;
                         box-shadow: 0px -2px 14px 2px grey;" 
                         ng-src="{{ institutionCtrl.getPhoto() }}"/>
                     <img hide-gt-xs style="height: 8em; width:8em; margin: -7em 0 -0.8em 0; border-radius: 50%;" 


### PR DESCRIPTION
**Feature/Bug description:** The photo background of institutions which are PNG file is the same as the cover. In some cases, this can be confused because do not has a distinction between cover color and photo color.

![screenshot from 2018-05-16 15-05-21](https://user-images.githubusercontent.com/20300259/40135568-0d79bdc0-591c-11e8-946a-30b9cc2b9f47.png)


**Solution:** Adding pattern of the white background for pictures.

![screenshot from 2018-05-16 15-04-15](https://user-images.githubusercontent.com/20300259/40135639-2f633948-591c-11e8-852b-62915271ccaf.png)


**TODO/FIXME:** n/a