### PR TITLE
Fix addChildInst function

### DIFF
--- a/frontend/institution/institution.js
+++ b/frontend/institution/institution.js
@@ -51,7 +51,7 @@ Institution.prototype.addParentInst = function addParentInst(institution){
 Institution.prototype.addChildInst = function addChildInst(institution){
     const INVALID_INDEX = -1;
     const childIndex = this.children_institutions.reduce((childIndex, inst, index) => {
-        return inst.key === institution.key ? index : childIndex;
+        return inst.key && inst.key === institution.key ? index : childIndex;
     }, INVALID_INDEX);
     const childIsNew = childIndex == INVALID_INDEX;
 

--- a/frontend/invites/invite_institution_hierarchie.html
+++ b/frontend/invites/invite_institution_hierarchie.html
@@ -89,7 +89,7 @@
           <div class="md-toolbar-tools" flex layout="row" layout-align="center center">
             <h1>
               <md-icon>account_balance</md-icon>
-              Instituição hierarquicamente subordinadas
+              Instituições hierarquicamente subordinadas
             </h1>
             <span flex md-truncate></span>
             <md-button class="md-icon-button md-secondary">


### PR DESCRIPTION
**Feature/Bug description:**
When the two or more children institution's invite were created they're not appearing in the view because the function that checks if they should be added to the institution.children_institutions or not was checking if there was an invite with the same key as the current invite and the invites didn't have any key, once they hasn't gone to the backend, so, the function wasn't allowing the addition because undefined === undefined was returning true, what made it realize that there was an invite with the same key. 
**Solution:**
I've checked if the invites have the key before checking if it was equals to the current invite's key.
**TODO/FIXME:** n/a