### PR TITLE
Refact utils

### DIFF
--- a/backend/handlers/event_collection_handler.py
+++ b/backend/handlers/event_collection_handler.py
@@ -8,7 +8,7 @@ from google.appengine.ext import ndb
 import json
 from utils import Utils
 from models import Event
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 from utils import NotAuthorizedException
 from utils import query_paginated

--- a/backend/handlers/event_handler.py
+++ b/backend/handlers/event_handler.py
@@ -5,7 +5,7 @@ from google.appengine.ext import ndb
 
 from models import Event
 from utils import Utils
-from utils import login_required
+from util.login_service import login_required
 from utils import NotAuthorizedException
 from utils import json_response
 from util.json_patch import JsonPatch

--- a/backend/handlers/get_key_handler.py
+++ b/backend/handlers/get_key_handler.py
@@ -6,7 +6,7 @@ import json
 from google.appengine.ext import ndb
 
 from utils import Utils
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 
 from . import BaseHandler

--- a/backend/handlers/institution_children_request_collection_handler.py
+++ b/backend/handlers/institution_children_request_collection_handler.py
@@ -3,7 +3,7 @@
 
 from google.appengine.ext import ndb
 import json
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 from utils import Utils
 from custom_exceptions.entityException import EntityException

--- a/backend/handlers/institution_children_request_handler.py
+++ b/backend/handlers/institution_children_request_handler.py
@@ -2,7 +2,7 @@
 """Institution Children Request Handler."""
 
 import json
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 from . import BaseHandler
 from service_entities import enqueue_task

--- a/backend/handlers/institution_collection_handler.py
+++ b/backend/handlers/institution_collection_handler.py
@@ -5,7 +5,7 @@ import json
 from utils import Utils
 from utils import offset_pagination
 from utils import to_int
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 from custom_exceptions.queryException import QueryException
 

--- a/backend/handlers/institution_events_handler.py
+++ b/backend/handlers/institution_events_handler.py
@@ -8,7 +8,7 @@ from google.appengine.ext import ndb
 import json
 from utils import Utils
 from models import Event
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 from utils import query_paginated
 from utils import to_int

--- a/backend/handlers/institution_followers_handler.py
+++ b/backend/handlers/institution_followers_handler.py
@@ -4,7 +4,7 @@
 from google.appengine.ext import ndb
 import json
 
-from utils import login_required
+from util.login_service import login_required
 from utils import Utils
 from utils import json_response
 

--- a/backend/handlers/institution_handler.py
+++ b/backend/handlers/institution_handler.py
@@ -8,7 +8,7 @@ from google.appengine.ext import ndb
 
 from utils import Utils
 from models import Invite
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 from custom_exceptions.notAuthorizedException import NotAuthorizedException
 from custom_exceptions.entityException import EntityException

--- a/backend/handlers/institution_hierarchy_handler.py
+++ b/backend/handlers/institution_hierarchy_handler.py
@@ -4,7 +4,7 @@
 from google.appengine.ext import ndb
 
 from utils import Utils
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 from custom_exceptions.notAuthorizedException import NotAuthorizedException
 from custom_exceptions.entityException import EntityException

--- a/backend/handlers/institution_members_handler.py
+++ b/backend/handlers/institution_members_handler.py
@@ -4,7 +4,7 @@
 from google.appengine.ext import ndb
 import json
 
-from utils import login_required
+from util.login_service import login_required
 from utils import Utils
 from utils import json_response
 from util.strings_pt_br import get_subject

--- a/backend/handlers/institution_parent_request_collection_handler.py
+++ b/backend/handlers/institution_parent_request_collection_handler.py
@@ -3,7 +3,7 @@
 
 from google.appengine.ext import ndb
 import json
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 from utils import Utils
 from custom_exceptions.entityException import EntityException

--- a/backend/handlers/institution_parent_request_handler.py
+++ b/backend/handlers/institution_parent_request_handler.py
@@ -2,7 +2,7 @@
 """Institution Parent Request Handler."""
 
 import json
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 from . import BaseHandler
 from service_entities import enqueue_task

--- a/backend/handlers/institution_request_collection_handler.py
+++ b/backend/handlers/institution_request_collection_handler.py
@@ -2,7 +2,7 @@
 """Institution Collection Request Handler."""
 
 import json
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 from utils import Utils
 from custom_exceptions.entityException import EntityException

--- a/backend/handlers/institution_request_handler.py
+++ b/backend/handlers/institution_request_handler.py
@@ -4,7 +4,7 @@
 import json
 import permissions
 
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 from . import BaseHandler
 from google.appengine.ext import ndb

--- a/backend/handlers/institution_timeline_handler.py
+++ b/backend/handlers/institution_timeline_handler.py
@@ -4,7 +4,7 @@
 from google.appengine.ext import ndb
 import json
 
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 from utils import offset_pagination
 from utils import Utils

--- a/backend/handlers/invite_collection_handler.py
+++ b/backend/handlers/invite_collection_handler.py
@@ -3,7 +3,7 @@
 
 import json
 
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 from utils import Utils
 from custom_exceptions.notAuthorizedException import NotAuthorizedException

--- a/backend/handlers/invite_handler.py
+++ b/backend/handlers/invite_handler.py
@@ -12,7 +12,6 @@ from custom_exceptions.fieldException import FieldException
 from custom_exceptions.notAuthorizedException import NotAuthorizedException
 from utils import json_response
 from utils import Utils
-from utils import make_user
 from util.json_patch import JsonPatch
 
 __all__ = ['InviteHandler']
@@ -97,4 +96,4 @@ class InviteHandler(BaseHandler):
         user.put()
         invite.send_response_notification(user.current_institution, user.key, 'ACCEPT')
         
-        self.response.write(json.dumps(make_user(user, self.request)))
+        self.response.write(json.dumps(user.make(self.request)))

--- a/backend/handlers/invite_handler.py
+++ b/backend/handlers/invite_handler.py
@@ -4,7 +4,7 @@
 from google.appengine.ext import ndb
 import json
 
-from utils import login_required
+from util.login_service import login_required
 from . import BaseHandler
 from models import InstitutionProfile
 from models import Invite

--- a/backend/handlers/invite_institution_handler.py
+++ b/backend/handlers/invite_institution_handler.py
@@ -3,7 +3,7 @@
 
 import json
 
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 from utils import Utils
 from custom_exceptions.notAuthorizedException import NotAuthorizedException

--- a/backend/handlers/invite_user_adm_handler.py
+++ b/backend/handlers/invite_user_adm_handler.py
@@ -3,7 +3,7 @@
 
 import json
 from google.appengine.ext import ndb
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 from utils import Utils
 from utils import make_user

--- a/backend/handlers/invite_user_adm_handler.py
+++ b/backend/handlers/invite_user_adm_handler.py
@@ -6,7 +6,6 @@ from google.appengine.ext import ndb
 from util.login_service import login_required
 from utils import json_response
 from utils import Utils
-from utils import make_user
 from service_entities import enqueue_task
 from . import BaseHandler
 from custom_exceptions.notAuthorizedException import NotAuthorizedException
@@ -51,7 +50,7 @@ class InviteUserAdmHandler(BaseHandler):
             )
             invite.send_response_notification(current_institution=user.current_institution, action='ACCEPT')
         save_changes(user, actual_admin, invite, institution)
-        self.response.write(json.dumps(make_user(user, self.request)))
+        self.response.write(json.dumps(user.make(self.request)))
 
     @json_response
     @login_required

--- a/backend/handlers/like_handler.py
+++ b/backend/handlers/like_handler.py
@@ -3,7 +3,7 @@
 
 import json
 from google.appengine.ext import ndb
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 from . import BaseHandler
 from models.post import Like

--- a/backend/handlers/post_collection_handler.py
+++ b/backend/handlers/post_collection_handler.py
@@ -4,7 +4,7 @@
 from google.appengine.ext import ndb
 import json
 from utils import Utils
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 
 from . import BaseHandler

--- a/backend/handlers/post_comment_handler.py
+++ b/backend/handlers/post_comment_handler.py
@@ -5,7 +5,7 @@ import json
 
 from google.appengine.ext import ndb
 
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 from utils import Utils
 from service_entities import enqueue_task

--- a/backend/handlers/post_handler.py
+++ b/backend/handlers/post_handler.py
@@ -4,7 +4,7 @@ import json
 from google.appengine.ext import ndb
 
 from utils import Utils
-from utils import login_required
+from util.login_service import login_required
 from utils import NotAuthorizedException
 from utils import json_response
 from util.json_patch import JsonPatch

--- a/backend/handlers/reply_comment_handler.py
+++ b/backend/handlers/reply_comment_handler.py
@@ -5,7 +5,7 @@ import json
 
 from google.appengine.ext import ndb
 
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 from utils import Utils
 from service_messages import send_message_notification

--- a/backend/handlers/request_handler.py
+++ b/backend/handlers/request_handler.py
@@ -4,7 +4,7 @@
 import json
 from utils import Utils
 from google.appengine.ext import ndb
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 from . import BaseHandler
 from custom_exceptions.entityException import EntityException

--- a/backend/handlers/resend_invite_handler.py
+++ b/backend/handlers/resend_invite_handler.py
@@ -2,7 +2,7 @@
 """Resend Invite Handler."""
 import json
 
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 from utils import Utils
 from custom_exceptions.notAuthorizedException import NotAuthorizedException

--- a/backend/handlers/search_handler.py
+++ b/backend/handlers/search_handler.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Search Handler."""
 
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 import json
 

--- a/backend/handlers/subscribe_post_handler.py
+++ b/backend/handlers/subscribe_post_handler.py
@@ -3,7 +3,7 @@
 
 from google.appengine.ext import ndb
 from utils import Utils
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 
 from . import BaseHandler

--- a/backend/handlers/user_handler.py
+++ b/backend/handlers/user_handler.py
@@ -5,7 +5,7 @@ import json
 
 from models import Invite
 from utils import Utils
-from utils import login_required
+from util.login_service import login_required
 from utils import create_user
 from utils import json_response
 from utils import make_user

--- a/backend/handlers/user_handler.py
+++ b/backend/handlers/user_handler.py
@@ -6,7 +6,7 @@ import json
 from models import Invite
 from utils import Utils
 from util.login_service import login_required
-from utils import create_user
+from models import User
 from utils import json_response
 from utils import make_user
 from models import InstitutionProfile
@@ -55,7 +55,7 @@ class UserHandler(BaseHandler):
             Author: Ruan Eloy - 18/09/17
         """
         if not user.key:
-            user = create_user(user.name, user.email)
+            user = User.create(user.name, user.email)
 
         user_json = make_user(user, self.request)
         user_json['invites'] = get_invites(user.email)

--- a/backend/handlers/user_handler.py
+++ b/backend/handlers/user_handler.py
@@ -8,7 +8,6 @@ from utils import Utils
 from util.login_service import login_required
 from models import User
 from utils import json_response
-from utils import make_user
 from models import InstitutionProfile
 
 from util.json_patch import JsonPatch
@@ -57,7 +56,7 @@ class UserHandler(BaseHandler):
         if not user.key:
             user = User.create(user.name, user.email)
 
-        user_json = make_user(user, self.request)
+        user_json = user.make(self.request)
         user_json['invites'] = get_invites(user.email)
 
         self.response.write(json.dumps(user_json))
@@ -93,4 +92,4 @@ class UserHandler(BaseHandler):
         """Update user."""
         user.put()
 
-        self.response.write(json.dumps(make_user(user, self.request)))
+        self.response.write(json.dumps(user.make(self.request)))

--- a/backend/handlers/user_institutions_handler.py
+++ b/backend/handlers/user_institutions_handler.py
@@ -4,7 +4,7 @@
 from google.appengine.ext import ndb
 import json
 
-from utils import login_required
+from util.login_service import login_required
 from utils import Utils
 from utils import json_response
 from send_email_hierarchy.leave_institution_email_sender import LeaveInstitutionEmailSender

--- a/backend/handlers/user_profile_handler.py
+++ b/backend/handlers/user_profile_handler.py
@@ -4,7 +4,7 @@
 import json
 
 from utils import Utils
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 
 from . import BaseHandler

--- a/backend/handlers/user_request_collection_handler.py
+++ b/backend/handlers/user_request_collection_handler.py
@@ -2,7 +2,7 @@
 """User Request Collection Handler."""
 import json
 from google.appengine.ext import ndb
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 from utils import Utils
 from models import RequestUser

--- a/backend/handlers/user_timeline_handler.py
+++ b/backend/handlers/user_timeline_handler.py
@@ -3,7 +3,7 @@
 
 import json
 
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 from utils import offset_pagination
 from utils import to_int

--- a/backend/handlers/vote_handler.py
+++ b/backend/handlers/vote_handler.py
@@ -2,7 +2,7 @@
 """Vote Handler."""
 
 from google.appengine.ext import ndb
-from utils import login_required
+from util.login_service import login_required
 from utils import json_response
 from . import BaseHandler
 from custom_exceptions.notAuthorizedException import NotAuthorizedException

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,7 +1,7 @@
 """Initialize models module."""
-from .user import *
 from .address import *
 from .institution import *
+from .user import *
 from .event import *
 from .invite import *
 from .invite_institution import *

--- a/backend/models/request_institution.py
+++ b/backend/models/request_institution.py
@@ -4,7 +4,7 @@
 from . import Invite
 from . import Request
 from google.appengine.ext import ndb
-from utils import get_deciis
+from util.provider_institutions import get_deciis
 from custom_exceptions.fieldException import FieldException
 from send_email_hierarchy.accepted_institution_email_sender import AcceptedInstitutionEmailSender
 

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -3,9 +3,15 @@ from search_module.search_user import SearchUser
 from google.appengine.ext import ndb
 from custom_exceptions.fieldException import FieldException
 from custom_exceptions.notAuthorizedException import NotAuthorizedException
+from util.provider_institutions import get_deciis
+from util.provider_institutions import get_health_ministry
 import random
 
 __all__ = ['InstitutionProfile', 'User']
+
+def follow_inst(user,inst):
+    user.follow(inst.key)
+    inst.follow(user.key)
 
 def pick_color():
     colors = [
@@ -180,6 +186,27 @@ class User(ndb.Model):
         self.institution_profiles.append(user_profile)
 
         self.put()
+    
+    @staticmethod
+    def create(name, email):
+        """Create user."""
+        user = User()
+        user.email = email
+        user.name = name
+        user.photo_url = "app/images/avatar.png"
+        health_ministry = get_health_ministry()
+        deciis = get_deciis()
+        """"TODO: All users have to follow MS and DECIIS
+            Think of a better way to do it
+            @author: Mayza Nunes 24/01/2018
+        """
+        if health_ministry is not None:
+            follow_inst(user, health_ministry)
+        if deciis is not None:
+            follow_inst(user, deciis)
+        user.put()
+        
+        return user
 
     def add_post(self, post):
         user = self.key.get()

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -5,6 +5,7 @@ from custom_exceptions.fieldException import FieldException
 from custom_exceptions.notAuthorizedException import NotAuthorizedException
 from util.provider_institutions import get_deciis
 from util.provider_institutions import get_health_ministry
+from utils import Utils
 import random
 
 __all__ = ['InstitutionProfile', 'User']
@@ -366,3 +367,20 @@ class User(ndb.Model):
 
     def is_admin(self, institution_key):
         return institution_key in self.institutions_admin
+
+    def make(self, request):
+        user_json = Utils.toJson(self, host=request.host)
+        user_json['logout'] = 'http://%s/logout?redirect=%s' %\
+            (request.host, request.path)
+        user_json['institutions'] = []
+        for institution in self.institutions:
+            user_json['institutions'].append(
+                Utils.toJson(institution.get())
+            )
+        user_json['follows'] = [institution_key.get().make(
+            ['name','acronym', 'photo_url', 'key', 'parent_institution'])
+            for institution_key in self.follows
+            if institution_key.get().state != 'inactive']
+        user_json['institution_profiles'] = [profile.make()
+            for profile in self.institution_profiles]
+        return user_json

--- a/backend/test/event_collection_handler_test.py
+++ b/backend/test/event_collection_handler_test.py
@@ -26,7 +26,7 @@ class EventCollectionHandlerTest(TestBaseHandler):
         cls.testapp = cls.webtest.TestApp(app)
         initModels(cls)
 
-    @patch('utils.verify_token', return_value={'email': 'user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@gmail.com'})
     def test_post(self, verify_token):
         """Test the calendar_handler's post event method."""
 
@@ -99,7 +99,7 @@ class EventCollectionHandlerTest(TestBaseHandler):
             "Excpected exception message must be equal to " +
             "Error! The end time must be after the current time")
 
-    @patch('utils.verify_token', return_value={'email': 'user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@gmail.com'})
     def test_get(self, verify_token):
         """Test the calendar_handler's post event method."""
 

--- a/backend/test/event_handler_test.py
+++ b/backend/test/event_handler_test.py
@@ -48,7 +48,7 @@ class EventHandlerTest(TestBaseHandler):
         # Events
         cls.event = mocks.create_event(cls.user, cls.institution)
 
-    @patch('utils.verify_token', return_value={'email': 'user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@gmail.com'})
     def test_delete_by_author(self, verify_token):
         """Test the event_handler's delete method when user is author."""
         self.user.add_permissions(
@@ -73,7 +73,7 @@ class EventHandlerTest(TestBaseHandler):
             self.testapp.delete("/api/events/%s" %
                                 self.event.key.urlsafe())
 
-    @patch('utils.verify_token', return_value={'email': 'usersd@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'usersd@gmail.com'})
     def test_delete_by_admin(self, verify_token):
         """Test the event_handler's delete method when user is admin."""
         # Call the delete method and assert that it raises an exception,
@@ -99,7 +99,7 @@ class EventHandlerTest(TestBaseHandler):
         self.assertEqual(self.event.last_modified_by, self.second_user.key,
                          "The last_modified_by expected was user.")
 
-    @patch('utils.verify_token', return_value={'email': 'user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@gmail.com'})
     def test_patch(self, verify_token):
         """Test the post_handler's patch method."""
         # Call the patch method and assert that it works
@@ -157,7 +157,7 @@ class EventHandlerTest(TestBaseHandler):
                                       "value": "New Local"}]
                                     )
 
-    @patch('utils.verify_token', return_value={'email': 'user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@gmail.com'})
     def test_pacth_datetime(self, verify_token):
         """Test pacth datetimes in event handler."""
         json_edit = json.dumps([
@@ -181,7 +181,7 @@ class EventHandlerTest(TestBaseHandler):
         self.assertEqual(self.event.end_time.isoformat(),
                          '2018-07-25T12:30:15')
 
-    @patch('utils.verify_token', return_value={'email': 'user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@gmail.com'})
     def test_patch_on_event_outdated(self, verify_token):
         """Test change the event basic data when it is outdated."""
         self.event.start_time = '2000-07-14T12:30:15'
@@ -216,7 +216,7 @@ class EventHandlerTest(TestBaseHandler):
                 getattr(self.event, prop), value,
                 "The event "+ prop + " should be 'other_value'")
     
-    @patch('utils.verify_token', return_value={'email': 'user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@gmail.com'})
     def test_get_a_deleted_event(self, verify_token):
         self.event.state = 'deleted'
         self.event.put()
@@ -227,7 +227,7 @@ class EventHandlerTest(TestBaseHandler):
         exception_message = self.get_message_exception(ex.exception.message)
         self.assertTrue(exception_message == 'Error! The event has been deleted.')
     
-    @patch('utils.verify_token', return_value={'email': 'user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@gmail.com'})
     def test_patch_a_deleted_event(self, verify_token):
         self.event.state = 'deleted'
         self.event.put()
@@ -241,7 +241,7 @@ class EventHandlerTest(TestBaseHandler):
         self.assertTrue(exception_message ==
                         'Error! The event has been deleted.')
     
-    @patch('utils.verify_token', return_value={'email': 'user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@gmail.com'})
     def test_permissions_in_delete(self, verify_token):
         """Test the permissions in delete."""
         with self.assertRaises(Exception) as ex:
@@ -261,7 +261,7 @@ class EventHandlerTest(TestBaseHandler):
         self.event = self.event.key.get()
         self.assertTrue(self.event.state == 'deleted')
 
-    @patch('utils.verify_token', return_value={'email': 'user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@gmail.com'})
     def test_patch_without_permission(self, verify_token):
         with self.assertRaises(Exception) as ex:
             patch = [{"op": "replace", "path": "/title", "value": 'other_value'}]

--- a/backend/test/followers_institution_handler_test.py
+++ b/backend/test/followers_institution_handler_test.py
@@ -21,7 +21,7 @@ class InstitutionFollowersHandlerTest(TestBaseHandler):
              ], debug=True)
         cls.testapp = cls.webtest.TestApp(app)
 
-    @patch('utils.verify_token', return_value=USER)
+    @patch('util.login_service.verify_token', return_value=USER)
     def teste_delete_usermember(self, verify_token):
         """Test that user member try unfollow the institution."""
         user = mocks.create_user(USER['email'])
@@ -50,7 +50,7 @@ class InstitutionFollowersHandlerTest(TestBaseHandler):
         self.assertEquals(len(institution.followers), 1,
                           "The institution should have a follower")
     
-    @patch('utils.verify_token', return_value=USER)
+    @patch('util.login_service.verify_token', return_value=USER)
     def teste_delete_usermember_health_ministry(self, verify_token):
         """Test that user member try unfollow the health ministry institution."""
         user = mocks.create_user(USER['email'])
@@ -78,7 +78,7 @@ class InstitutionFollowersHandlerTest(TestBaseHandler):
             "Expected exception message must be equal to Error! The institution can not be unfollowed")
 
         
-    @patch('utils.verify_token', return_value=USER)
+    @patch('util.login_service.verify_token', return_value=USER)
     def test_delete(self, verify_token):
         """Test the institution_follower_handler delete method."""
         user = mocks.create_user(USER['email'])
@@ -104,7 +104,7 @@ class InstitutionFollowersHandlerTest(TestBaseHandler):
         self.assertEquals(len(institution.followers), 0,
                           "The institution shouldn't have any follower")
 
-    @patch('utils.verify_token', return_value=USER)
+    @patch('util.login_service.verify_token', return_value=USER)
     def test_post(self, verify_token):
         """Test the institution_follower_handler post method."""
         user = mocks.create_user(USER['email'])

--- a/backend/test/institution_children_request_collection_handler_test.py
+++ b/backend/test/institution_children_request_collection_handler_test.py
@@ -29,7 +29,7 @@ class InstitutionChildrenRequestCollectionHandlerTest(TestBaseHandler):
              ], debug=True)
         cls.testapp = cls.webtest.TestApp(app)
 
-    @patch('utils.verify_token', return_value=ADMIN)
+    @patch('util.login_service.verify_token', return_value=ADMIN)
     def test_post(self, verify_token):
         """Test method post of InstitutionParentRequestCollectionHandler."""
         admin = mocks.create_user(ADMIN['email'])
@@ -79,7 +79,7 @@ class InstitutionChildrenRequestCollectionHandlerTest(TestBaseHandler):
             'REQUEST_INSTITUTION_CHILDREN',
             'Expected sender type_of_invite is REQUEST_INSTITUTION_CHILDREN')
     
-    @patch('utils.verify_token', return_value=ADMIN)
+    @patch('util.login_service.verify_token', return_value=ADMIN)
     def test_post_with_wrong_institution(self, verify_token):
         """Test post with wrong institution."""
         admin = mocks.create_user(ADMIN['email'])
@@ -122,7 +122,7 @@ class InstitutionChildrenRequestCollectionHandlerTest(TestBaseHandler):
             exception_message,
             "Expected error message is Error! User is not allowed to send request")
 
-    @patch('utils.verify_token', return_value=USER)
+    @patch('util.login_service.verify_token', return_value=USER)
     def test_post_user_not_admin(self, verify_token):
         # Test post request with user is not admin.
         admin = mocks.create_user(ADMIN['email'])
@@ -161,7 +161,7 @@ class InstitutionChildrenRequestCollectionHandlerTest(TestBaseHandler):
             "Expected error message is Error! User is not allowed to send request")
 
     
-    @patch('utils.verify_token', return_value=USER)
+    @patch('util.login_service.verify_token', return_value=USER)
     def test_post_circular_hierarchy(self, verify_token):
         """
         Test post request when the user tries to create

--- a/backend/test/institution_children_request_handler_test.py
+++ b/backend/test/institution_children_request_handler_test.py
@@ -69,7 +69,7 @@ class InstitutionChildrenRequestHandlerTest(TestBaseHandler):
 
 
     @patch('service_messages.send_message_notification')
-    @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'otheruser@test.com'})
     def test_put(self, verify_token, mock_method):
         """Test method post of InstitutionChildrenRequestHandler."""
         request = self.testapp.put_json(
@@ -100,7 +100,7 @@ class InstitutionChildrenRequestHandlerTest(TestBaseHandler):
             "Should call the send_message_notification"
         )
 
-    @patch('utils.verify_token', return_value={'email': 'useradmin@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'useradmin@test.com'})
     def test_put_user_not_admin(self, verify_token):
         """Test put request with user is not admin."""
         with self.assertRaises(Exception) as ex:
@@ -116,7 +116,7 @@ class InstitutionChildrenRequestHandlerTest(TestBaseHandler):
             "Expected error message is Error! User is not allowed to accept link between institutions")
 
     @patch('service_messages.send_message_notification')
-    @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'otheruser@test.com'})
     def test_delete(self, verify_token, mock_method):
         """Test method post of InstitutionChildrenRequestHandler."""
         self.testapp.delete(
@@ -140,7 +140,7 @@ class InstitutionChildrenRequestHandlerTest(TestBaseHandler):
                         "Should call the send_message_notification")
 
     @patch('handlers.institution_children_request_handler.enqueue_task')
-    @patch('utils.verify_token', return_value={'email': 'user@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@example.com'})
     def test_add_admin_permission_in_institution_hierarchy(self, verify_token, enqueue_task):
         """Test add admin permissions in institution hierarchy."""
         first_user = mocks.create_user()

--- a/backend/test/institution_collection_handler_test.py
+++ b/backend/test/institution_collection_handler_test.py
@@ -23,7 +23,7 @@ class InstitutionCollectionHandlerTest(TestBaseHandler):
         cls.testapp = cls.webtest.TestApp(app)
 
 
-    @patch('utils.verify_token', return_value={'email': 'user@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@example.com'})
     def test_get(self, verify_token):
         """Test the get method."""
         # create models

--- a/backend/test/institution_events_handler_test.py
+++ b/backend/test/institution_events_handler_test.py
@@ -26,7 +26,7 @@ class InstitutionEventsHandlerTest(TestBaseHandler):
              ], debug=True)
         cls.testapp = cls.webtest.TestApp(app)
 
-    @patch('utils.verify_token', return_value={'email': 'user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@gmail.com'})
     def test_get_one_event(self, verify_token):
         """Test the institution_events_handler's get method."""
 
@@ -54,7 +54,7 @@ class InstitutionEventsHandlerTest(TestBaseHandler):
         self.assertEqual(event_obj.institution_key, institution.key,
                          "The institutions must be the same")
 
-    @patch('utils.verify_token', return_value={'email': 'user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@gmail.com'})
     def test_get_events_from_a_passed_begin(self, verify_token):
         """Test the institution_events_handler's get method."""
 
@@ -78,7 +78,7 @@ class InstitutionEventsHandlerTest(TestBaseHandler):
         self.assertTrue(third_event.key.urlsafe() in keys)
         self.assertTrue(len(keys) == 1)
 
-    @patch('utils.verify_token', return_value={'email': 'user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@gmail.com'})
     def test_get_many_events(self, verify_token):
         """Test the institution_events_handler's get method."""
 

--- a/backend/test/institution_followers_handler_test.py
+++ b/backend/test/institution_followers_handler_test.py
@@ -22,7 +22,7 @@ class InstitutionFollowersHandlerTest(TestBaseHandler):
         cls.testapp = cls.webtest.TestApp(app)
         initModels(cls)
 
-    @patch('utils.verify_token', return_value={'email': 'user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@gmail.com'})
     def test_get(self, verify_token):
         """Test http get method."""
         result = self.testapp.get("/api/institutions/%s/followers"
@@ -31,7 +31,7 @@ class InstitutionFollowersHandlerTest(TestBaseHandler):
         self.assertTrue(Utils.toJson(self.user) in result.json)
         self.assertTrue(Utils.toJson(self.second_user) in result.json)
 
-    @patch('utils.verify_token', return_value={'email': 'second_user@ccc.ufcg.edu.br'})
+    @patch('util.login_service.verify_token', return_value={'email': 'second_user@ccc.ufcg.edu.br'})
     def test_post(self, verify_token):
         """Test post method."""
         """Assert the initials conditions"""
@@ -50,7 +50,7 @@ class InstitutionFollowersHandlerTest(TestBaseHandler):
             self.second_user.key in self.other_institution.followers)
         self.assertTrue(self.other_institution.key in self.second_user.follows)
 
-    @patch('utils.verify_token', return_value={'email': 'second_user@ccc.ufcg.edu.br'})
+    @patch('util.login_service.verify_token', return_value={'email': 'second_user@ccc.ufcg.edu.br'})
     def test_post_with_inactive_institution(self, verify_token):
         """Test post method with an inactive institution."""
         # Set up the test
@@ -64,7 +64,7 @@ class InstitutionFollowersHandlerTest(TestBaseHandler):
         self.assertTrue(exception_message ==
                         "Error! The institution has been deleted")
 
-    @patch('utils.verify_token', return_value={'email': 'second_user@ccc.ufcg.edu.br'})
+    @patch('util.login_service.verify_token', return_value={'email': 'second_user@ccc.ufcg.edu.br'})
     def test_delete(self, verify_token):
         """Test delete method."""
         # Assert initials conditions
@@ -80,7 +80,7 @@ class InstitutionFollowersHandlerTest(TestBaseHandler):
         self.assertTrue(self.second_user.key not in self.institution.followers)
         self.assertTrue(self.institution.key not in self.second_user.follows)
 
-    @patch('utils.verify_token', return_value={'email': 'user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@gmail.com'})
     def test_delete_with_a_member(self, verify_token):
         """Test delete when the user is a member
 

--- a/backend/test/institution_handler_test.py
+++ b/backend/test/institution_handler_test.py
@@ -110,7 +110,7 @@ class InstitutionHandlerTest(TestBaseHandler):
         if handler_selector == 'add-admin-permissions' or handler_selector == 'remove-admin-permissions' or handler_selector == 'remove-inst':
             self.testapp.post('/api/queue/' + handler_selector, params=params)
 
-    @patch('utils.verify_token', return_value={'email': 'user@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@example.com'})
     def test_patch(self, verify_token):
         """Test the post_handler's patch method."""
         # Call the patch method and assert that  it raises an exception
@@ -143,7 +143,7 @@ class InstitutionHandlerTest(TestBaseHandler):
             "Expected exception message must be equal to " +
             "Error! User is not allowed to edit institution")
 
-    @patch('utils.verify_token', return_value={'email': 'other_user@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'other_user@example.com'})
     def test_post(self, verify_token):
         """Test the post_handler's post method."""
         # Call the patch method and assert that  it raises an exception
@@ -198,7 +198,7 @@ class InstitutionHandlerTest(TestBaseHandler):
             "Error! User is not invitee to create this Institution")
     
     @patch('handlers.institution_handler.enqueue_task')
-    @patch('utils.verify_token', return_value={'email': 'user@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@example.com'})
     def test_add_admin_permission_in_institution_hierarchy(self, verify_token, enqueue_task):
         """Test add admin permissions in institution hierarchy."""
         first_user = mocks.create_user()
@@ -259,7 +259,7 @@ class InstitutionHandlerTest(TestBaseHandler):
         
 
     @patch('handlers.institution_handler.enqueue_task')
-    @patch('utils.verify_token', return_value={'email': 'user@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@example.com'})
     def test_remove_admin_permission_in_institution_hierarchy(self, verify_token, enqueue_task):
         """Test remove admin permissions in institution hierarchy."""
         first_user = mocks.create_user()
@@ -332,7 +332,7 @@ class InstitutionHandlerTest(TestBaseHandler):
         self.assertFalse(has_permissions(
             third_user, third_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
 
-    @patch('utils.verify_token', return_value={'email': 'user@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@example.com'})
     def test_get(self, verify_token):
         """Test the get method."""
         # Call the get method
@@ -360,7 +360,7 @@ class InstitutionHandlerTest(TestBaseHandler):
         self.assertEqual(admin_first_inst["key"], self.user.key.urlsafe(),
                          "The key of admin should be equal to key of obj user")
 
-    @patch('utils.verify_token', return_value={'email': 'user@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@example.com'})
     def test_get_without_admin(self, verify_token):
         """Test the get method."""
         # Call the get method
@@ -382,7 +382,7 @@ class InstitutionHandlerTest(TestBaseHandler):
         self.assertEqual(admin_second_inst, None,
                          "The admin should be None")
 
-    @patch('utils.verify_token', return_value={'email': 'user@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@example.com'})
     def test_delete_without_remove_hierarchy(self, verify_token):
         """Test delete method."""
         # Set the cerbio's state to active
@@ -413,7 +413,7 @@ class InstitutionHandlerTest(TestBaseHandler):
         self.assertTrue(self.first_inst.key not in self.user.institutions)
 
     @patch('handlers.institution_handler.enqueue_task')
-    @patch('utils.verify_token', return_value={'email': 'user@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@example.com'})
     def test_delete_with_remove_hierarchy(self, verify_token, mock_method):
         """Test delete removing hierarchy."""
         # Setting up the remove hierarchy test
@@ -462,7 +462,7 @@ class InstitutionHandlerTest(TestBaseHandler):
         self.assertTrue(self.second_inst.key not in self.user.institutions)
         self.assertTrue(self.third_inst.key not in self.user.institutions)
 
-    @patch('utils.verify_token', return_value={'email': 'user@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@example.com'})
     def test_delete_child_institution(self, verify_token):
         """Test delete child institution."""
         self.user.institutions_admin.append(self.second_inst.key)
@@ -481,7 +481,7 @@ class InstitutionHandlerTest(TestBaseHandler):
         self.third_inst = self.third_inst.key.get()
         self.assertTrue(self.third_inst.state == "inactive")
 
-    @patch('utils.verify_token', return_value={'email': 'other_user@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'other_user@example.com'})
     def test_delete_child_institution_without_admin(self, verify_token):
         """Test delete child institution."""
         self.other_user.institutions.append(self.third_inst.key)
@@ -498,7 +498,7 @@ class InstitutionHandlerTest(TestBaseHandler):
         self.assertTrue(self.first_inst.state == "active")
     
     @patch('handlers.institution_handler.enqueue_task')
-    @patch('utils.verify_token', return_value={'email': 'user@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@example.com'})
     def test_remove_admin_permission(self, verify_token, enqueue_task):
         """Test remove admin permissions in institution hierarchy."""
         first_user = mocks.create_user()
@@ -583,7 +583,7 @@ class InstitutionHandlerTest(TestBaseHandler):
             first_user, fourth_inst.key.urlsafe(), permissions.DEFAULT_ADMIN_PERMISSIONS))
     
     @patch('handlers.institution_handler.enqueue_task')
-    @patch('utils.verify_token', return_value={'email': 'user@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@example.com'})
     def test_delete_hierarchy_with_a_one_direction_link(self, verify_token, enqueue_task):
         """Test remove admin permissions in institution hierarchy."""
         first_user = mocks.create_user()
@@ -674,7 +674,7 @@ class InstitutionHandlerTest(TestBaseHandler):
             permissions.DEFAULT_ADMIN_PERMISSIONS))
     
     @patch('handlers.institution_handler.enqueue_task')
-    @patch('utils.verify_token', return_value={'email': 'user@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@example.com'})
     def test_remove_admin_permission_in_a_middle_institution(self, verify_token, enqueue_task):
         """Test remove admin permissions in institution hierarchy."""
         first_user = mocks.create_user()
@@ -744,7 +744,7 @@ class InstitutionHandlerTest(TestBaseHandler):
         self.assertFalse(third_inst.state == 'inactive')
     
     @patch('handlers.institution_handler.enqueue_task')
-    @patch('utils.verify_token', return_value={'email': 'user@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@example.com'})
     def test_remove_admin_permission_in_a_middle_institution_with_two_administered_institutions(self, verify_token, enqueue_task):
         """Test remove admin permissions in institution hierarchy."""
         first_user = mocks.create_user()

--- a/backend/test/institution_hierarchy_handler_test.py
+++ b/backend/test/institution_hierarchy_handler_test.py
@@ -37,7 +37,7 @@ class InstitutionHierarchyHandlerTest(TestBaseHandler):
             self.testapp.post('/api/queue/' + handler_selector, params=params)
 
     @patch('handlers.institution_hierarchy_handler.send_message_notification')
-    @patch('utils.verify_token', return_value=ADMIN)
+    @patch('util.login_service.verify_token', return_value=ADMIN)
     def test_delete_child_connection(self, verify_token, send_message_notification):
         """Test delete method with isParent=false."""
         # Assert the initial conditions
@@ -93,7 +93,7 @@ class InstitutionHierarchyHandlerTest(TestBaseHandler):
         )
 
     @patch('handlers.institution_hierarchy_handler.send_message_notification')
-    @patch('utils.verify_token', return_value=USER)
+    @patch('util.login_service.verify_token', return_value=USER)
     def test_delete_parent_connection(self, verify_token, send_message_notification):
         """Test delete method with isParent=true."""
         # Assert the initial conditions
@@ -148,7 +148,7 @@ class InstitutionHierarchyHandlerTest(TestBaseHandler):
         )
 
     @patch('handlers.institution_hierarchy_handler.enqueue_task')
-    @patch('utils.verify_token', return_value={'email': 'user@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@example.com'})
     def test_remove_admin_permission_in_institution_hierarchy(self, verify_token, enqueue_task):
         """Test remove admin permissions in institution hierarchy."""
         second_user = mocks.create_user()

--- a/backend/test/institution_member_handler_test.py
+++ b/backend/test/institution_member_handler_test.py
@@ -58,7 +58,7 @@ class InstitutionMemberHandlerTest(TestBaseHandler):
 
     @patch('handlers.institution_members_handler.send_message_notification')
     @patch('handlers.institution_members_handler.RemoveMemberEmailSender.send_email')
-    @patch('utils.verify_token', return_value={'email': 'user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@gmail.com'})
     def test_delete_with_notification(self, verify_token, send_email, send_message_notification):
         """Test if a notification is sent when the member is deleted."""
         # Set up the second_user
@@ -101,7 +101,7 @@ class InstitutionMemberHandlerTest(TestBaseHandler):
 
     @patch('handlers.institution_members_handler.send_message_notification')
     @patch('handlers.institution_members_handler.RemoveMemberEmailSender.send_email')
-    @patch('utils.verify_token', return_value={'email': 'user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@gmail.com'})
     def test_delete_with_email(self, verify_token, send_email, send_message_notification):
         """Test delete a member that belongs to only one institution."""
         # new user
@@ -125,7 +125,7 @@ class InstitutionMemberHandlerTest(TestBaseHandler):
         # Assert that send_email has been called
         send_email.assert_called()
 
-    @patch('utils.verify_token', return_value={'email': 'user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@gmail.com'})
     def test_delete(self, verify_token):
         """Test delete method with an user that is not admin"""
         # Assert the initial conditions
@@ -180,7 +180,7 @@ class InstitutionMemberHandlerTest(TestBaseHandler):
         self.assertTrue(self.institution.key in self.user.institutions,
                         "Institution shouldn't be in institutions of second_user")
 
-    @patch('utils.verify_token', return_value={'email': 'second_user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'second_user@gmail.com'})
     def test_delete_not_admin(self, verify_token):
         """Test delete method with user not admin"""
         # Assert the initial conditions

--- a/backend/test/institution_parent_request_collection_handler_test.py
+++ b/backend/test/institution_parent_request_collection_handler_test.py
@@ -28,7 +28,7 @@ class InstitutionParentRequestCollectionHandlerTest(TestBaseHandler):
              ], debug=True)
         cls.testapp = cls.webtest.TestApp(app)
 
-    @patch('utils.verify_token', return_value=ADMIN)
+    @patch('util.login_service.verify_token', return_value=ADMIN)
     def test_post(self, verify_token):
         """Test method post of InstitutionParentRequestCollectionHandler."""
         admin = mocks.create_user(ADMIN['email'])
@@ -82,7 +82,7 @@ class InstitutionParentRequestCollectionHandlerTest(TestBaseHandler):
             institution.parent_institution, inst_requested.key,
             "The parent institution of inst test must be update to inst_requested")
     
-    @patch('utils.verify_token', return_value=ADMIN)
+    @patch('util.login_service.verify_token', return_value=ADMIN)
     def test_post_with_wrong_institution(self, verify_token):
         """Test post with wrong institution."""
         admin = mocks.create_user(ADMIN['email'])
@@ -122,7 +122,7 @@ class InstitutionParentRequestCollectionHandlerTest(TestBaseHandler):
             exception_message,
             "Expected error message is Error! User is not allowed to send request")
 
-    @patch('utils.verify_token', return_value=USER)
+    @patch('util.login_service.verify_token', return_value=USER)
     def test_post_user_not_admin(self, verify_token):
         #Test post request with user is not admin.
         admin = mocks.create_user(ADMIN['email'])
@@ -160,7 +160,7 @@ class InstitutionParentRequestCollectionHandlerTest(TestBaseHandler):
             "Expected error message is Error! User is not allowed to send request")
 
 
-    @patch('utils.verify_token', return_value=USER)
+    @patch('util.login_service.verify_token', return_value=USER)
     def test_post_circular_hierarchy(self, verify_token):
         """
         Test post request when the user tries to create

--- a/backend/test/institution_parent_request_handler_test.py
+++ b/backend/test/institution_parent_request_handler_test.py
@@ -68,7 +68,7 @@ class InstitutionParentRequestHandlerTest(TestBaseHandler):
             self.testapp.post('/api/queue/' + handler_selector, params=params)
 
     @patch.object(Invite, 'send_notification')
-    @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'otheruser@test.com'})
     def test_put(self, verify_token, send_notification):
         """Test method put of InstitutionParentRequestHandler."""
         request = self.testapp.put_json(
@@ -110,7 +110,7 @@ class InstitutionParentRequestHandlerTest(TestBaseHandler):
             message=json.dumps(message)
         )
 
-    @patch('utils.verify_token', return_value={'email': 'useradmin@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'useradmin@test.com'})
     def test_put_user_not_admin(self, verify_token):
         """Test put request with user is not admin."""
         with self.assertRaises(Exception) as ex:
@@ -126,7 +126,7 @@ class InstitutionParentRequestHandlerTest(TestBaseHandler):
             "Expected error message is %s but was %s" % (expected_message, exception_message))
 
     @patch.object(Invite, 'send_notification')
-    @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'otheruser@test.com'})
     def test_delete(self, verify_token, send_notification):
         """Test method delete of InstitutionParentRequestHandler."""
         self.testapp.delete(
@@ -169,7 +169,7 @@ class InstitutionParentRequestHandlerTest(TestBaseHandler):
         )
 
     @patch('handlers.institution_parent_request_handler.enqueue_task')
-    @patch('utils.verify_token', return_value={'email': 'user@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@example.com'})
     def test_add_admin_permission_in_institution_hierarchy(self, verify_token, enqueue_task):
         """Test add admin permissions in institution hierarchy."""
         first_user = mocks.create_user()

--- a/backend/test/institution_request_collection_handler_test.py
+++ b/backend/test/institution_request_collection_handler_test.py
@@ -25,7 +25,7 @@ class InstitutionRequestCollectionHandlerTest(TestBaseHandler):
         cls.testapp = cls.webtest.TestApp(app)
 
     @patch.object(Invite, 'send_invite')
-    @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'otheruser@test.com'})
     def test_post(self, verify_token, send_invite):
         """Test handler post."""
         # Initialize objects

--- a/backend/test/institution_request_handler_test.py
+++ b/backend/test/institution_request_handler_test.py
@@ -28,7 +28,7 @@ class InstitutionRequestHandlerTest(TestBaseHandler):
         cls.testapp = cls.webtest.TestApp(app)
         initModels(cls)
 
-    @patch('utils.verify_token', return_value={'email': 'useradmin@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'useradmin@test.com'})
     def test_get(self, verify_token):
         """Test handler get."""
         response = self.testapp.get('/api/requests/' + self.request.key.urlsafe() + '/institution')
@@ -39,7 +39,7 @@ class InstitutionRequestHandlerTest(TestBaseHandler):
             self.request.make(),
             "Expected make must be equal to make of request")
 
-    @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'otheruser@test.com'})
     def test_get_fail(self, verify_token):
         """Test fail get."""
         with self.assertRaises(Exception) as ex:
@@ -51,7 +51,7 @@ class InstitutionRequestHandlerTest(TestBaseHandler):
             'Error! User is not allowed to get requests',
             "Expected message must be equal to Error! User is not allowed to get requests")
 
-    @patch('utils.verify_token', return_value={'email': 'useradmin@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'useradmin@test.com'})
     def test_put(self, verify_token):
         """Test handler put."""
         self.testapp.put('/api/requests/' + self.request.key.urlsafe() + '/institution')
@@ -96,7 +96,7 @@ class InstitutionRequestHandlerTest(TestBaseHandler):
         for permission in permissions.DEFAULT_ADMIN_PERMISSIONS:
             self.assertTrue(permission in user.permissions)
 
-    @patch('utils.verify_token', return_value={'email': 'useradmin@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'useradmin@test.com'})
     def teste_delete(self, verify_token):
         """Test handler delete."""
         self.testapp.delete('/api/requests/' + self.request.key.urlsafe() + '/institution')
@@ -107,7 +107,7 @@ class InstitutionRequestHandlerTest(TestBaseHandler):
             'inactive',
             "Expected state must be equal to inactive")
     
-    @patch('utils.verify_token', return_value={'email': 'useradmin@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'useradmin@test.com'})
     def test_delete_with_an_accepted_request(self, verify_token):
         """Test delete with an accepted request."""
         self.request.status = "accepted"
@@ -130,7 +130,7 @@ class InstitutionRequestHandlerTest(TestBaseHandler):
             "Expected exception message must be equal to %s" % expected_message
         )
     
-    @patch('utils.verify_token', return_value={'email': 'useradmin@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'useradmin@test.com'})
     def test_delete_with_a_rejected_request(self, verify_token):
         """Test delete with a rejected request."""
         self.request.status = "rejected"
@@ -153,7 +153,7 @@ class InstitutionRequestHandlerTest(TestBaseHandler):
             "Expected exception message must be equal to %s" % expected_message
         )
 
-    @patch('utils.verify_token', return_value={'email': 'useradmin@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'useradmin@test.com'})
     def test_put_with_a_rejected_request(self, verify_token):
         """Test delete with a rejected request."""
         self.request.status = "rejected"
@@ -180,7 +180,7 @@ class InstitutionRequestHandlerTest(TestBaseHandler):
         for permission in permissions.DEFAULT_ADMIN_PERMISSIONS:
             self.assertTrue(permission not in user.permissions)
     
-    @patch('utils.verify_token', return_value={'email': 'useradmin@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'useradmin@test.com'})
     def test_put_with_an_accepted_request(self, verify_token):
         """Test delete with an accepted request."""
         self.request.status = "accepted"

--- a/backend/test/institution_timeline_handler_test.py
+++ b/backend/test/institution_timeline_handler_test.py
@@ -25,7 +25,7 @@ class InstitutionTimelineHandlerTest(TestBaseHandler):
              ], debug=True)
         cls.testapp = cls.webtest.TestApp(app)
 
-    @patch('utils.verify_token')
+    @patch('util.login_service.verify_token')
     def test_get(self, verify_token):
         """Test the institution_timeline_handler get method."""
         user = mocks.create_user()
@@ -87,7 +87,7 @@ class InstitutionTimelineHandlerTest(TestBaseHandler):
             "The maked post should be equal to the expected one"
         )
 
-    @patch('utils.verify_token')
+    @patch('util.login_service.verify_token')
     def test_get_with_deleted_post(self, verify_token):
         """Test the institution_timeline_handler get method with deleted post."""
         user = mocks.create_user()

--- a/backend/test/invite_collection_handler_test.py
+++ b/backend/test/invite_collection_handler_test.py
@@ -55,7 +55,7 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         cls.otherinst.add_member(cls.otheruser)
 
 
-    @patch('utils.verify_token', return_value=ADMIN)
+    @patch('util.login_service.verify_token', return_value=ADMIN)
     def test_post_invite_institution(self, verify_token):
 
         invite = self.testapp.post_json("/api/invites", {'data': {
@@ -82,7 +82,7 @@ class InviteCollectionHandlerTest(TestBaseHandler):
                           invite expected was New Institution")
 
     
-    @patch('utils.verify_token', return_value=ADMIN)
+    @patch('util.login_service.verify_token', return_value=ADMIN)
     def test_post_invite_institution_without_suggestion_name(self, verify_token):
         # Check if raise exception when the invite is for
         # institution and not specify the suggestion institution name.
@@ -101,7 +101,7 @@ class InviteCollectionHandlerTest(TestBaseHandler):
             "Expected exception message must be equal to " +
             "Error! The invite for institution have to specify the suggestion institution name")
 
-    @patch('utils.verify_token', return_value=ADMIN)
+    @patch('util.login_service.verify_token', return_value=ADMIN)
     def test_post_invite_institution_parent(self, verify_token):
         #Test the invite_collection_handler's post method in case to parent institution.
 
@@ -151,7 +151,7 @@ class InviteCollectionHandlerTest(TestBaseHandler):
 
    
     @patch('handlers.invite_collection_handler.enqueue_task')
-    @patch('utils.verify_token', return_value=ADMIN)
+    @patch('util.login_service.verify_token', return_value=ADMIN)
     def test_post_invite_user(self, verify_token, enqueue_task):
 
         body = create_body(['ana@gmail.com'], self.admin, self.institution)
@@ -171,7 +171,7 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         self.assertTrue(invite['key'])
 
     @patch('handlers.invite_collection_handler.enqueue_task')
-    @patch('utils.verify_token', return_value=ADMIN)
+    @patch('util.login_service.verify_token', return_value=ADMIN)
     def test_post_invite_user_member_of_other_institution(self, verify_token, enqueue_task):
 
         body = create_body([USER['email']], self.admin, self.institution)
@@ -190,7 +190,7 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         enqueue_task.assert_called()
 
     @patch.object(Invite, 'send_invite')
-    @patch('utils.verify_token', return_value=USER)
+    @patch('util.login_service.verify_token', return_value=USER)
     def test_post_invite_without_admin(self, verify_token, send_invite):
         """ Check if raise exception when the admin_key is not admistrator."""
         body = create_body(['ana@gmail.com'], self.admin, self.institution)
@@ -208,7 +208,7 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         send_invite.assert_not_called()
     
     @patch('handlers.invite_collection_handler.enqueue_task')
-    @patch('utils.verify_token', return_value=ADMIN)
+    @patch('util.login_service.verify_token', return_value=ADMIN)
     def test_post_many_invites_at_once(self, verify_token, enqueue_task):
 
         body = create_body(

--- a/backend/test/invite_handler_test.py
+++ b/backend/test/invite_handler_test.py
@@ -55,7 +55,7 @@ class InviteHandlerTest(TestBaseHandler):
         cls.invite.put()
 
 
-    @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'otheruser@test.com'})
     def test_get(self, verify_token):
         """Test method get of InviteHandler."""
         response = self.testapp.get('/api/invites/' +
@@ -68,7 +68,7 @@ class InviteHandlerTest(TestBaseHandler):
             "Expected invite should be equal to make")
 
     @patch.object(Invite, 'send_notification')
-    @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'otheruser@test.com'})
     def test_delete(self, verify_token, send_notification):
         """Test method delete of InviteHandler."""
         # create innvite institution
@@ -145,7 +145,7 @@ class InviteHandlerTest(TestBaseHandler):
         )
 
     @patch.object(Invite, 'send_notification')
-    @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'otheruser@test.com'})
     def test_patch(self, verify_token, send_notification):
         """Test method patch of InviteHandler."""
         profile = '{"email": "otheruser@test.com", "office": "Developer", "institution_key": "%s"}' % self.inst_test.key.urlsafe()
@@ -202,7 +202,7 @@ class InviteHandlerTest(TestBaseHandler):
         )
 
     @patch.object(Invite, 'send_notification')
-    @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'otheruser@test.com'})
     def test_patch_fail(self, verify_token, send_notification):
         """Test patch fail in InviteHandler because the profile has not office."""
         profile = '{"email": "otheruser@test.com"}'
@@ -224,7 +224,7 @@ class InviteHandlerTest(TestBaseHandler):
         # assert the notification was not sent
         send_notification.assert_not_called()
     
-    @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'otheruser@test.com'})
     def test_patch_with_inst_inactive(self, verify_token):
         """Test a patch invite_user when the user is already a member."""
         self.inst_test.state = "inactive"
@@ -247,7 +247,7 @@ class InviteHandlerTest(TestBaseHandler):
             "Expected exception message must be equal to %s" %expected_message
         )
     
-    @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'otheruser@test.com'})
     def test_patch_with_a_user_that_is_already_a_member(self, verify_token):
         """Test a patch invite_user when the user is already a member."""
         self.inst_test.add_member(self.other_user)
@@ -270,7 +270,7 @@ class InviteHandlerTest(TestBaseHandler):
             "Expected exception message must be equal to %s" %expected_message
         )
 
-    @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'otheruser@test.com'})
     def test_patch_with_an_accepted_invite(self, verify_token):
         """Test patch with an accepted invite."""
         self.invite.status = "accepted"
@@ -293,7 +293,7 @@ class InviteHandlerTest(TestBaseHandler):
             "Expected exception message must be equal to %s" % expected_message
         )
     
-    @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'otheruser@test.com'})
     def test_patch_with_a_rejected_invite(self, verify_token):
         """Test patch with a rejected invite."""
         self.invite.status = "rejected"
@@ -316,7 +316,7 @@ class InviteHandlerTest(TestBaseHandler):
             "Expected exception message must be equal to %s" % expected_message
         )
     
-    @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'otheruser@test.com'})
     def test_delete_with_a_rejected_invite(self, verify_token):
         """Test delete with a rejected invite."""
         self.invite.status = "rejected"
@@ -339,7 +339,7 @@ class InviteHandlerTest(TestBaseHandler):
             "Expected exception message must be equal to %s" % expected_message
         )
     
-    @patch('utils.verify_token', return_value={'email': 'otheruser@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'otheruser@test.com'})
     def test_delete_with_an_accepted_invite(self, verify_token):
         """Test delete with an accepted invite."""
         self.invite.status = "accepted"

--- a/backend/test/invite_institution_handler_test.py
+++ b/backend/test/invite_institution_handler_test.py
@@ -52,7 +52,7 @@ class InviteInstitutionHandlerTest(TestBaseHandler):
         }
 
     @patch.object(Invite, 'send_invite')
-    @patch('utils.verify_token', return_value={'email': 'first_user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'first_user@gmail.com'})
     def test_post_invite_institution(self, verify_token, send_invite):
         """Test post invite institution."""
         self.testapp.post_json("/api/invites/institution", self.body,
@@ -61,7 +61,7 @@ class InviteInstitutionHandlerTest(TestBaseHandler):
         send_invite.assert_called_with(host, self.institution.key)
     
     @patch.object(Invite, 'send_invite')
-    @patch('utils.verify_token', return_value={'email': 'first_user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'first_user@gmail.com'})
     def test_post_invite_institution_fail(self, verify_token, send_invite):
         """Test post invite institution fail."""
         with self.assertRaises(Exception) as ex:
@@ -78,7 +78,7 @@ class InviteInstitutionHandlerTest(TestBaseHandler):
         send_invite.assert_not_called() 
 
     @patch.object(Invite, 'send_invite')
-    @patch('utils.verify_token', return_value={'email': 'second_user@ccc.ufcg.edu.br'})
+    @patch('util.login_service.verify_token', return_value={'email': 'second_user@ccc.ufcg.edu.br'})
     def test_post_user_not_allowed(self, verify_token, send_invite):
         """Test post user not allowed."""
         # new Institution
@@ -106,7 +106,7 @@ class InviteInstitutionHandlerTest(TestBaseHandler):
         send_invite.assert_not_called() 
 
     @patch.object(Invite, 'send_invite')
-    @patch('utils.verify_token', return_value={'email': 'first_user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'first_user@gmail.com'})
     def test_post_invite_institution_inactive(self, verify_token, send_invite):
         """Test post invite institution fail."""
         with self.assertRaises(Exception) as ex:

--- a/backend/test/invite_user_adm_handler_test.py
+++ b/backend/test/invite_user_adm_handler_test.py
@@ -36,7 +36,7 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
 
     @patch('models.invite_user_adm.InviteUserAdm.send_notification')
     @patch('handlers.invite_user_adm_handler.enqueue_task')
-    @patch('utils.verify_token', return_value={'email': 'usr_test@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'usr_test@test.com'})
     def test_put(self, verify_token, enqueue_task, send_notification):
         """Test put method  in inviteUserAdmHandler."""
         enqueue_task.side_effect = self.enqueue_task
@@ -106,7 +106,7 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
     
     @patch('models.invite_user_adm.InviteUserAdm.send_notification')
     @patch('handlers.invite_user_adm_handler.enqueue_task')
-    @patch('utils.verify_token', return_value={'email': 'usr_test@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'usr_test@test.com'})
     def test_put_invite_in_hierarchy(self, verify_token, enqueue_task, send_notification):
         """Test put invite in hierarchy."""
         enqueue_task.side_effect = self.enqueue_task
@@ -252,7 +252,7 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
     
     @patch('models.invite_user_adm.InviteUserAdm.send_notification')
     @patch('handlers.invite_user_adm_handler.enqueue_task')
-    @patch('utils.verify_token', return_value={'email': 'usr_test@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'usr_test@test.com'})
     def test_put_invite_with_user_admin_of_parent_inst(self, verify_token, enqueue_task, send_notification):
         """Test put invite with user is admin of parent institution."""
         enqueue_task.side_effect = self.enqueue_task
@@ -398,7 +398,7 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
 
     @patch('models.invite_user_adm.InviteUserAdm.send_notification')
     @patch('handlers.invite_user_adm_handler.enqueue_task')
-    @patch('utils.verify_token', return_value={'email': 'usr_test@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'usr_test@test.com'})
     def test_put_invite_with_super_user_admin_of_parent_inst(self, verify_token, enqueue_task, send_notification):
         """Test put invite with user super user and is admin of parent institution."""
         enqueue_task.side_effect = self.enqueue_task
@@ -546,7 +546,7 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
     
     @patch('models.invite_user_adm.InviteUserAdm.send_notification')
     @patch('handlers.invite_user_adm_handler.enqueue_task')
-    @patch('utils.verify_token', return_value={'email': 'usr_test@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'usr_test@test.com'})
     def test_put_invite_super_user(self, verify_token, enqueue_task, send_notification):
         """Test put invite with user is super admin."""
         enqueue_task.side_effect = self.enqueue_task
@@ -626,7 +626,7 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
             'new_admin must have super user permissions for second_inst institution!'
         )
 
-    @patch('utils.verify_token', return_value={'email': 'usr_test@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'usr_test@test.com'})
     def test_put_accepted_and_rejected_invite(self, verify_token):
         """Test put accepted and rejected invite."""
         admin = mocks.create_user()
@@ -738,7 +738,7 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
             'Expected message of exception must be equal to Error! This invitation has already been processed'
         )
 
-    @patch('utils.verify_token', return_value={'email': 'usr_test@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'usr_test@test.com'})
     def test_put_invite_not_allowed(self, verify_token):
         """Test put invite not allowed."""
         admin = mocks.create_user()
@@ -813,7 +813,7 @@ class InviteUserAdmHandlerTest(TestBaseHandler):
         )
 
     @patch('models.invite_user_adm.InviteUserAdm.send_notification')
-    @patch('utils.verify_token', return_value={'email': 'usr_test@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'usr_test@test.com'})
     def test_delete(self, verify_token, send_notification):
         """Test reject invite."""
         admin = mocks.create_user()

--- a/backend/test/like_comment_handler_test.py
+++ b/backend/test/like_comment_handler_test.py
@@ -41,7 +41,7 @@ class LikeCommentHandlerTest(TestBaseHandler):
         # creating uri
         cls.uri = '/api/posts/%s/comments/%s/likes' % (cls.post.key.urlsafe(), cls.comment.id)
 
-    @patch('utils.verify_token', return_value={'email': 'otheruser@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'otheruser@example.com'})
     def test_get(self, verify_token):
         """Test the like_comment_handler's get method."""
         # like the comment
@@ -60,7 +60,7 @@ class LikeCommentHandlerTest(TestBaseHandler):
         )
 
     @patch('handlers.like_handler.send_message_notification')
-    @patch('utils.verify_token', return_value={'email': 'user@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@example.com'})
     def test_post(self, verify_token, send_message_notification):
         """Test post method when the user likes a comment."""
         # assert the comment has no likes
@@ -120,7 +120,7 @@ class LikeCommentHandlerTest(TestBaseHandler):
             "The number of likes should be 1, but it was %d" % len(comment['likes'])
         )
         
-    @patch('utils.verify_token', return_value={'email': 'otheruser@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'otheruser@example.com'})
     def test_delete(self, verify_token):
         """Test the like_comment_handler's delete method."""
         # like the comment

--- a/backend/test/like_post_handler_test.py
+++ b/backend/test/like_post_handler_test.py
@@ -36,7 +36,7 @@ class LikePostHandlerTest(TestBaseHandler):
         cls.post = mocks.create_post(cls.user.key, cls.institution.key)
 
 
-    @patch('utils.verify_token', return_value={'email': 'otheruser@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'otheruser@example.com'})
     def test_get(self, verify_token):
         """Test method get of LikeHandler."""
         uri = '/api/posts/%s/likes' % self.post.key.urlsafe()
@@ -71,7 +71,7 @@ class LikePostHandlerTest(TestBaseHandler):
         self.assertIn(self.other_user.name, authors)
 
     @patch('handlers.like_handler.enqueue_task')
-    @patch('utils.verify_token', return_value={'email': 'otheruser@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'otheruser@example.com'})
     def test_post(self, verify_token, enqueue_task):
         """Test the like_handler's post method when a post is liked."""
         uri = '/api/posts/%s/likes' % self.post.key.urlsafe()
@@ -125,7 +125,7 @@ class LikePostHandlerTest(TestBaseHandler):
                          "The number of likes expected was 2, but was %d"
                          % self.post.get_number_of_likes())
 
-    @patch('utils.verify_token', return_value={'email': 'otheruser@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'otheruser@example.com'})
     def test_post_deleted_post(self, verify_token):
         institution = mocks.create_institution()
         user = mocks.create_user()
@@ -146,7 +146,7 @@ class LikePostHandlerTest(TestBaseHandler):
             'Expected message of exception must be equal to Error! This post has been deleted'
         )
 
-    @patch('utils.verify_token', return_value={'email': 'otheruser@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'otheruser@example.com'})
     def test_delete(self, verify_token):
         """Test the like_post_handler's delete method."""
         uri = '/api/posts/%s/likes' % self.post.key.urlsafe()

--- a/backend/test/like_reply_handler_test.py
+++ b/backend/test/like_reply_handler_test.py
@@ -22,7 +22,7 @@ class LikeReplyHandlerTest(TestBaseHandler):
         cls.testapp = cls.webtest.TestApp(app)
         init(cls)
 
-    @patch('utils.verify_token', return_value={'email': 'otheruser@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'otheruser@example.com'})
     def test_get(self, verify_token):
         """Test the like_comment_handler's get method."""
         # like the comment
@@ -41,7 +41,7 @@ class LikeReplyHandlerTest(TestBaseHandler):
         )
 
     @patch('handlers.like_handler.send_message_notification')
-    @patch('utils.verify_token', return_value={'email': 'user@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@example.com'})
     def test_post(self, verify_token, send_message_notification):
         """Test post method when the user likes a comment."""
         # Call the get method again
@@ -102,7 +102,7 @@ class LikeReplyHandlerTest(TestBaseHandler):
             "The number of likes should be 1, but it was %d" % len(likes)
         )
         
-    @patch('utils.verify_token', return_value={'email': 'otheruser@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'otheruser@example.com'})
     def test_delete(self, verify_token):
         """Test the like_comment_handler's delete method."""
         # like the reply

--- a/backend/test/post_collection_handler_test.py
+++ b/backend/test/post_collection_handler_test.py
@@ -66,7 +66,7 @@ class PostCollectionHandlerTest(TestBaseHandler):
 
 
     @patch('handlers.post_collection_handler.enqueue_task')
-    @patch('utils.verify_token', return_value={'email': 'user@email.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@email.com'})
     def test_post(self, verify_token, enqueue_task):
         """Test the post_collection_handler's post method."""
 
@@ -149,7 +149,7 @@ class PostCollectionHandlerTest(TestBaseHandler):
         )
 
     @patch('handlers.post_collection_handler.enqueue_task')
-    @patch('utils.verify_token', return_value={'email': 'user@email.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@email.com'})
     def test_post_sharing(self, verify_token, enqueue_task):
         """Test the post_collection_handler's post method."""
         # Make the request and assign the answer to post
@@ -221,7 +221,7 @@ class PostCollectionHandlerTest(TestBaseHandler):
 
     @patch('handlers.post_collection_handler.enqueue_task')
     @patch('handlers.post_collection_handler.send_message_notification')
-    @patch('utils.verify_token', return_value={'email': 'user@email.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@email.com'})
     def test_post_shared_event(self, verify_token, send_message_notification, enqueue_task):
         """Test the post_collection_handler's post method in case that post is shared_event."""
         # create an event
@@ -311,7 +311,7 @@ class PostCollectionHandlerTest(TestBaseHandler):
     
     @patch('handlers.post_collection_handler.enqueue_task')
     @patch('handlers.post_collection_handler.send_message_notification')
-    @patch('utils.verify_token', return_value={'email': 'user@email.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@email.com'})
     def test_post_survey(self, verify_token, send_message_notification, enqueue_task):
         """Test post method."""
         # Survey post

--- a/backend/test/post_comment_handler_test.py
+++ b/backend/test/post_comment_handler_test.py
@@ -57,7 +57,7 @@ class PostCommentHandlerTest(TestBaseHandler):
         }
 
     @patch('handlers.post_comment_handler.enqueue_task')
-    @patch('utils.verify_token', return_value={'email': OTHER_USER_EMAIL})
+    @patch('util.login_service.verify_token', return_value={'email': OTHER_USER_EMAIL})
     def test_post(self, verify_token, enqueue_task):
         """Other_user's comment on user's post."""
         # Verify size of list
@@ -116,7 +116,7 @@ class PostCommentHandlerTest(TestBaseHandler):
 
 
     @patch('handlers.post_comment_handler.enqueue_task')
-    @patch('utils.verify_token', return_value={'email': USER_EMAIL})
+    @patch('util.login_service.verify_token', return_value={'email': USER_EMAIL})
     def test_post_ownerpost(self, verify_token, enqueue_task):
         """Owner user comments on its own Post."""
         # Verify size of list
@@ -140,7 +140,7 @@ class PostCommentHandlerTest(TestBaseHandler):
         # assert the notification was not sent
         enqueue_task.assert_not_called()
 
-    @patch('utils.verify_token', return_value={'email': OTHER_USER_EMAIL})
+    @patch('util.login_service.verify_token', return_value={'email': OTHER_USER_EMAIL})
     def test_delete(self, verify_token):
         """User can delete your comment in Post."""
         # Added comment
@@ -166,7 +166,7 @@ class PostCommentHandlerTest(TestBaseHandler):
         self.assertEquals(len(self.user_post.comments), 0,
                           "Expected size of comment's list should be zero")
 
-    @patch('utils.verify_token', return_value={'email': OTHER_USER_EMAIL})
+    @patch('util.login_service.verify_token', return_value={'email': OTHER_USER_EMAIL})
     def test_delete_in_deleted_post(self, verify_token):
         """User can not delete comment in deleted Post."""
         # Added comment
@@ -197,7 +197,7 @@ class PostCommentHandlerTest(TestBaseHandler):
         self.assertEquals(len(self.user_post.comments), 1,
                           "Expected size of comment's list should be one")
 
-    @patch('utils.verify_token', return_value={'email': USER_EMAIL})
+    @patch('util.login_service.verify_token', return_value={'email': USER_EMAIL})
     def test_delete_simpleuser(self, verify_token):
         """An simple user can't delete comments by other users in Post."""
         # Added comment of user
@@ -228,7 +228,7 @@ class PostCommentHandlerTest(TestBaseHandler):
         self.assertEquals(len(self.user_post.comments), 1,
                           "Expected size of comment's list should be one")
 
-    @patch('utils.verify_token', return_value={'email': OTHER_USER_EMAIL})
+    @patch('util.login_service.verify_token', return_value={'email': OTHER_USER_EMAIL})
     def test_delete_ownerpost(self, verify_token):
         """Owner user can delete comment from other user in Post."""
         # Added comment user other_user
@@ -255,7 +255,7 @@ class PostCommentHandlerTest(TestBaseHandler):
         self.assertEquals(len(self.user_post.comments), 0,
                           "Expected size of comment's list should be zero")
 
-    @patch('utils.verify_token', return_value={'email': USER_EMAIL})
+    @patch('util.login_service.verify_token', return_value={'email': USER_EMAIL})
     def test_check_permission(self, verify_token):
         """Test method check_permission in post_comment_handler."""
         # Added comment

--- a/backend/test/post_handler_test.py
+++ b/backend/test/post_handler_test.py
@@ -29,7 +29,7 @@ class PostHandlerTest(TestBaseHandler):
         cls.first_user.put()
         initModels(cls)
 
-    @patch('utils.verify_token', return_value={'email': 'first_user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'first_user@gmail.com'})
     def test_delete(self, verify_token):
         """Test the post_handler's delete method."""
         # test delete post when the post has a comment
@@ -79,7 +79,7 @@ class PostHandlerTest(TestBaseHandler):
         self.assertEqual(self.second_user_post.state, 'deleted',
                          "After delete the post state should be 'deleted'")
 
-    @patch('utils.verify_token', return_value={'email': 'first_user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'first_user@gmail.com'})
     def test_patch(self, verify_token):
         """Test the post_handler's patch method."""
 
@@ -169,7 +169,7 @@ class PostHandlerTest(TestBaseHandler):
             expected_alert + raises_context_message)
     
     @patch('handlers.post_handler.send_message_notification')
-    @patch('utils.verify_token', return_value={'email': 'first_user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'first_user@gmail.com'})
     def test_delete_with_admin(self, verify_token, mock_method):
         """Test delete a post with admin."""
         self.first_user.add_permission(
@@ -187,7 +187,7 @@ class PostHandlerTest(TestBaseHandler):
         
         mock_method.assert_called()
 
-    @patch('utils.verify_token', return_value={'email': 'second_user@ccc.ufcg.edu.br'})
+    @patch('util.login_service.verify_token', return_value={'email': 'second_user@ccc.ufcg.edu.br'})
     def test_delete_without_admin(self, verify_token):
         """Test delete a post with admin."""
         self.assertEqual(self.first_user_post.state, 'published',

--- a/backend/test/reply_comment_handler_test.py
+++ b/backend/test/reply_comment_handler_test.py
@@ -60,7 +60,7 @@ class ReplyCommentHandlerTest(TestBaseHandler):
 
 
     @patch('handlers.reply_comment_handler.send_message_notification')
-    @patch('utils.verify_token', return_value={'email': THIRD_USER_EMAIL})
+    @patch('util.login_service.verify_token', return_value={'email': THIRD_USER_EMAIL})
     def test_post(self, verify_token, send_message_notification):
         """Reply a comment of post"""
         # Verify size of list
@@ -125,7 +125,7 @@ class ReplyCommentHandlerTest(TestBaseHandler):
         send_message_notification.assert_has_calls(calls)
     
     @patch('handlers.reply_comment_handler.send_message_notification')
-    @patch('utils.verify_token', return_value={'email': THIRD_USER_EMAIL})
+    @patch('util.login_service.verify_token', return_value={'email': THIRD_USER_EMAIL})
     def test_post_method_on_deleted_post(self, verify_token, send_message_notification):
         """Test post a comment when the post is deleted."""
         body = {
@@ -163,7 +163,7 @@ class ReplyCommentHandlerTest(TestBaseHandler):
         # assert no notification was sent
         send_message_notification.assert_not_called()
 
-    @patch('utils.verify_token', return_value={'email': USER_EMAIL})
+    @patch('util.login_service.verify_token', return_value={'email': USER_EMAIL})
     def test_delete(self, verify_token):
         """Delete a reply of a comment"""
         # Verify if before the delete the post's state is published

--- a/backend/test/request_handler_test.py
+++ b/backend/test/request_handler_test.py
@@ -31,7 +31,7 @@ class RequestHandlerTest(TestBaseHandler):
              ], debug=True)
         cls.testapp = cls.webtest.TestApp(app)
 
-    @patch('utils.verify_token', return_value=ADMIN)
+    @patch('util.login_service.verify_token', return_value=ADMIN)
     def test_get(self, verify_token):
         """Test method get of RequestHandler."""
         admin = mocks.create_user(ADMIN['email'])
@@ -74,7 +74,7 @@ class RequestHandlerTest(TestBaseHandler):
             'REQUEST_USER',
             "expected type_of_invite must be equal to  REQUEST_USER")
 
-    @patch('utils.verify_token', return_value=ADMIN)
+    @patch('util.login_service.verify_token', return_value=ADMIN)
     def test_put(self, verify_token):
         """Test method put of RequestHandler."""
         admin = mocks.create_user(ADMIN['email'])
@@ -124,7 +124,7 @@ class RequestHandlerTest(TestBaseHandler):
             user.key in institution.followers,
             "key of user must be in institution followers")
 
-    @patch('utils.verify_token', return_value=ADMIN)
+    @patch('util.login_service.verify_token', return_value=ADMIN)
     def test_put_request_accepted(self, verify_token):
         """Test put request accepted."""
         admin = mocks.create_user(ADMIN['email'])
@@ -157,7 +157,7 @@ class RequestHandlerTest(TestBaseHandler):
             exception_message,
             "Expected error message is Error! this request has already been processed")
 
-    @patch('utils.verify_token', return_value=USER)
+    @patch('util.login_service.verify_token', return_value=USER)
     def test_put_user_not_admin(self, verify_token):
         """Test put request with user is not admin."""
         admin = mocks.create_user(ADMIN['email'])
@@ -186,7 +186,7 @@ class RequestHandlerTest(TestBaseHandler):
             exception_message,
             "Expected error message is Error! User is not allowed to accept user request")
 
-    @patch('utils.verify_token', return_value=ADMIN)
+    @patch('util.login_service.verify_token', return_value=ADMIN)
     def test_delete(self, verify_token):
         """Test method delete of RequestHandler."""
         admin = mocks.create_user(ADMIN['email'])
@@ -230,7 +230,7 @@ class RequestHandlerTest(TestBaseHandler):
             len(self.other_user.institution_profiles),
             0, 'The other_user should have no profile')
 
-    @patch('utils.verify_token', return_value=USER)
+    @patch('util.login_service.verify_token', return_value=USER)
     def test_delete_user_not_admin(self, verify_token):
         """Test delete request with user is not admin."""
         admin = mocks.create_user(ADMIN['email'])

--- a/backend/test/resend_invite_handler_test.py
+++ b/backend/test/resend_invite_handler_test.py
@@ -32,7 +32,7 @@ class ResendInviteHandlerTest(TestBaseHandler):
 
     @mock.patch('models.invite_user.InviteUser.send_email')
     @mock.patch('models.invite_user.InviteUser.send_notification')
-    @patch('utils.verify_token', return_value={'email': 'user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@gmail.com'})
     def test_post(self, verify_token, mock_method, second_mock_method):
         """Test post."""
         user = mocks.create_user("user@gmail.com")

--- a/backend/test/search_handler_test.py
+++ b/backend/test/search_handler_test.py
@@ -20,7 +20,7 @@ class SearchHandlerTest(TestBaseHandler):
              ], debug=True)
         cls.testapp = cls.webtest.TestApp(app)
 
-    @patch('utils.verify_token', return_value=USER)
+    @patch('util.login_service.verify_token', return_value=USER)
     def test_get_institution(self, verify_token):
         """Test the search_handler's get method."""
         splab = mocks.create_institution()
@@ -75,7 +75,7 @@ class SearchHandlerTest(TestBaseHandler):
             % ('Ensaio quimico', 'active'))
         self.assertTrue('CERTBIO' in institutions)
 
-    @patch('utils.verify_token', return_value=USER)
+    @patch('util.login_service.verify_token', return_value=USER)
     def test_get_user(self, verify_token):
         """Test the search_handler's get method with type=user."""
         user = mocks.create_user(USER['email'])

--- a/backend/test/subscribe_post_handler_test.py
+++ b/backend/test/subscribe_post_handler_test.py
@@ -22,7 +22,7 @@ class SubscribePostHandlerTest(TestBaseHandler):
         cls.testapp = cls.webtest.TestApp(app)
         initModels(cls)
 
-    @patch('utils.verify_token', return_value={'email': 'test@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'test@example.com'})
     def test_post(self, verify_token):
         """Test the SubscribePostHandler's post method."""
         # Check the initial conditions
@@ -38,7 +38,7 @@ class SubscribePostHandlerTest(TestBaseHandler):
         # Check the final conditions
         self.assertTrue(self.user.key in self.post.subscribers)
 
-    @patch('utils.verify_token', return_value={'email': 'test@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'test@example.com'})
     def test_delete(self, verify_token):
         """Test the SubscribePostHandler's delete method."""
         # Check the initial conditions
@@ -57,7 +57,7 @@ class SubscribePostHandlerTest(TestBaseHandler):
         # Check the final conditions
         self.assertFalse(self.user.key in self.post.subscribers)
 
-    @patch('utils.verify_token', return_value={'email': 'second@example.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'second@example.com'})
     def test_delete_with_author(self, verify_token):
         """Test the SubscribePostHandler's delete method with the author."""
         # Check the initial conditions

--- a/backend/test/user_handler_test.py
+++ b/backend/test/user_handler_test.py
@@ -58,7 +58,7 @@ class UserHandlerTest(TestBaseHandler):
         """Deactivate the test."""
         cls.test.deactivate()
 
-    @patch('utils.verify_token')
+    @patch('util.login_service.verify_token')
     def test_get(self, verify_token):
         """Test the user_handler's get method."""
         verify_token._mock_return_value = {'email': self.user.email[0]}
@@ -85,7 +85,7 @@ class UserHandlerTest(TestBaseHandler):
             "The institutions_admin is different from the expected one"
         )
 
-    @patch('utils.verify_token')
+    @patch('util.login_service.verify_token')
     def test_delete(self, verify_token):
         """Test the user_handler's delete method."""
         verify_token._mock_return_value = {'email': self.other_user.email[0]}
@@ -126,7 +126,7 @@ class UserHandlerTest(TestBaseHandler):
         self.assertEquals(self.other_user.institution_profiles, [], "User permissions should be empty")
 
 
-    @patch('utils.verify_token')
+    @patch('util.login_service.verify_token')
     def test_patch(self, verify_token):
         verify_token._mock_return_value = {'email': self.other_user.email[0]}
         """Test the user_handler's patch method."""

--- a/backend/test/user_institutions_handler_test.py
+++ b/backend/test/user_institutions_handler_test.py
@@ -22,7 +22,7 @@ class UserInstitutionsHandlerTest(TestBaseHandler):
         initModels(cls)
 
     @patch('handlers.user_institutions_handler.LeaveInstitutionEmailSender.send_email')
-    @patch('utils.verify_token', return_value={'email': 'second_user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'second_user@gmail.com'})
     def test_delete(self, verify_token, send_email):
         """Test delete."""
         # Assert the initial conditions

--- a/backend/test/user_profile_handler_test.py
+++ b/backend/test/user_profile_handler_test.py
@@ -29,7 +29,7 @@ class UserProfileHandlerTest(TestBaseHandler):
         cls.testapp = cls.webtest.TestApp(app)
         initModels(cls)
 
-    @patch('utils.verify_token', return_value={'email': 'raoni.smaneoto@ccc.ufcg.edu.br'})
+    @patch('util.login_service.verify_token', return_value={'email': 'raoni.smaneoto@ccc.ufcg.edu.br'})
     def test_get(self, verify_token):
         """Test the get method."""
         result = self.testapp.get(

--- a/backend/test/user_request_collection_handler_test.py
+++ b/backend/test/user_request_collection_handler_test.py
@@ -49,7 +49,7 @@ class UserRequestCollectionHandlerTest(TestBaseHandler):
         cls.headers = {"Institution-Authorization": cls.other_inst.key.urlsafe()}
 
     @patch.object(Invite, "send_invite")
-    @patch('utils.verify_token', return_value={'email': 'other_user@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'other_user@test.com'})
     def test_post(self, verify_token, send_invite):
         """Test method post of UserRequestCollectionHandlerTest."""
         data = {
@@ -93,7 +93,7 @@ class UserRequestCollectionHandlerTest(TestBaseHandler):
         send_invite.assert_called_with('localhost:80', self.other_inst.key)
 
     @patch.object(Invite, "send_invite")
-    @patch('utils.verify_token', return_value={'email': 'other_user@test.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'other_user@test.com'})
     def test_post_invalid_request_type(self, verify_token, send_invite):
         """Test if an exception is thrown by passing an invalid request."""
         data = {

--- a/backend/test/user_timeline_handler_test.py
+++ b/backend/test/user_timeline_handler_test.py
@@ -27,7 +27,7 @@ class UserTimelineHandlerTest(TestBaseHandler):
         cls.testapp = cls.webtest.TestApp(app)
         initModels(cls)
 
-    @patch('utils.verify_token', return_value={'email': 'user@gmail.com'})
+    @patch('util.login_service.verify_token', return_value={'email': 'user@gmail.com'})
     def test_get(self, verify_token):
         """Test the user_timeline_handler get method."""
         # Added a post in datastore

--- a/backend/test/vote_handler_test.py
+++ b/backend/test/vote_handler_test.py
@@ -25,7 +25,7 @@ class VoteHandlerTest(TestBaseHandler):
         cls.testapp = cls.webtest.TestApp(app)
         initModels(cls)
 
-    @patch('utils.verify_token')
+    @patch('util.login_service.verify_token')
     def test_post(self, verify_token):
         """Test the vote_handler's post method."""
         verify_token.return_value = {'email': 'user@example.com'}

--- a/backend/util/login_service.py
+++ b/backend/util/login_service.py
@@ -1,4 +1,6 @@
 
+"""Service to manage user authentication."""
+
 import json
 from google.appengine.ext import ndb
 from utils import verify_token

--- a/backend/util/login_service.py
+++ b/backend/util/login_service.py
@@ -1,6 +1,6 @@
 
 import json
-from goolge.appengine.ext import ndb
+from google.appengine.ext import ndb
 from utils import verify_token
 from models import User
 

--- a/backend/util/login_service.py
+++ b/backend/util/login_service.py
@@ -1,0 +1,48 @@
+
+import json
+from goolge.appengine.ext import ndb
+from utils import verify_token
+from models import User
+
+
+def setup_current_institution(user, request):
+    """
+    Current institution is used by the backend to specify which
+    institution the user is logged. The HTTP header Institution-Authorization,
+    if exist, comes with the institution key that provides the direct
+    access to the resource. Once the header exists, it creates a user
+    property 'current_institution' with a ndb.Key to be used during 
+    the transaction.
+    """
+    try:
+        institution_header = request.headers['Institution-Authorization']
+        institution_key = ndb.Key(urlsafe=institution_header)
+        user.current_institution = institution_key
+    except KeyError as error:
+        user.current_institution = None
+
+def login_required(method):
+    """Handle required login."""
+    def login(self, *args):
+        credential = verify_token(self.request)
+        if not credential:
+            self.response.write(json.dumps({
+                'msg': 'Auth needed',
+                'login_url': 'http://%s/#/signin' % self.request.host
+            }))
+            self.response.set_status(401)
+            return
+
+        user_name = credential.get('name', 'Unknown')
+        user_email = credential.get('email', 'Unknown')
+        user = User.get_by_email(user_email)
+
+        if user is None:
+            user = User()
+            user.name = user_name
+            user.email = [user_email]
+
+        setup_current_institution(user, self.request)
+
+        method(self, user, *args)
+    return login

--- a/backend/util/provider_institutions.py
+++ b/backend/util/provider_institutions.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+"""Service to get the super institutions."""
+
 from models import Institution
 
 

--- a/backend/util/provider_institutions.py
+++ b/backend/util/provider_institutions.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from models import Institution
+
+
+def get_health_ministry():
+    """Get health ministry institution."""
+    query = Institution.query(Institution.name == "Ministério da Saúde", Institution.acronym == "MS")
+    return query.get()
+
+def get_deciis():
+    """Get health ministry institution."""
+    query = Institution.query(Institution.trusted == True)
+    return query.get()

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -9,9 +9,6 @@ from app_version import APP_VERSION
 
 from google.appengine.ext import ndb
 
-from models import User
-from models import Institution
-
 from oauth2client import client
 from oauth2client.crypt import AppIdentityError
 
@@ -97,40 +94,6 @@ def verify_token(request):
         except (ValueError, AppIdentityError) as error:
             logging.exception(str(error))
             return None
-
-def follow_inst(user,inst):
-    user.follow(inst.key)
-    inst.follow(user.key)
-
-def create_user(name, email):
-    """Create user."""
-    user = User()
-    user.email = email
-    user.name = name
-    user.photo_url = "app/images/avatar.png"
-    health_ministry = get_health_ministry()
-    deciis = get_deciis()
-    """"TODO: All users have to follow MS and DECIIS
-        Think of a better way to do it
-        @author: Mayza Nunes 24/01/2018
-    """
-    if health_ministry is not None:
-        follow_inst(user, health_ministry)
-    if deciis is not None:
-        follow_inst(user, deciis)
-    user.put()
-    
-    return user
-
-def get_health_ministry():
-    """Get health ministry institution."""
-    query = Institution.query(Institution.name == "Ministério da Saúde", Institution.acronym == "MS")
-    return query.get()
-
-def get_deciis():
-    """Get health ministry institution."""
-    query = Institution.query(Institution.trusted == True)
-    return query.get()
 
 def json_response(method):
     """Add content type header to the response."""

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -156,20 +156,3 @@ def to_int(value, exception, message_exception):
         raise exception(message_exception)
 
     return value
-
-def make_user(user, request):
-    user_json = Utils.toJson(user, host=request.host)
-    user_json['logout'] = 'http://%s/logout?redirect=%s' %\
-        (request.host, request.path)
-    user_json['institutions'] = []
-    for institution in user.institutions:
-        user_json['institutions'].append(
-            Utils.toJson(institution.get())
-        )
-    user_json['follows'] = [institution_key.get().make(
-        ['name','acronym', 'photo_url', 'key', 'parent_institution'])
-        for institution_key in user.follows
-        if institution_key.get().state != 'inactive']
-    user_json['institution_profiles'] = [profile.make()
-        for profile in user.institution_profiles]
-    return user_json

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -98,49 +98,6 @@ def verify_token(request):
             logging.exception(str(error))
             return None
 
-def setup_current_institution(user, request):
-    """
-    Current institution is used by the backend to specify which
-    institution the user is logged. The HTTP header Institution-Authorization,
-    if exist, comes with the institution key that provides the direct
-    access to the resource. Once the header exists, it creates a user
-    property 'current_institution' with a ndb.Key to be used during 
-    the transaction.
-    """
-    try:
-        institution_header = request.headers['Institution-Authorization']
-        institution_key = ndb.Key(urlsafe=institution_header)
-        user.current_institution = institution_key
-    except KeyError as error:
-        user.current_institution = None
-
-
-def login_required(method):
-    """Handle required login."""
-    def login(self, *args):
-        credential = verify_token(self.request)
-        if not credential:
-            self.response.write(json.dumps({
-                'msg': 'Auth needed',
-                'login_url': 'http://%s/#/signin' % self.request.host
-            }))
-            self.response.set_status(401)
-            return
-
-        user_name = credential.get('name', 'Unknown')
-        user_email = credential.get('email', 'Unknown')
-        user = User.get_by_email(user_email)
-
-        if user is None:
-            user = User()
-            user.name = user_name
-            user.email = [user_email]
-
-        setup_current_institution(user, self.request)
-
-        method(self, user, *args)
-    return login
-
 def follow_inst(user,inst):
     user.follow(inst.key)
     inst.follow(user.key)


### PR DESCRIPTION
**Feature/Bug description:** The utils module were directly using the user and institution models, this was occasionally causing cyclical dependence on imports, making it impossible for the user to use any of the functions present in the utils module.

**Solution:** I removed from the utils all the methods that used the user and institution templates directly and put them in more appropriate places, thus making the utils only with generic methods that can be used throughout the system. With this, it was possible to eliminate the possibility of a cyclic dependency involving the utils module.

**TODO/FIXME:** n/a