### PR TITLE
Fix change institution parent

### DIFF
--- a/frontend/requests/requestProcessingController.js
+++ b/frontend/requests/requestProcessingController.js
@@ -51,6 +51,7 @@
         }
 
         requestController.rejectRequest = function rejectRequest(event){
+            requestController.warnPaternityExistence = false;
             requestController.isRejecting = true;
         };
 
@@ -106,6 +107,7 @@
                 formatPositions();
                 getLegalNature();
                 getActuationArea();
+                selectDialogFlow();
             }, function error(response) {
                 MessageService.showToast(response.data.msg);
             });
@@ -140,6 +142,20 @@
             window.open(makeUrl(institutionKey), '_blank');
         };
 
+        requestController.confirmLinkRemoval = function confirmLinkRemoval() {
+            const isParent = true;
+            const institutionKey = requestController.children.key;
+            const institutionLinkKey = requestController.children.parent_institution.key;
+
+            InstitutionService.removeLink(institutionKey, institutionLinkKey, isParent).then(function success(data) {
+                MessageService.showToast('Vínculo removido.');
+                requestController.warnPaternityExistence = false;
+                delete requestController.children.parent_institution;
+            }, function error(response) {
+                MessageService.showToast(response.data.msg);
+            });
+        };
+
         function makeUrl(institutionKey){
             var currentUrl = window.location.href;
             currentUrl = currentUrl.split('#');
@@ -158,6 +174,14 @@
                 requestController.instActuationArea = _.get(response.data,
                     requestController.parent.actuation_area);
             });
+        }
+
+        function selectDialogFlow() {
+            const isChildrenRequest = request.type_of_invite === REQUEST_CHILDREN;
+            const hasParent = requestController.children.parent_institution;
+            if (isChildrenRequest && hasParent) {
+                requestController.warnPaternityExistence = true;
+            }
         }
 
         (function main () {

--- a/frontend/requests/request_processing.html
+++ b/frontend/requests/request_processing.html
@@ -1,25 +1,87 @@
 <md-dialog flex-gt-sm="{{requestCtrl.getSizeGtSmDialog()}}" flex-sm="80" flex-xs="100">
-  <md-dialog-content ng-if="!requestCtrl.isRejecting" class="md-dialog-content" layout-gt-sm="column" layout-padding>
-    <h4 style="margin: 0;">Confirmar Vínculo</h4>
-    <p style="margin: 0;">
-      Um usuário da plataforma solicitou vincular-se a uma das instituições que você administra. Clique em confirmar para aceitar ou cancelar para recusar vinculo.
-    </p>
-    <div layout="column">
-      <div layout="row" md-colors="{background: 'default-grey-200'}" layout-margin style="margin: 0 0 8px 0;">
-        <div>
-          <img style="width: 75px; height: 75px; border-radius: 50%;" ng-src="{{requestCtrl.parent.photo_url || 'app/images/institution.png'}}" 
-            alt="{{requestCtrl.parent.name}}"></img>
+  <div ng-if="!requestCtrl.warnPaternityExistence">
+    <md-dialog-content ng-if="!requestCtrl.isRejecting" class="md-dialog-content" layout-gt-sm="column" layout-padding>
+      <h4 style="margin: 0;">Confirmar Vínculo</h4>
+      <p style="margin: 0;">
+        Um usuário da plataforma solicitou vincular-se a uma das instituições que você administra. Clique em confirmar para aceitar ou cancelar para recusar vinculo.
+      </p>
+      <div layout="column">
+        <div layout="row" md-colors="{background: 'default-grey-200'}" layout-margin style="margin: 0 0 8px 0;">
+          <div>
+            <img style="width: 75px; height: 75px; border-radius: 50%;" ng-src="{{requestCtrl.parent.photo_url || 'app/images/institution.png'}}" 
+              alt="{{requestCtrl.parent.name}}"></img>
+          </div>
+          <div layout="column" layout-align="center start">
+            <b>{{ requestCtrl.parent.name }}</b>
+            <span>{{ requestCtrl.parent.email }}</span>
+          </div>
         </div>
-        <div layout="column" layout-align="center start">
-          <b>{{ requestCtrl.parent.name }}</b>
-          <span>{{ requestCtrl.parent.email }}</span>
+        <div layout="row">
+          <div flex="5" layout="row" layout-align="center">
+            <div style="width: 8px;" md-colors="{background: 'default-teal-500'}"></div>
+          </div>
+          <div layout="row" md-colors="{background: 'default-grey-200'}" layout-margin flex="95" style="margin: 0;">
+              <div>
+                <img style="width: 75px; height: 75px; border-radius: 50%;" ng-src="{{ requestCtrl.children.photo_url || 'app/images/avatar.png'}}"
+                  alt="{{ requestCtrl.children.name }}"></img>
+              </div>
+              <div layout="column" layout-align="center start">
+                <b>{{ requestCtrl.children.name || requestCtrl.children.sender_name}}</b>
+                <span>{{ requestCtrl.children.institutional_email }}</span>
+                <span>{{ requestCtrl.children.office }}</span>
+              </div>
+          </div>
         </div>
       </div>
-      <div layout="row">
-        <div flex="5" layout="row" layout-align="center">
-          <div style="width: 8px;" md-colors="{background: 'default-teal-500'}"></div>
+    </md-dialog-content>
+    <md-dialog-actions ng-if="!requestCtrl.isRejecting" layout="row" layout-align="end center" layout-wrap>
+      <md-button ng-click="requestCtrl.rejectRequest($event)" class="md-primary" md-colors="{color: 'default-teal-500'}">
+        Rejeitar
+      </md-button>
+      <md-button ng-click="requestCtrl.acceptRequest()" class="md-primary"
+        md-colors="{color: 'default-teal-500'}">
+        Confirmar
+      </md-button>
+    </md-dialog-actions>
+
+    <md-card-content ng-if="requestCtrl.isRejecting" class="md-dialog-content">
+      <h4 style="margin: 0;">Rejeitar Vínculo</h4>
+      <p>Tem certeza que deseja rejeitar?</p>
+    </md-card-content>
+    <md-dialog-actions ng-if="requestCtrl.isRejecting" layout="row" layout-align="end center" layout-wrap>
+      <md-button class="md-primary" ng-click="requestCtrl.cancelReject()"
+        md-colors="{color: 'default-teal-500'}">
+        Cancelar
+      </md-button>
+      <md-button class="md-primary" ng-click="requestCtrl.confirmReject()"
+        md-colors="{color: 'default-teal-500'}">
+        Confirmar
+      </md-button>
+    </md-dialog-actions>
+  </div>
+  <div ng-if="requestCtrl.warnPaternityExistence">
+    <md-dialog-content class="md-dialog-content" layout-gt-sm="column" layout-padding>
+      <h4 style="margin: 0;">Confirmar remoção de vínculo existente</h4>
+      <p style="margin: 0;">
+        Para aceitar o vínculo e tornar {{ requestCtrl.children.name }} uma subornadinada de {{ requestCtrl.parent.name }} 
+        você deve remover o vínculo já existente. Isso fará com que {{ requestCtrl.children.name }} perca toda a relação hierarquica 
+        com {{ requestCtrl.children.parent_institution.name }} e seus superiores.
+      </p>
+      <div layout="column">
+        <div layout="row" md-colors="{background: 'default-grey-200'}" layout-margin style="margin: 0 0 8px 0;">
+          <div>
+            <img style="width: 75px; height: 75px; border-radius: 50%;" ng-src="{{requestCtrl.children.parent_institution.photo_url || 'app/images/institution.png'}}"
+              alt="{{requestCtrl.children.parent_institution.name}}"></img>
+          </div>
+          <div layout="column" layout-align="center start">
+            <b>{{ requestCtrl.children.parent_institution.name }}</b>
+          </div>
         </div>
-        <div layout="row" md-colors="{background: 'default-grey-200'}" layout-margin flex="95" style="margin: 0;">
+        <div layout="row">
+          <div flex="5" layout="row" layout-align="center">
+            <div style="width: 8px;" md-colors="{background: 'default-teal-500'}"></div>
+          </div>
+          <div layout="row" md-colors="{background: 'default-grey-200'}" layout-margin flex="95" style="margin: 0;">
             <div>
               <img style="width: 75px; height: 75px; border-radius: 50%;" ng-src="{{ requestCtrl.children.photo_url || 'app/images/avatar.png'}}"
                 alt="{{ requestCtrl.children.name }}"></img>
@@ -29,32 +91,17 @@
               <span>{{ requestCtrl.children.institutional_email }}</span>
               <span>{{ requestCtrl.children.office }}</span>
             </div>
+          </div>
         </div>
       </div>
-    </div>
-  </md-dialog-content>
-  <md-dialog-actions ng-if="!requestCtrl.isRejecting" layout="row" layout-align="end center" layout-wrap>
-    <md-button ng-click="requestCtrl.rejectRequest($event)" class="md-primary" md-colors="{color: 'default-teal-500'}">
-      Rejeitar
-    </md-button>
-    <md-button ng-click="requestCtrl.acceptRequest()" class="md-primary"
-      md-colors="{color: 'default-teal-500'}">
-      Confirmar
-    </md-button>
-  </md-dialog-actions>
-
-  <md-card-content ng-if="requestCtrl.isRejecting" class="md-dialog-content">
-    <h4 style="margin: 0;">Rejeitar Vínculo</h4>
-    <p>Tem certeza que deseja rejeitar?</p>
-  </md-card-content>
-  <md-dialog-actions ng-if="requestCtrl.isRejecting" layout="row" layout-align="end center" layout-wrap>
-    <md-button class="md-primary" ng-click="requestCtrl.cancelReject()"
-      md-colors="{color: 'default-teal-500'}">
-      Cancelar
-    </md-button>
-    <md-button class="md-primary" ng-click="requestCtrl.confirmReject()"
-      md-colors="{color: 'default-teal-500'}">
-      Confirmar
-    </md-button>
-  </md-dialog-actions>
+    </md-dialog-content>
+    <md-dialog-actions layout="row" layout-align="end center" layout-wrap>
+      <md-button class="md-primary" ng-click="requestCtrl.rejectRequest()" md-colors="{color: 'default-teal-500'}">
+        Cancelar
+      </md-button>
+      <md-button class="md-primary" ng-click="requestCtrl.confirmLinkRemoval()" md-colors="{color: 'default-teal-500'}">
+        Remover
+      </md-button>
+    </md-dialog-actions>
+  </div>
 </md-dialog>


### PR DESCRIPTION
**Feature/Bug description:**
When a institution that has parent received a REQUEST_CHILDREN and the admin accept this the permissions of the previous parent admin weren't removed. 

**Solution:**
I've forked the flow in two steps: In the first one the user is warned that the previous link is gonna be removed. If he accepts it, the handler that removes the link is called and the permissions is gone too. In the second one the user answers about the new link.
**TODO/FIXME:** n/a