### PR TITLE
Fix survey voters' names

### DIFF
--- a/frontend/survey/panel-voters.html
+++ b/frontend/survey/panel-voters.html
@@ -1,10 +1,10 @@
 <md-card style="margin: 0px;">
   <md-content class="custom-scrollbar">
 	<md-list style="max-height: 150px">
-  	  <md-list-item ng-repeat="voter in ctrl.option.voters" ng-click="null">
+  	  <md-list-item class="md-2-line" ng-repeat="voter in ctrl.option.voters" ng-click="null">
 	    <img ng-src="{{voter.photo_url}}" class="md-avatar" />
 	    <div class="md-list-item-text" layout="column">
-	      <p>{{ voter.name }}</p>
+	      <p>{{ ctrl.limitString(voter.name, 50) }}</p>
 	    </div>
   	  </md-list-item>
 	</md-list>

--- a/frontend/survey/surveyDetailsDirective.js
+++ b/frontend/survey/surveyDetailsDirective.js
@@ -183,6 +183,10 @@
         surveyCtrl.getOption = function getOption(optionText) {
             return surveyCtrl.isdialog ? Utils.limitString(optionText, MAX_DIALOG_CHAR_QUANTITY) : Utils.limitString(optionText, MAX_CHAR_QUANTITY);
         };
+
+        surveyCtrl.limitString = function limitString(string, maxSize) {
+            return Utils.limitString(string, maxSize);
+        };
     });
 
     app.directive("surveyDetails", function() {

--- a/frontend/test/specs/surveyDetailsDirectiveSpec.js
+++ b/frontend/test/specs/surveyDetailsDirectiveSpec.js
@@ -148,4 +148,13 @@
             expect(surveyCtrl.timeHasBeenExpired()).toBeFalsy();
         });
     });
+
+    describe('limitString()', function () {
+        it('should call limitString', function () {
+            spyOn(Utils, 'limitString').and.callThrough();
+            const result = surveyCtrl.limitString('Test string', 5);
+            expect(_.size(result)).toEqual(9);
+            expect(Utils.limitString).toHaveBeenCalled();
+        });
+    });
 }));


### PR DESCRIPTION
**Feature/Bug description:**
The voters' names were overtaking the limit they should have making the view weird. 
**Solution:**
I've added a md-3-line class to md-list-item and limited the max characters quantity showed by name.

![screenshot from 2018-05-22 07-49-38](https://user-images.githubusercontent.com/23387866/40358603-2f2df8b8-5d96-11e8-83c5-b7307a79aa2d.png)

![screenshot from 2018-05-22 07-55-47](https://user-images.githubusercontent.com/23387866/40358604-30fe7352-5d96-11e8-92bc-b9be3306c86f.png)

**TODO/FIXME:** n/a