### PR TITLE
Refact search modules imports

### DIFF
--- a/backend/handlers/search_handler.py
+++ b/backend/handlers/search_handler.py
@@ -6,7 +6,7 @@ from utils import json_response
 import json
 
 from . import BaseHandler
-from search_module.search_user import SearchUser
+from search_module import SearchUser
 from search_module import SearchInstitution
 
 __all__ = ['SearchHandler']

--- a/backend/handlers/search_handler.py
+++ b/backend/handlers/search_handler.py
@@ -7,7 +7,7 @@ import json
 
 from . import BaseHandler
 from search_module.search_user import SearchUser
-from search_module.search_institution import SearchInstitution
+from search_module import SearchInstitution
 
 __all__ = ['SearchHandler']
 

--- a/backend/models/institution.py
+++ b/backend/models/institution.py
@@ -2,7 +2,7 @@
 
 from google.appengine.ext import ndb
 
-from search_module.search_institution import SearchInstitution
+from search_module import SearchInstitution
 from models import Address
 from permissions import DEFAULT_ADMIN_PERMISSIONS
 from permissions import DEFAULT_SUPER_USER_PERMISSIONS

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,5 +1,5 @@
 """User Model."""
-from search_module.search_user import SearchUser
+from search_module import SearchUser
 from google.appengine.ext import ndb
 from custom_exceptions.fieldException import FieldException
 from custom_exceptions.notAuthorizedException import NotAuthorizedException

--- a/backend/search_module/__init__.py
+++ b/backend/search_module/__init__.py
@@ -1,7 +1,8 @@
 """Initialize search modules."""
 from .search_document import *
+from .search_institution import *
 
 
-search_modules = [search_document]
+search_modules = [search_document, search_institution]
 
 __all__ = [prop for search_module in search_modules for prop in search_module.__all__]

--- a/backend/search_module/__init__.py
+++ b/backend/search_module/__init__.py
@@ -1,8 +1,9 @@
 """Initialize search modules."""
 from .search_document import *
 from .search_institution import *
+from .search_user import *
 
 
-search_modules = [search_document, search_institution]
+search_modules = [search_document, search_institution, search_user]
 
 __all__ = [prop for search_module in search_modules for prop in search_module.__all__]

--- a/backend/search_module/__init__.py
+++ b/backend/search_module/__init__.py
@@ -1,0 +1,7 @@
+"""Initialize search modules."""
+from .search_document import *
+
+
+search_modules = [search_document]
+
+__all__ = [prop for search_module in search_modules for prop in search_module.__all__]

--- a/backend/search_module/search_document.py
+++ b/backend/search_module/search_document.py
@@ -6,6 +6,7 @@ from google.appengine.api import search
 
 import logging
 
+__all__ = ['SearchDocument']
 
 def has_changes(fields, entity):
     """It returns True when there is a change

--- a/backend/search_module/search_institution.py
+++ b/backend/search_module/search_institution.py
@@ -4,6 +4,7 @@
 from google.appengine.api import search
 from . import SearchDocument
 
+__all__ = ['SearchInstitution']
 
 def institution_has_changes(fields, entity):
         """It returns True when there is a change

--- a/backend/search_module/search_institution.py
+++ b/backend/search_module/search_institution.py
@@ -2,7 +2,7 @@
 """Search Institution."""
 
 from google.appengine.api import search
-from search_document import SearchDocument
+from . import SearchDocument
 
 
 def institution_has_changes(fields, entity):

--- a/backend/search_module/search_user.py
+++ b/backend/search_module/search_user.py
@@ -2,7 +2,7 @@
 """Search User."""
 
 from google.appengine.api import search
-from search_document import SearchDocument
+from . import SearchDocument
 
 
 class SearchUser(SearchDocument):

--- a/backend/search_module/search_user.py
+++ b/backend/search_module/search_user.py
@@ -4,6 +4,7 @@
 from google.appengine.api import search
 from . import SearchDocument
 
+__all__ = ['SearchUser']
 
 class SearchUser(SearchDocument):
     """Search user's model."""

--- a/backend/test/invite_handler_test.py
+++ b/backend/test/invite_handler_test.py
@@ -5,7 +5,7 @@ import json
 import mocks
 
 from test_base_handler import TestBaseHandler
-from search_module.search_institution import SearchInstitution
+from search_module import SearchInstitution
 from models import InviteUser
 from models import Invite
 from models import InviteInstitution

--- a/backend/test/resend_invite_handler_test.py
+++ b/backend/test/resend_invite_handler_test.py
@@ -2,7 +2,7 @@
 """Resend Invite Handler Test."""
 
 import json
-from search_module.search_institution import SearchInstitution
+from search_module import SearchInstitution
 from test_base_handler import TestBaseHandler
 from models import User
 from models import Institution


### PR DESCRIPTION
**Feature/Bug description:** The search modules imports made in the backend are extensive and difficult to read.
Example:

```python
from search_module.search_institution import SearchInstitution
```

**Solution:** I set up the __init__.py file so that it recognizes all packet models by simplifying imports and making reading easier.
Example:

```python
from search_module import SearchInstitution
```

**Refactored search modules:**

* SearchDocument
* SearchInstitution
* SearchUser

**TODO/FIXME:** n/a