### PR TITLE
Refact send email hierarchy modules import

### DIFF
--- a/backend/handlers/institution_hierarchy_handler.py
+++ b/backend/handlers/institution_hierarchy_handler.py
@@ -8,7 +8,7 @@ from util.login_service import login_required
 from utils import json_response
 from custom_exceptions.notAuthorizedException import NotAuthorizedException
 from custom_exceptions.entityException import EntityException
-from send_email_hierarchy.request_link_email_sender import RequestLinkEmailSender
+from send_email_hierarchy import RequestLinkEmailSender
 
 from models import Institution
 

--- a/backend/handlers/institution_members_handler.py
+++ b/backend/handlers/institution_members_handler.py
@@ -9,7 +9,7 @@ from utils import Utils
 from utils import json_response
 from util.strings_pt_br import get_subject
 from service_messages import send_message_notification
-from send_email_hierarchy.remove_member_email_sender import RemoveMemberEmailSender
+from send_email_hierarchy import RemoveMemberEmailSender
 
 from . import BaseHandler
 

--- a/backend/handlers/user_institutions_handler.py
+++ b/backend/handlers/user_institutions_handler.py
@@ -7,7 +7,7 @@ import json
 from util.login_service import login_required
 from utils import Utils
 from utils import json_response
-from send_email_hierarchy.leave_institution_email_sender import LeaveInstitutionEmailSender
+from send_email_hierarchy import LeaveInstitutionEmailSender
 from util.strings_pt_br import get_subject 
 
 from . import BaseHandler

--- a/backend/models/invite.py
+++ b/backend/models/invite.py
@@ -4,7 +4,7 @@ from google.appengine.ext import ndb
 from google.appengine.ext.ndb.polymodel import PolyModel
 from service_messages import send_message_notification
 from service_messages import create_message
-from send_email_hierarchy.email_sender import EmailSender
+from send_email_hierarchy import EmailSender
 from . import User       
 from util.strings_pt_br import get_subject      
 

--- a/backend/models/invite_institution.py
+++ b/backend/models/invite_institution.py
@@ -3,7 +3,7 @@ from . import Invite
 from . import Institution
 from custom_exceptions.fieldException import FieldException
 from . import User
-from send_email_hierarchy.invite_institution_email_sender import InviteInstitutionEmailSender
+from send_email_hierarchy import InviteInstitutionEmailSender
 from util.strings_pt_br import get_subject
 
 __all__ = ['InviteInstitution']

--- a/backend/models/invite_user.py
+++ b/backend/models/invite_user.py
@@ -4,7 +4,7 @@ from google.appengine.ext import ndb
 from custom_exceptions.fieldException import FieldException
 from . import User
 from . import Institution
-from send_email_hierarchy.invite_user_email_sender import InviteUserEmailSender
+from send_email_hierarchy import InviteUserEmailSender
 from util.strings_pt_br import get_subject
 
 __all__ = ['InviteUser']

--- a/backend/models/request_institution.py
+++ b/backend/models/request_institution.py
@@ -6,7 +6,7 @@ from . import Request
 from google.appengine.ext import ndb
 from util.provider_institutions import get_deciis
 from custom_exceptions.fieldException import FieldException
-from send_email_hierarchy.accepted_institution_email_sender import AcceptedInstitutionEmailSender
+from send_email_hierarchy import AcceptedInstitutionEmailSender
 
 
 __all__ = ['RequestInstitution']

--- a/backend/models/request_institution_children.py
+++ b/backend/models/request_institution_children.py
@@ -4,7 +4,7 @@
 from . import Invite
 from . import Request
 from google.appengine.ext import ndb
-from send_email_hierarchy.request_link_email_sender import RequestLinkEmailSender
+from send_email_hierarchy import RequestLinkEmailSender
 from util.strings_pt_br import get_subject
 
 __all__ = ['RequestInstitutionChildren']

--- a/backend/models/request_institution_parent.py
+++ b/backend/models/request_institution_parent.py
@@ -4,7 +4,7 @@
 from . import Invite
 from . import Request
 from google.appengine.ext import ndb
-from send_email_hierarchy.request_link_email_sender import RequestLinkEmailSender
+from send_email_hierarchy import RequestLinkEmailSender
 from util.strings_pt_br import get_subject
 
 __all__ = ['RequestInstitutionParent']

--- a/backend/models/request_user.py
+++ b/backend/models/request_user.py
@@ -5,7 +5,7 @@ from google.appengine.ext import ndb
 from custom_exceptions.fieldException import FieldException
 from . import Institution
 from . import Request
-from send_email_hierarchy.request_user_email_sender import RequestUserEmailSender
+from send_email_hierarchy import RequestUserEmailSender
 from util.strings_pt_br import get_subject
 
 

--- a/backend/send_email_hierarchy/__init__.py
+++ b/backend/send_email_hierarchy/__init__.py
@@ -7,12 +7,14 @@ from .invite_user_email_sender import *
 from .leave_institution_email_sender import *
 from .remove_institution_email_sender import *
 from .remove_member_email_sender import *
+from .request_link_email_sender import *
 
 
 email_modules = [
     email_sender, accepted_institution_email_sender, invite_institution_email_sender,
     invite_user_email_sender, leave_institution_email_sender,
-    remove_institution_email_sender, remove_member_email_sender
+    remove_institution_email_sender, remove_member_email_sender,
+    request_link_email_sender
 ]
 
 __all__ = [prop for email_module in email_modules for prop in email_module.__all__]

--- a/backend/send_email_hierarchy/__init__.py
+++ b/backend/send_email_hierarchy/__init__.py
@@ -1,8 +1,9 @@
 """Initialize send email hierarchy modules."""
 
 from .email_sender import *
+from .accepted_institution_email_sender import *
 
 
-email_modules = [email_sender]
+email_modules = [email_sender, accepted_institution_email_sender]
 
 __all__ = [prop for email_module in email_modules for prop in email_module.__all__]

--- a/backend/send_email_hierarchy/__init__.py
+++ b/backend/send_email_hierarchy/__init__.py
@@ -2,8 +2,11 @@
 
 from .email_sender import *
 from .accepted_institution_email_sender import *
+from .invite_institution_email_sender import *
 
 
-email_modules = [email_sender, accepted_institution_email_sender]
+email_modules = [
+    email_sender, accepted_institution_email_sender, invite_institution_email_sender
+]
 
 __all__ = [prop for email_module in email_modules for prop in email_module.__all__]

--- a/backend/send_email_hierarchy/__init__.py
+++ b/backend/send_email_hierarchy/__init__.py
@@ -8,13 +8,14 @@ from .leave_institution_email_sender import *
 from .remove_institution_email_sender import *
 from .remove_member_email_sender import *
 from .request_link_email_sender import *
+from .request_user_email_sender import *
 
 
 email_modules = [
     email_sender, accepted_institution_email_sender, invite_institution_email_sender,
     invite_user_email_sender, leave_institution_email_sender,
     remove_institution_email_sender, remove_member_email_sender,
-    request_link_email_sender
+    request_link_email_sender, request_user_email_sender
 ]
 
 __all__ = [prop for email_module in email_modules for prop in email_module.__all__]

--- a/backend/send_email_hierarchy/__init__.py
+++ b/backend/send_email_hierarchy/__init__.py
@@ -6,12 +6,13 @@ from .invite_institution_email_sender import *
 from .invite_user_email_sender import *
 from .leave_institution_email_sender import *
 from .remove_institution_email_sender import *
+from .remove_member_email_sender import *
 
 
 email_modules = [
     email_sender, accepted_institution_email_sender, invite_institution_email_sender,
     invite_user_email_sender, leave_institution_email_sender,
-    remove_institution_email_sender
+    remove_institution_email_sender, remove_member_email_sender
 ]
 
 __all__ = [prop for email_module in email_modules for prop in email_module.__all__]

--- a/backend/send_email_hierarchy/__init__.py
+++ b/backend/send_email_hierarchy/__init__.py
@@ -5,11 +5,13 @@ from .accepted_institution_email_sender import *
 from .invite_institution_email_sender import *
 from .invite_user_email_sender import *
 from .leave_institution_email_sender import *
+from .remove_institution_email_sender import *
 
 
 email_modules = [
     email_sender, accepted_institution_email_sender, invite_institution_email_sender,
-    invite_user_email_sender, leave_institution_email_sender
+    invite_user_email_sender, leave_institution_email_sender,
+    remove_institution_email_sender
 ]
 
 __all__ = [prop for email_module in email_modules for prop in email_module.__all__]

--- a/backend/send_email_hierarchy/__init__.py
+++ b/backend/send_email_hierarchy/__init__.py
@@ -4,11 +4,12 @@ from .email_sender import *
 from .accepted_institution_email_sender import *
 from .invite_institution_email_sender import *
 from .invite_user_email_sender import *
+from .leave_institution_email_sender import *
 
 
 email_modules = [
     email_sender, accepted_institution_email_sender, invite_institution_email_sender,
-    invite_user_email_sender
+    invite_user_email_sender, leave_institution_email_sender
 ]
 
 __all__ = [prop for email_module in email_modules for prop in email_module.__all__]

--- a/backend/send_email_hierarchy/__init__.py
+++ b/backend/send_email_hierarchy/__init__.py
@@ -1,0 +1,8 @@
+"""Initialize send email hierarchy modules."""
+
+from .email_sender import *
+
+
+email_modules = [email_sender]
+
+__all__ = [prop for email_module in email_modules for prop in email_module.__all__]

--- a/backend/send_email_hierarchy/__init__.py
+++ b/backend/send_email_hierarchy/__init__.py
@@ -3,10 +3,12 @@
 from .email_sender import *
 from .accepted_institution_email_sender import *
 from .invite_institution_email_sender import *
+from .invite_user_email_sender import *
 
 
 email_modules = [
-    email_sender, accepted_institution_email_sender, invite_institution_email_sender
+    email_sender, accepted_institution_email_sender, invite_institution_email_sender,
+    invite_user_email_sender
 ]
 
 __all__ = [prop for email_module in email_modules for prop in email_module.__all__]

--- a/backend/send_email_hierarchy/accepted_institution_email_sender.py
+++ b/backend/send_email_hierarchy/accepted_institution_email_sender.py
@@ -1,6 +1,6 @@
 """Accepted institution email sender model."""
 
-from email_sender import EmailSender
+from . import EmailSender
 
 
 class AcceptedInstitutionEmailSender(EmailSender):

--- a/backend/send_email_hierarchy/accepted_institution_email_sender.py
+++ b/backend/send_email_hierarchy/accepted_institution_email_sender.py
@@ -2,6 +2,7 @@
 
 from . import EmailSender
 
+__all__ = ['AcceptedInstitutionEmailSender']
 
 class AcceptedInstitutionEmailSender(EmailSender):
     """Entity responsible for send accepted institution email."""

--- a/backend/send_email_hierarchy/email_sender.py
+++ b/backend/send_email_hierarchy/email_sender.py
@@ -5,6 +5,7 @@ from google.appengine.api import taskqueue
 reload(sys)
 sys.setdefaultencoding('utf8')
 
+__all__ = ['EmailSender']
 
 class EmailSender(object):
 

--- a/backend/send_email_hierarchy/invite_institution_email_sender.py
+++ b/backend/send_email_hierarchy/invite_institution_email_sender.py
@@ -2,6 +2,8 @@
 
 from . import EmailSender
 
+__all__ = ['InviteInstitutionEmailSender']
+
 MAXIMUM_INSTITUTION_NAME = 29
 MAXIMUM_USER_NAME = 26
 

--- a/backend/send_email_hierarchy/invite_institution_email_sender.py
+++ b/backend/send_email_hierarchy/invite_institution_email_sender.py
@@ -1,6 +1,6 @@
 """Invite institution email sender model."""
 
-from email_sender import EmailSender
+from . import EmailSender
 
 MAXIMUM_INSTITUTION_NAME = 29
 MAXIMUM_USER_NAME = 26

--- a/backend/send_email_hierarchy/invite_user_email_sender.py
+++ b/backend/send_email_hierarchy/invite_user_email_sender.py
@@ -1,6 +1,6 @@
 """Invite user email sender model."""
 
-from email_sender import EmailSender
+from . import EmailSender
 
 MAXIMUM_INSTITUTION_NAME = 29
 MAXIMUM_USER_NAME = 26

--- a/backend/send_email_hierarchy/invite_user_email_sender.py
+++ b/backend/send_email_hierarchy/invite_user_email_sender.py
@@ -2,6 +2,8 @@
 
 from . import EmailSender
 
+__all__ = ['InviteUserEmailSender']
+
 MAXIMUM_INSTITUTION_NAME = 29
 MAXIMUM_USER_NAME = 26
 

--- a/backend/send_email_hierarchy/leave_institution_email_sender.py
+++ b/backend/send_email_hierarchy/leave_institution_email_sender.py
@@ -2,6 +2,7 @@
 
 from . import EmailSender
 
+__all__ = ['LeaveInstitutionEmailSender']
 
 class LeaveInstitutionEmailSender(EmailSender):
 

--- a/backend/send_email_hierarchy/leave_institution_email_sender.py
+++ b/backend/send_email_hierarchy/leave_institution_email_sender.py
@@ -1,6 +1,6 @@
 """Leave institution email sender model."""
 
-from email_sender import EmailSender
+from . import EmailSender
 
 
 class LeaveInstitutionEmailSender(EmailSender):

--- a/backend/send_email_hierarchy/remove_institution_email_sender.py
+++ b/backend/send_email_hierarchy/remove_institution_email_sender.py
@@ -4,6 +4,7 @@ from . import EmailSender
 import json
 from google.appengine.api import taskqueue
 
+__all__ = ['RemoveInstitutionEmailSender']
 
 class RemoveInstitutionEmailSender(EmailSender):
 

--- a/backend/send_email_hierarchy/remove_institution_email_sender.py
+++ b/backend/send_email_hierarchy/remove_institution_email_sender.py
@@ -1,6 +1,6 @@
 """Remove institution email sender model."""
 
-from email_sender import EmailSender
+from . import EmailSender
 import json
 from google.appengine.api import taskqueue
 

--- a/backend/send_email_hierarchy/remove_member_email_sender.py
+++ b/backend/send_email_hierarchy/remove_member_email_sender.py
@@ -1,6 +1,6 @@
 """Remove member email sender model."""
 
-from email_sender import EmailSender
+from . import EmailSender
 
 MAXIMUM_INSTITUTION_NAME = 29
 MAXIMUM_USER_NAME = 26

--- a/backend/send_email_hierarchy/remove_member_email_sender.py
+++ b/backend/send_email_hierarchy/remove_member_email_sender.py
@@ -2,6 +2,8 @@
 
 from . import EmailSender
 
+__all__ = ['RemoveMemberEmailSender']
+
 MAXIMUM_INSTITUTION_NAME = 29
 MAXIMUM_USER_NAME = 26
 

--- a/backend/send_email_hierarchy/request_link_email_sender.py
+++ b/backend/send_email_hierarchy/request_link_email_sender.py
@@ -2,6 +2,8 @@
 
 from . import EmailSender
 
+__all__ = ['RequestLinkEmailSender']
+
 MAXIMUM_INSTITUTION_NAME = 29
 
 

--- a/backend/send_email_hierarchy/request_link_email_sender.py
+++ b/backend/send_email_hierarchy/request_link_email_sender.py
@@ -1,6 +1,6 @@
 """Request an institution to make a connection with another one."""
 
-from email_sender import EmailSender
+from . import EmailSender
 
 MAXIMUM_INSTITUTION_NAME = 29
 

--- a/backend/send_email_hierarchy/request_user_email_sender.py
+++ b/backend/send_email_hierarchy/request_user_email_sender.py
@@ -1,6 +1,6 @@
 """Request user to be member email sender model."""
 
-from email_sender import EmailSender
+from . import EmailSender
 
 MAXIMUM_INSTITUTION_NAME = 29
 MAXIMUM_USER_NAME = 26

--- a/backend/send_email_hierarchy/request_user_email_sender.py
+++ b/backend/send_email_hierarchy/request_user_email_sender.py
@@ -2,6 +2,8 @@
 
 from . import EmailSender
 
+__all__ = ['RequestUserEmailSender']
+
 MAXIMUM_INSTITUTION_NAME = 29
 MAXIMUM_USER_NAME = 26
 

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -17,7 +17,7 @@ from service_messages import send_message_email
 from jinja2 import Environment, FileSystemLoader
 from permissions import DEFAULT_SUPER_USER_PERMISSIONS
 from permissions import DEFAULT_ADMIN_PERMISSIONS
-from send_email_hierarchy.remove_institution_email_sender import RemoveInstitutionEmailSender
+from send_email_hierarchy import RemoveInstitutionEmailSender
 
 
 def should_remove(user, institution_key, current_inst_key):


### PR DESCRIPTION
**Feature/Bug description:** The send email hierarchy modules imports made in the backend are extensive and difficult to read.
Example:

```python
from send_email_hierarchy.accepted_institution_email_sender import AcceptedInstitutionEmailSender
```

**Solution:** I set up the __init__.py file so that it recognizes all packet models by simplifying imports and making reading easier.
Example:

```python
from send_email_hierarchy import AcceptedInstitutionEmailSender
```

**Refactored email modules:**

* AcceptedInstitutionEmailSender
* EmailSender
* InviteInstitutionEmailSender
* InviteUserEmailsSender
* LeaveInstitutionEmailSender
* RemoveInstitutionEmailSender
* RemoveMemberEmailSender
* RequestLinkEmailSender
* RequestUserEmailSender

**TODO/FIXME:** n/a