### PR TITLE
Add verification to avoid parent connection substitution

### DIFF
--- a/backend/handlers/institution_children_request_handler.py
+++ b/backend/handlers/institution_children_request_handler.py
@@ -4,9 +4,11 @@
 import json
 from util import login_required
 from utils import json_response
+from utils import Utils
 from . import BaseHandler
 from service_entities import enqueue_task
 from google.appengine.ext import ndb
+from custom_exceptions import NotAuthorizedException
 
 __all__ = ['InstitutionChildrenRequestHandler']
 
@@ -29,6 +31,13 @@ class InstitutionChildrenRequestHandler(BaseHandler):
         user.check_permission('answer_link_inst_request',
                               'User is not allowed to accept link between institutions',
                               request.institution_requested_key.urlsafe())
+        
+        Utils._assert(
+            request.institution_requested_key.get().parent_institution != None,
+            "The institution's already have a parent",
+            NotAuthorizedException
+        )
+
         request.change_status('accepted')
 
         institution_children = request.institution_requested_key.get()

--- a/backend/handlers/institution_parent_request_collection_handler.py
+++ b/backend/handlers/institution_parent_request_collection_handler.py
@@ -60,6 +60,13 @@ class InstitutionParentRequestCollectionHandler(BaseHandler):
         requested_inst_key = data.get('institution_requested_key')
         requested_inst_key = ndb.Key(urlsafe=requested_inst_key)
 
+        child_institution = child_key.get()
+        Utils._assert(
+            child_institution.parent_institution != None,
+            "The institution's already have a parent",
+            NotAuthorizedException
+        )
+
         Utils._assert(
             Institution.has_connection_between(requested_inst_key, child_key),
             "Circular hierarchy not allowed",
@@ -69,7 +76,6 @@ class InstitutionParentRequestCollectionHandler(BaseHandler):
         request = InviteFactory.create(data, type_of_invite)
         request.put()
 
-        child_institution = child_key.get()
         child_institution.parent_institution = requested_inst_key
         child_institution.put()
 


### PR DESCRIPTION
**Feature/Bug description:**
The backend wasn't checking if the child_institution's already have a parent before send a parent request or accept a children request.
**Solution:**
I've added the verification and some tests to avoid the removal of the verification blindly.

**TODO/FIXME:** n/a