### PR TITLE
Fix admin profile visualization

### DIFF
--- a/frontend/institution/members.html
+++ b/frontend/institution/members.html
@@ -20,8 +20,7 @@
 						md-colors="{background: 'grey-300'}" ng-click="membersCtrl.showUserProfile(membersCtrl.institution.admin.key, $event)">  
 						<img title="{{membersCtrl.institution.admin.name}}" ng-src="{{membersCtrl.institution.admin.photo_url}}" class="md-avatar"
 						style="width: 60px; height: 60px; margin-right: 2%; border-radius: 50%;"/>
-						<div layout="column" layout-align="center" 
-							ng-click="membersCtrl.showUserProfile(membersCtrl.institution.admin.key, $event)">
+						<div layout="column" layout-align="center">
 							<b>{{ membersCtrl.institution.admin.name }}</b>
 							<span>{{ membersCtrl.institution.admin.email[0]}}</span>
 						</div>


### PR DESCRIPTION
**Feature/Bug description:**
The ng-click was duplicated. One to the external div and another to the div that wraps the admin name. So, when the click was right in the name, two ng-clicks were called making the profile show twice. 
**Solution:**
I've removed the internal ng-click.
**TODO/FIXME:** n/a