### PR TITLE
Fix adm name in management page

### DIFF
--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -342,6 +342,10 @@
             return alreadySended;
         };
 
+        manageMemberCtrl.limitString = function limitString(string, maxSize) {
+            return Utils.limitString(string, maxSize)
+        };
+
         function getMemberByKey(key) {
             return manageMemberCtrl.members.reduce((foundMember, member) => (member.key === key) ? member : foundMember, {});
         }

--- a/frontend/institution/management_members.html
+++ b/frontend/institution/management_members.html
@@ -81,9 +81,15 @@
             ng-click="manageMemberCtrl.showUserProfile(manageMemberCtrl.institution.admin.key, $event)" flex-xs>
             <img title="{{manageMemberCtrl.institution.admin.name}}" ng-src="{{manageMemberCtrl.institution.admin.photo_url || '/app/images/avatar.png'}}" 
               class="md-avatar" style="margin: 0 15px 0 -15px; width: 60px; height: 60px;"/>
-            <div layout="column">
-               <b style="position: relative; margin-top: 20px; font-size: 15px;">{{ manageMemberCtrl.institution.admin.name }}</b>
-               <span style="position: relative; bottom: 20px; font-size: 15px;">{{ manageMemberCtrl.institution.admin.email[0]}}</span>
+            <div class="md-list-item-text" layout="column" style="margin-top: 12px;">
+              <b style="position: relative; font-size: 15px;">
+                <span style="line-height: 1.0;">
+                  {{ manageMemberCtrl.institution.admin.name }}
+                </span>
+              </b>
+              <span style="position: relative; font-size: 15px; margin-top: -10px;">
+                {{ manageMemberCtrl.institution.admin.email[0] }}
+              </span>
             </div>
             <div layout="row" layout-align="end center" flex>
               <p class="status-invite-adm" style="line-height: 21px; padding: 5px;" md-colors="{color: 'teal-500'}">
@@ -99,9 +105,15 @@
               <div layout="row" layout-align="start center"  flex>
                 <img title="{{manageMemberCtrl.institution.admin.name}}" ng-src="{{manageMemberCtrl.getMemberPhotoUrl(invite.invitee_key)}}" 
                   class="md-avatar" style="margin: 0 15px 0 px; width: 60px; height: 60px;"/>
-                <div layout="column">
-                  <b style="position: relative; margin-top: 20px; font-size: 15px;">{{ manageMemberCtrl.getMemberName(invite.invitee_key) }}</b>
-                  <span style="position: relative; bottom: 20px; font-size: 15px;">{{ invite.invitee }}</span>
+                <div layout="column" style="margin-top: 12px;">
+                  <b style="position: relative; font-size: 15px;">
+                    <span style="line-height: 1.0;">
+                      {{ manageMemberCtrl.getMemberName(invite.invitee_key) }}
+                    </span>
+                  </b>
+                  <span style="position: relative; margin-top: -10px; font-size: 15px;">
+                    {{ invite.invitee }}
+                  </span>
                 </div>
                 <div layout="row" layout-align="end center" flex>
                   <p class="status-invite-adm" style="margin-right: -6px; line-height: 21px; padding: 5px;"

--- a/frontend/institution/management_members.html
+++ b/frontend/institution/management_members.html
@@ -83,15 +83,18 @@
               class="md-avatar" style="margin: 0 15px 0 -15px; width: 60px; height: 60px;"/>
             <div class="md-list-item-text" layout="column" style="margin-top: 12px;">
               <b style="position: relative; font-size: 15px;">
-                <span style="line-height: 1.0;">
+                <span style="line-height: 1.0;" hide show-gt-xs>
                   {{ manageMemberCtrl.institution.admin.name }}
+                </span>
+                <span style="line-height: 1.0;" hide show-xs>
+                  {{ manageMemberCtrl.limitString(manageMemberCtrl.institution.admin.name, 45) }}
                 </span>
               </b>
               <span style="position: relative; font-size: 15px; margin-top: -10px;">
                 {{ manageMemberCtrl.institution.admin.email[0] }}
               </span>
             </div>
-            <div layout="row" layout-align="end center" flex>
+            <div layout="row" layout-align="end center" flex hide show-gt-xs>
               <p class="status-invite-adm" style="line-height: 21px; padding: 5px;" md-colors="{color: 'teal-500'}">
                 ADMINISTRADOR
               </p>
@@ -115,7 +118,7 @@
                     {{ invite.invitee }}
                   </span>
                 </div>
-                <div layout="row" layout-align="end center" flex>
+                <div layout="row" layout-align="end center" flex hide show-gt-xs>
                   <p class="status-invite-adm" style="margin-right: -6px; line-height: 21px; padding: 5px;"
                     ng-if="invite.status === 'sent'" md-colors="{color: 'teal-500'}">PENDENTE</p>
                   <div style="margin-right: -6px;" class="status-invite-adm"

--- a/frontend/test/specs/managementMembersControllerSpec.js
+++ b/frontend/test/specs/managementMembersControllerSpec.js
@@ -322,5 +322,14 @@
                 expect(manageMemberCtrl.requests).toEqual([]);
             });  
         });
+
+        describe('limitString()', function () {
+            it('should call limitString', function () {
+                spyOn(Utils, 'limitString').and.callThrough();
+                const result = manageMemberCtrl.limitString('Test string', 5);
+                expect(_.size(result)).toEqual(9);
+                expect(Utils.limitString).toHaveBeenCalled();
+            });
+        });
     });
 }));


### PR DESCRIPTION
**Feature/Bug description:**
When the name was too large the view's behavior was weird. The height between the first name's line and the second one was larger than it should.

![screenshot from 2018-05-22 10-21-31](https://user-images.githubusercontent.com/23387866/40365077-301b036a-5daa-11e8-997e-6abb9e061184.png)

**Solution:**
I've set the line-height property.

![screenshot from 2018-05-22 09-59-10](https://user-images.githubusercontent.com/23387866/40363937-560c7e26-5da7-11e8-9a68-e4f97a2f2787.png)

![screenshot from 2018-05-22 09-58-43](https://user-images.githubusercontent.com/23387866/40363945-5a957c04-5da7-11e8-89a3-8f9e23f8c6bb.png)

![screenshot from 2018-05-22 10-30-12](https://user-images.githubusercontent.com/23387866/40365650-6961fe98-5dab-11e8-9301-1a3903cb8c4a.png)



**TODO/FIXME:** n/a