### PR TITLE
Remove member email

### DIFF
--- a/backend/handlers/institution_members_handler.py
+++ b/backend/handlers/institution_members_handler.py
@@ -56,23 +56,17 @@ class InstitutionMembersHandler(BaseHandler):
             )
 
         subject = get_subject('LINK_REMOVAL')
-        message = """Lamentamos informar que seu vínculo com a instituição %s
-        foi removido pelo administrador %s
-        """ % (institution.name, user.name)
-
         justification = self.request.get('justification')
 
-        if justification:
-            message = message + """pelo seguinte motivo:
-            '%s'
-            """ % (justification)
-
-        body = message + """
-        Equipe da Plataforma CIS
-        """
         email_sender = RemoveMemberEmailSender(**{
             'receiver': member.email,
             'subject': subject,
-            'body': body
+            'user_name': member.name,
+            'user_email': member.email[0],
+            'justification': justification,
+            'institution_name': institution.name,
+            'institution_admin': institution.admin.get().name,
+            'institution_email': institution.email,
+            'institution_key': institution.key.urlsafe()
         })
         email_sender.send_email()

--- a/backend/send_email_hierarchy/remove_member_email_sender.py
+++ b/backend/send_email_hierarchy/remove_member_email_sender.py
@@ -2,9 +2,39 @@
 
 from email_sender import EmailSender
 
+MAXIMUM_INSTITUTION_NAME = 29
+MAXIMUM_USER_NAME = 26
 
 class RemoveMemberEmailSender(EmailSender):
 
     def __init__(self, **kwargs):
+        """The class constructor.
+
+        It initializes the object with its html and its specific properties.
+        crop_institution_name is called to make sure that the names don't exceed the maximum allowed size.
+        """
         super(RemoveMemberEmailSender, self).__init__(**kwargs)
-        self.body = kwargs['body']
+        self.html = 'remove_member_email.html'
+        self.user_name = self.crop_name(kwargs['user_name'], MAXIMUM_USER_NAME)
+        self.user_email = self.crop_name(kwargs['user_email'], MAXIMUM_USER_NAME)
+        self.justification = kwargs['justification'] if 'justification' in kwargs else ''
+        self.institution_admin = self.crop_name(kwargs['institution_admin'], MAXIMUM_USER_NAME)
+        self.institution_name = self.crop_name(kwargs['institution_name'], MAXIMUM_INSTITUTION_NAME)
+        self.institution_email = self.crop_name(kwargs['institution_email'], MAXIMUM_INSTITUTION_NAME)
+        self.institution_key = kwargs['institution_key']
+
+    def send_email(self):
+        """It enqueue a sending email task with the json that will fill the entity's html.
+        
+        For that, it call its super with email_json property.
+        """
+        email_json = {
+            'user_name': self.user_name,
+            'user_email': self.user_email,
+            'justification': self.justification,
+            'institution_admin': self.institution_admin,
+            'institution_name': self.institution_name,
+            'institution_email': self.institution_email,
+            'institution_key': self.institution_key
+        }
+        super(RemoveMemberEmailSender, self).send_email(email_json)

--- a/backend/templates/rejected_request_user_email.html
+++ b/backend/templates/rejected_request_user_email.html
@@ -65,7 +65,7 @@
                                                 </div>
                                                 <div style="background-color: #E0E0E0; width: 90%; height: 50px; margin-top: 10px; ">
                                                     <div>
-                                                        <div style="float: left; background-color: #009688; width: 5px; height: 45px;">
+                                                        <div style="float: left; background-color: #009688; width: 5px; height: 50px;">
                                                         </div>
                                                         <div>
                                                             <img align="left" src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2Favatar.png?alt=media&token=c7ea2239-f178-424c-87be-16124c9f5933"

--- a/backend/templates/remove_member_email.html
+++ b/backend/templates/remove_member_email.html
@@ -8,7 +8,7 @@
 
     <title></title>
 </head>
-<body style="margin:0; padding:0;">
+<body style="margin:0; padding:0; height: 910px;">
     <table width="100%" border="0" cellpadding="0" cellspacing="0" align="center">
         <tr align="center">
             <td align="center">
@@ -26,20 +26,28 @@
                 <table width="100%" height="100%" border="0" cellpadding="0" cellspacing="0" align="center">
                     <tr>
                         <td>
-                            <div style="height: 490px;">
-                                <div style="background-color: #009688; height: 65%;" align="center">
-                                    <div style="height: 25%; background-color: #004D40;">
-                                        <div style="width: 275px; height: 460px; margin-top: 10px; border: 1px solid #E1E1E1;  background: #fff;
-                                        border-radius: 5px; display: inline-block; position: relative;" align="center">
+                            <div>
+                                <div style="background-color: #009688; height: 300px;" align="center">
+                                    <div style="height: 100px; background-color: #004D40;">
+                                        <div style="width: 275px; margin-top: 10px; border: 1px solid #E1E1E1;  background: #fff;
+                                        border-radius: 5px; display: inline-block;" align="center">
                                             <div style="height: 40%; background-color: #EEEEEE; border-top-left-radius: 10px; border-top-right-radius: 10px;">
-                                                <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2FAsset%203logo.png?alt=media&token=a92e7619-130f-4dbf-8c65-2f91261074c3"
-                                                    style="width: 100px; margin-top: 50px;" />
+                                                <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2FAsset%209logo.png?alt=media&token=c7d9da3a-c984-4747-bc47-29a307cee415"
+                                                    style="width: 100px; margin-top: 50px; margin-bottom: 20px;" />
                                             </div>
                                             <div style="background-color: white; font-size: 15px;">
                                                 <div style="color: #004D40; margin-top: 10px; padding: 0px 10px 0px 10px;">
                                                     <b>O ADMINISTRADOR DA INSTITUIÇÃO REMOVEU SEU VÍNCULO</b>
                                                 </div>
                                                 <hr width="80%;" />
+                                                <div style="margin-top: 10px; padding: 0px 10px 0px 10px; word-wrap:break-word">
+                                                    Justificativa do administrador: 
+                                                    <p>
+                                                        {%- if justification|length > 0 -%} {{justification}}{% endif %}
+                                                        {%- if justification|length == 0 -%} Não foi informada.{% endif %}
+                                                    </p>
+                                                    
+                                                </div>
                                                 <div style="background-color: #E0E0E0; width: 90%; height: 50px; margin-top: 15px; margin-bottom: 5px;">
                                                     <div>
                                                         <div>
@@ -49,13 +57,13 @@
                                                         </div>
                                                         <div align="left" valign="middle" style="margin-left: 50px; padding-top: 4px;">
                                                             <div style="height: 11px;">
-                                                                <b style="font-size: 12px; color: black;">{{institution_requested_name}}</b>
+                                                                <b style="font-size: 12px; color: black;">{{institution_name}}</b>
                                                             </div>
                                                             <div style="height: 10px; margin-top: 2px;">
-                                                                <span style="font-size: 9px; color: black;">{{institution_requested_email}}</span>
+                                                                <span style="font-size: 9px; color: black;">{{institution_email}}</span>
                                                             </div>
                                                             <div style="height: 10px; margin-top: 2px;">
-                                                                <span style="font-size: 9px; color: black;">Administrada por: {{institution_requested_admin}}</span>
+                                                                <span style="font-size: 9px; color: black;">Administrada por: {{institution_admin}}</span>
                                                             </div>
                                                         </div>
                                                     </div>
@@ -75,14 +83,11 @@
                                                             <div style="height: 10px; ">
                                                                 <span style="font-size: 9px; color: black;">{{user_email}}</span>
                                                             </div>
-                                                            <div style="height: 10px; ">
-                                                                <span style="font-size: 9px; color: black;">Cargo: {{office}}</span>
-                                                            </div>
                                                         </div>
                                                     </div>
                                                 </div>
-                                                <div style="margin-top: 15px;">
-                                                    <a href="http://frontend.plataformacis.org/" style="text-decoration: none;">
+                                                <div style="margin-top: 15px; margin-bottom: 15px;">
+                                                    <a href="http://frontend.plataformacis.org/institution/{{institution_requested_key}}" style="text-decoration: none;">
                                                         <button style="background-color: #009688; width: 90%; height: 25px; border: none;">                                                         
                                                             <span style="text-align: center; font-size: 8px; color: #FFFFFF">ACESSAR A PLATAFORMA</span>
                                                         </button>    
@@ -90,89 +95,55 @@
                                                 </div>
                                             </div>
                                         </div>
+                                        <table width="100%" border="0" cellpadding="0" cellspacing="0" align="center" style="margin-top: 15px;margin-bottom: 5px;">
+                                            <tr align="center">
+                                                <td>
+                                                    <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2FLOGo.png?alt=media&token=fbb74261-4b24-42aa-b67f-be36577c48df"
+                                                        style="width: 50px; height: 50px;"/>
+                                                    <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2FAsset_09LOGO.png?alt=media&token=a33e8fc2-95d4-4b74-ae95-c6f50514645e"
+                                                        style="width: 150px; padding-bottom: 10px;"> 
+                                                </td>
+                                            </tr>
+                                        </table>
+                                        <table width="100%" border="0" cellpadding="0" cellspacing="0" align="center">
+                                            <tr align="center">
+                                                <td style="width: 100%;">
+                                                    <div style="width: 100%; height: 160px; border-top: 1px solid #E0E0E0; border-bottom: 1px solid #E1E1E1; background: #fff;
+                                                    border-radius: 0px;
+                                                    display: inline-block;" align="center">
+                                                        <div style="height: 50%; background-color: white;">
+                                                            <div>
+                                                                <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2Fufcg.png?alt=media&token=6edbaf3e-3c46-4e8a-8101-80d432d1ab6f"
+                                                                    style="width: 100px; margin-top: 5px;" />
+                                                                <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2Fcis.png?alt=media&token=ccab7007-97b0-462b-a1d0-38b5da58a2ad"
+                                                                    style="width: 100px; margin-top: 5px; margin-left: 20px;" />
+                                                            </div>
+                                                            <div>
+                                                                <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2Fopasoms.png?alt=media&token=a71b5c27-a317-417e-aa6e-3c744ed0e602"
+                                                                    style="width: 220px; margin-top: 5px;" />
+                                                            </div>
+                                                            <div>
+                                                                <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2Fbr.png?alt=media&token=22012e23-60ad-4e63-969c-76e9000343f3"
+                                                                    style="width: 150px; margin-top: 10px;" />
+                                                            </div>
+                                                            <div style="margin-top: 23px; font-size: 10px;">
+                                                                <span align="center" style="word-break: break-all; color: black;">
+                                                                    Copyright © 2017 Plataforma CIS - Ministério da Saúde.
+                                                                </span>
+                                                            </div>
+                                                            <div>
+                                                                <span style="font-size: 10px; color: black;">
+                                                                    Todos os direitos reservados.
+                                                                </span>
+                                                            </div>
+                                                        </div>
+                                                        <div style="height: 50%; background-color: white;">
+                                                        </div>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        </table>
                                     </div>
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                </table>
-
-                <table width="100%" height="100%" border="0" cellpadding="0" cellspacing="0" align="center" style="padding-bottom: 10px;">
-                    <tr align="center">
-                        <td>
-                            <div style="width: 275px; height: 440px; border: 1px solid #E1E1E1; background: #fff;
-                            border-radius: 5px; display: inline-block; position: relative;" align="center">
-                                <div style="color: #00796B; margin-top: 10px; font-size: 20px; padding: 10px 15px 0px 15px;">
-                                    <b>CONHEÇA A PLATAFORMA</b>
-                                </div>
-                                <div>
-                                    <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2FLOGo.png?alt=media&token=fbb74261-4b24-42aa-b67f-be36577c48df"
-                                        style="width: 100px; margin-top: 10px;" />
-                                </div>
-                                <div style="height: 248px;">
-                                    <p style="font-size: 25px; text-align: center; color: #BDBDBD; width: 95%;">
-                                        <b>Plataforma Virtual do Complexo Indústrial da Saúde</b>
-                                    </p>
-                                    <p style="font-size: 12px; color: black; margin-left: 2px; margin-right: 2px; margin-top: -5px;">A Plataforma Virtual do Complexo Industrial da Saúde (CIS) é uma ferramenta criada
-                                        para favorecer a interlocução, articulação, discussão, proposições de medidas e ações
-                                        sobre o Complexo Industrial da Saúde (CIS).</p>
-                                    <div style="margin-top: 8px;">
-                                        <a href="https://plataformacis.org/" style="text-decoration: none;">
-                                            <button style="background-color: #009688; width: 90%; height: 25px; border: none; margin-bottom: 5px;">
-                                                    <span style="text-align: center; font-size: 8px; color: #FFFFFF">CONFIRA AS FUNCIONALIDADES</span>
-                                            </button>
-                                        </a>
-                                    </div>
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                </table>
-
-                <table width="100%" border="0" cellpadding="0" cellspacing="0" align="center" style="margin-bottom: 5px;">
-                    <tr align="center">
-                        <td>
-                            <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2FLOGo.png?alt=media&token=fbb74261-4b24-42aa-b67f-be36577c48df"
-                                style="width: 50px; height: 50px;"/>
-                            <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2FAsset_09LOGO.png?alt=media&token=a33e8fc2-95d4-4b74-ae95-c6f50514645e"
-                                style="width: 150px; padding-bottom: 10px;"> 
-                        </td>
-                    </tr>
-                </table>
-
-                <table width="100%" border="0" cellpadding="0" cellspacing="0" align="center">
-                    <tr align="center">
-                        <td style="width: 100%;">
-                            <div style="width: 100%; height: 160px; position: relative; border-top: 1px solid #E0E0E0; border-bottom: 1px solid #E1E1E1; background: #fff;
-                            border-radius: 0px;
-                            display: inline-block; position: relative;" align="center">
-                                <div style="height: 50%; background-color: white;">
-                                    <div>
-                                        <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2Fufcg.png?alt=media&token=6edbaf3e-3c46-4e8a-8101-80d432d1ab6f"
-                                            style="width: 100px; margin-top: 5px;" />
-                                        <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2Fcis.png?alt=media&token=ccab7007-97b0-462b-a1d0-38b5da58a2ad"
-                                            style="width: 100px; margin-top: 5px; margin-left: 20px;" />
-                                    </div>
-                                    <div>
-                                        <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2Fopasoms.png?alt=media&token=a71b5c27-a317-417e-aa6e-3c744ed0e602"
-                                            style="width: 220px; margin-top: 5px;" />
-                                    </div>
-                                    <div>
-                                        <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2Fbr.png?alt=media&token=22012e23-60ad-4e63-969c-76e9000343f3"
-                                            style="width: 150px; margin-top: 10px;" />
-                                    </div>
-                                    <div style="margin-top: 23px; font-size: 10px;">
-                                        <span align="center" style="word-break: break-all; color: black;">
-                                            Copyright © 2017 Plataforma CIS - Ministério da Saúde.
-                                        </span>
-                                    </div>
-                                    <div>
-                                        <span style="font-size: 10px; color: black;">
-                                            Todos os direitos reservados.
-                                        </span>
-                                    </div>
-                                </div>
-                                <div style="height: 50%; background-color: white;">
                                 </div>
                             </div>
                         </td>

--- a/backend/templates/remove_member_email.html
+++ b/backend/templates/remove_member_email.html
@@ -1,0 +1,186 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html lang="en">
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <title></title>
+</head>
+<body style="margin:0; padding:0;">
+    <table width="100%" border="0" cellpadding="0" cellspacing="0" align="center">
+        <tr align="center">
+            <td align="center">
+                <table width="100%" border="0" cellpadding="0" cellspacing="0" align="center" style="background-color: #004D40;">
+                    <tr align="center">
+                        <td>
+                            <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2FLOGo.png?alt=media&token=fbb74261-4b24-42aa-b67f-be36577c48df"
+                                style="width: 50px; padding-top: 20px; height: 50px;" />
+                            <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2Fasset_09_logo_white.png?alt=media&token=5fa33bc3-140a-4f71-90ff-5d1e9203a196"
+                                style="width: 150px; padding-bottom: 10px;" />
+                        </td>
+                    </tr>
+                </table>
+
+                <table width="100%" height="100%" border="0" cellpadding="0" cellspacing="0" align="center">
+                    <tr>
+                        <td>
+                            <div style="height: 490px;">
+                                <div style="background-color: #009688; height: 65%;" align="center">
+                                    <div style="height: 25%; background-color: #004D40;">
+                                        <div style="width: 275px; height: 460px; margin-top: 10px; border: 1px solid #E1E1E1;  background: #fff;
+                                        border-radius: 5px; display: inline-block; position: relative;" align="center">
+                                            <div style="height: 40%; background-color: #EEEEEE; border-top-left-radius: 10px; border-top-right-radius: 10px;">
+                                                <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2FAsset%203logo.png?alt=media&token=a92e7619-130f-4dbf-8c65-2f91261074c3"
+                                                    style="width: 100px; margin-top: 50px;" />
+                                            </div>
+                                            <div style="background-color: white; font-size: 15px;">
+                                                <div style="color: #004D40; margin-top: 10px; padding: 0px 10px 0px 10px;">
+                                                    <b>O ADMINISTRADOR DA INSTITUIÇÃO REMOVEU SEU VÍNCULO</b>
+                                                </div>
+                                                <hr width="80%;" />
+                                                <div style="background-color: #E0E0E0; width: 90%; height: 50px; margin-top: 15px; margin-bottom: 5px;">
+                                                    <div>
+                                                        <div>
+                                                            <img align="left" src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2F2.png?alt=media&token=e19cea6d-ff42-44cb-ae55-4caa4230785b"
+                                                                style="height: 35px; width: 35px; margin-top: 5px; margin-left: 5px;"
+                                                            />
+                                                        </div>
+                                                        <div align="left" valign="middle" style="margin-left: 50px; padding-top: 4px;">
+                                                            <div style="height: 11px;">
+                                                                <b style="font-size: 12px; color: black;">{{institution_requested_name}}</b>
+                                                            </div>
+                                                            <div style="height: 10px; margin-top: 2px;">
+                                                                <span style="font-size: 9px; color: black;">{{institution_requested_email}}</span>
+                                                            </div>
+                                                            <div style="height: 10px; margin-top: 2px;">
+                                                                <span style="font-size: 9px; color: black;">Administrada por: {{institution_requested_admin}}</span>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                <div style="background-color: #E0E0E0; width: 90%; height: 50px; margin-top: 10px; ">
+                                                    <div>
+                                                        <div style="float: left; background-color: #009688; width: 5px; height: 50px;">
+                                                        </div>
+                                                        <div>
+                                                            <img align="left" src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2Favatar.png?alt=media&token=c7ea2239-f178-424c-87be-16124c9f5933"
+                                                                style="height: 35px; width: 35px; margin-top: 5px; margin-left: 5px;" />
+                                                        </div>
+                                                        <div align="left" valign="middle" style="padding-top: 4px; margin-left: 50px;">
+                                                            <div style="height: 11px;">
+                                                                <b style="font-size: 12px; word-break: break-all">{{user_name}}</b>
+                                                            </div>
+                                                            <div style="height: 10px; ">
+                                                                <span style="font-size: 9px; color: black;">{{user_email}}</span>
+                                                            </div>
+                                                            <div style="height: 10px; ">
+                                                                <span style="font-size: 9px; color: black;">Cargo: {{office}}</span>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                <div style="margin-top: 15px;">
+                                                    <a href="http://frontend.plataformacis.org/" style="text-decoration: none;">
+                                                        <button style="background-color: #009688; width: 90%; height: 25px; border: none;">                                                         
+                                                            <span style="text-align: center; font-size: 8px; color: #FFFFFF">ACESSAR A PLATAFORMA</span>
+                                                        </button>    
+                                                    </a>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+
+                <table width="100%" height="100%" border="0" cellpadding="0" cellspacing="0" align="center" style="padding-bottom: 10px;">
+                    <tr align="center">
+                        <td>
+                            <div style="width: 275px; height: 440px; border: 1px solid #E1E1E1; background: #fff;
+                            border-radius: 5px; display: inline-block; position: relative;" align="center">
+                                <div style="color: #00796B; margin-top: 10px; font-size: 20px; padding: 10px 15px 0px 15px;">
+                                    <b>CONHEÇA A PLATAFORMA</b>
+                                </div>
+                                <div>
+                                    <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2FLOGo.png?alt=media&token=fbb74261-4b24-42aa-b67f-be36577c48df"
+                                        style="width: 100px; margin-top: 10px;" />
+                                </div>
+                                <div style="height: 248px;">
+                                    <p style="font-size: 25px; text-align: center; color: #BDBDBD; width: 95%;">
+                                        <b>Plataforma Virtual do Complexo Indústrial da Saúde</b>
+                                    </p>
+                                    <p style="font-size: 12px; color: black; margin-left: 2px; margin-right: 2px; margin-top: -5px;">A Plataforma Virtual do Complexo Industrial da Saúde (CIS) é uma ferramenta criada
+                                        para favorecer a interlocução, articulação, discussão, proposições de medidas e ações
+                                        sobre o Complexo Industrial da Saúde (CIS).</p>
+                                    <div style="margin-top: 8px;">
+                                        <a href="https://plataformacis.org/" style="text-decoration: none;">
+                                            <button style="background-color: #009688; width: 90%; height: 25px; border: none; margin-bottom: 5px;">
+                                                    <span style="text-align: center; font-size: 8px; color: #FFFFFF">CONFIRA AS FUNCIONALIDADES</span>
+                                            </button>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+
+                <table width="100%" border="0" cellpadding="0" cellspacing="0" align="center" style="margin-bottom: 5px;">
+                    <tr align="center">
+                        <td>
+                            <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2FLOGo.png?alt=media&token=fbb74261-4b24-42aa-b67f-be36577c48df"
+                                style="width: 50px; height: 50px;"/>
+                            <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2FAsset_09LOGO.png?alt=media&token=a33e8fc2-95d4-4b74-ae95-c6f50514645e"
+                                style="width: 150px; padding-bottom: 10px;"> 
+                        </td>
+                    </tr>
+                </table>
+
+                <table width="100%" border="0" cellpadding="0" cellspacing="0" align="center">
+                    <tr align="center">
+                        <td style="width: 100%;">
+                            <div style="width: 100%; height: 160px; position: relative; border-top: 1px solid #E0E0E0; border-bottom: 1px solid #E1E1E1; background: #fff;
+                            border-radius: 0px;
+                            display: inline-block; position: relative;" align="center">
+                                <div style="height: 50%; background-color: white;">
+                                    <div>
+                                        <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2Fufcg.png?alt=media&token=6edbaf3e-3c46-4e8a-8101-80d432d1ab6f"
+                                            style="width: 100px; margin-top: 5px;" />
+                                        <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2Fcis.png?alt=media&token=ccab7007-97b0-462b-a1d0-38b5da58a2ad"
+                                            style="width: 100px; margin-top: 5px; margin-left: 20px;" />
+                                    </div>
+                                    <div>
+                                        <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2Fopasoms.png?alt=media&token=a71b5c27-a317-417e-aa6e-3c744ed0e602"
+                                            style="width: 220px; margin-top: 5px;" />
+                                    </div>
+                                    <div>
+                                        <img src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2Fbr.png?alt=media&token=22012e23-60ad-4e63-969c-76e9000343f3"
+                                            style="width: 150px; margin-top: 10px;" />
+                                    </div>
+                                    <div style="margin-top: 23px; font-size: 10px;">
+                                        <span align="center" style="word-break: break-all; color: black;">
+                                            Copyright © 2017 Plataforma CIS - Ministério da Saúde.
+                                        </span>
+                                    </div>
+                                    <div>
+                                        <span style="font-size: 10px; color: black;">
+                                            Todos os direitos reservados.
+                                        </span>
+                                    </div>
+                                </div>
+                                <div style="height: 50%; background-color: white;">
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+
+</html>

--- a/backend/templates/request_user_email.html
+++ b/backend/templates/request_user_email.html
@@ -66,7 +66,7 @@
                                                 </div>
                                                 <div style="background-color: #E0E0E0; width: 90%; height: 50px; margin-top: 10px; ">
                                                     <div>
-                                                        <div style="float: left; background-color: #009688; width: 5px; height: 45px;">
+                                                        <div style="float: left; background-color: #009688; width: 5px; height: 50px;">
                                                         </div>
                                                         <div>
                                                             <img align="left" src="https://firebasestorage.googleapis.com/v0/b/eciis-splab.appspot.com/o/admin_email%2Favatar.png?alt=media&token=c7ea2239-f178-424c-87be-16124c9f5933"

--- a/frontend/institution/removeMemberDialog.html
+++ b/frontend/institution/removeMemberDialog.html
@@ -18,7 +18,7 @@
       <form name="saveForm" style="margin: 2em 0 -1em 0">
         <b>Motivo da remoção <b style="font-size: 10px;">(Opcional)</b></b>
         <md-input-container class="md-block">
-          <textarea placeholder="Escreva aqui" name="message" 
+          <textarea placeholder="Escreva aqui" name="message" maxlength="140" md-maxlength="140"
             ng-model="removeMemberCtrl.justification" style="border-color: #004D40;">
           </textarea>
         </md-input-container>


### PR DESCRIPTION
**Feature/Bug description:** When administration removes the member, it can place the justification text with undefined size and the old member will receive the email that was with the old design.

**Solution:** Changed layout of email, and defined length to justification in the frontend.

**TODO/FIXME:** n/a

![screenshot from 2018-05-18 13-50-59](https://user-images.githubusercontent.com/18709274/40247589-4d98479a-5aa3-11e8-817d-660591bc0f71.png)

**Hotmail:**
![screenshot from 2018-05-18 13-56-12](https://user-images.githubusercontent.com/18709274/40247664-84df1b0c-5aa3-11e8-9c8c-faf91c297315.png)
![screenshot from 2018-05-18 13-56-22](https://user-images.githubusercontent.com/18709274/40247669-86a16210-5aa3-11e8-91cd-2c610938dc8d.png)

**Gmail:**
![captura de tela de 2018-05-18 13-49-39](https://user-images.githubusercontent.com/18709274/40247687-9555f8a2-5aa3-11e8-8eb6-ac09d4720fd3.png)
![captura de tela de 2018-05-18 13-50-06](https://user-images.githubusercontent.com/18709274/40247692-9d1fed68-5aa3-11e8-95bd-5ddc55c80a80.png)

