### PR TITLE
Fix create survey post

### DIFF
--- a/frontend/post/postDirective.js
+++ b/frontend/post/postDirective.js
@@ -320,6 +320,7 @@
 
         postCtrl.cancelDialog = function() {
             postCtrl.clearPost();
+            SubmitFormListenerService.unobserve("postCtrl.post");
             $mdDialog.hide();
         };
 

--- a/frontend/survey/surveyDirective.js
+++ b/frontend/survey/surveyDirective.js
@@ -4,7 +4,8 @@
 
     var app = angular.module('app');
 
-    app.controller('SurveyDirectiveController', function(PostService, AuthService, MessageService, $scope, $mdDialog, $state) {
+    app.controller('SurveyDirectiveController', function(PostService, AuthService, MessageService, $scope, $mdDialog, $state,
+        SubmitFormListenerService) {
 
         var surveyCtrl = this;
         surveyCtrl.options = $scope.options;
@@ -70,6 +71,7 @@
                     MessageService.showToast('Postado com sucesso!');
                     surveyCtrl.callback();
                     $mdDialog.hide();
+                    unobserveNewPost();
                 }, function error(response) {
                     AuthService.reload().then(function success() {
                         $mdDialog.hide();
@@ -89,6 +91,7 @@
             surveyCtrl.options.push(angular.copy(option_empty));
             surveyCtrl.options.push(angular.copy(option_empty));
             surveyCtrl.multipleChoice = false;
+            unobserveNewPost();
             $mdDialog.hide();
         };
 
@@ -97,6 +100,9 @@
             return surveyCtrl.post.title && !notEnoughOptions && surveyCtrl.post.deadline;
         };
 
+        function unobserveNewPost() {
+            SubmitFormListenerService.unobserve("postCtrl.post");
+        }
     });
 
     app.directive("surveyDirective", function() {

--- a/frontend/test/specs/submitFormListenerServiceSpec.js
+++ b/frontend/test/specs/submitFormListenerServiceSpec.js
@@ -68,4 +68,29 @@
 
         expect(messageService.showConfirmationDialog).not.toHaveBeenCalled();
     });
+
+    it('Should unobserve object', function() {
+        var element = {};
+        scope.$apply();
+        submitFormListenerService.addListener('vm.tst', element, scope);
+        scope.$apply("vm.tst={name: 'tst'}");
+        scope.$apply("vm.tst.name = 'test'");
+        scope.$apply(function() {
+            state.go('app.user.home');
+        });
+
+        expect(messageService.showConfirmationDialog).toHaveBeenCalledWith(
+            'event', 
+            '', 
+            'Deseja sair sem salvar as alterações?');
+        expect(messageService.showConfirmationDialog.calls.count()).toEqual(1);
+        
+        submitFormListenerService.unobserve("vm.tst");
+
+        scope.$apply(function() {
+            state.go('app.user.home');
+        });
+
+        expect(messageService.showConfirmationDialog.calls.count()).toEqual(1);
+    });
 }));

--- a/frontend/utils/submitFormListenerService.js
+++ b/frontend/utils/submitFormListenerService.js
@@ -43,8 +43,11 @@
 
         service.unobserve = function unobserve(obj){
             let transitionListener = listeners[obj];
-            transitionListener();
-            delete listeners[obj];
+
+            if (transitionListener) {
+                transitionListener();
+                delete listeners[obj];
+            }
         };
     });
 })();

--- a/frontend/utils/submitFormListenerService.js
+++ b/frontend/utils/submitFormListenerService.js
@@ -6,6 +6,8 @@
     app.service('SubmitFormListenerService', function($transitions, MessageService, $state) {
         var service = this;
 
+        var listeners = {};
+
         service.addListener = function addListener(obj, formElement, scope) {
             var modified = false;
             var objectEquality = true;
@@ -25,16 +27,24 @@
                             'Deseja sair sem salvar as alterações?');
                     
                     promisse.then(function success() {
-                        transitionListener();
+                        service.unobserve(obj);
                         $state.go(targetState._identifier, targetState._params);
                     }, function error() {
                     });
                 } else {
-                    transitionListener();
+                    service.unobserve(obj);
                 }
             });
 
-            formElement.onsubmit = () => {transitionListener();};
+            listeners[obj] = transitionListener;
+
+            formElement.onsubmit = () => {service.unobserve(obj);};
+        };
+
+        service.unobserve = function unobserve(obj){
+            let transitionListener = listeners[obj];
+            transitionListener();
+            delete listeners[obj];
         };
     });
 })();


### PR DESCRIPTION
**Feature/Bug description:** When creating a survey type post and trying to move to another page, the dialog indicating that unsaved changes appear, even after the post has already been created.

**Solution:** I created a function in the submitFormListener service that allows a given object to stop being observed, and I used it in the surveyController to stop observing the post created when it is posted.

**TODO/FIXME:** n/a