### PR TITLE
Split notifications queue

### DIFF
--- a/backend/models/invite.py
+++ b/backend/models/invite.py
@@ -73,8 +73,8 @@ class Invite(PolyModel):
 
     def send_invite(self, host, current_institution=None):
         """Send invite."""
-        self.send_email(host)
         self.send_notification(current_institution)
+        self.send_email(host)
 
     def send_email(self, host, receiver_email=None, body=None):
         """Method of send email of invite user."""

--- a/backend/send_email_hierarchy/email_sender.py
+++ b/backend/send_email_hierarchy/email_sender.py
@@ -29,7 +29,7 @@ class EmailSender(object):
         taskqueue.add(
             url='/api/queue/send-email',
             target='worker',
-            queue_name='notifications',
+            queue_name='emails',
             params={
                 'invitee': self.receiver,
                 'subject': self.subject,

--- a/backend/send_email_hierarchy/remove_institution_email_sender.py
+++ b/backend/send_email_hierarchy/remove_institution_email_sender.py
@@ -18,7 +18,7 @@ class RemoveInstitutionEmailSender(EmailSender):
         taskqueue.add(
             url='/api/queue/email-members',
             target='worker',
-            queue_name='notifications',
+            queue_name='emails',
             params={
                 'institution_key': self.institution_key,
                 'subject': self.subject,

--- a/queue.yaml
+++ b/queue.yaml
@@ -3,3 +3,5 @@ queue:
   rate: 1/s
 - name: notifications
   rate: 1/s
+- name: emails
+  rate: 1/s


### PR DESCRIPTION
**Feature/Bug description:** 
The emails were being sent from the notifications queue, what doesn't make sense.
**Solution:**
I've added another queue in queue.yml and changed the method that add the emails' tasks, making it enqueue in emails' queue.
**TODO/FIXME:** n/a