### PR TITLE
Refact institution handler's post method

### DIFF
--- a/backend/handlers/institution_handler.py
+++ b/backend/handlers/institution_handler.py
@@ -125,14 +125,13 @@ class InstitutionHandler(BaseHandler):
     @json_response
     @login_required
     @isUserInvited
-    def post(self, user, institution_key, inviteKey):
+    def put(self, user, institution_key, inviteKey):
         """
-        Handler POST Requests.
+        Handle PUT Requests.
         
-        This handler terminates the configuration of the institution 
-        from the created stub, marks the invite received as accepted and 
-        adds the permissions of administered in the higher institutions 
-        if the institution created has a parent institution.
+        This method end up the institution's configurations 
+        from its previously created stub. Besides, it marks the invite received as accepted and 
+        adds the permissions to the parent admins if the institution created has a parent institution.
         """
         body = json.loads(self.request.body)
         data = body['data']

--- a/backend/handlers/like_handler.py
+++ b/backend/handlers/like_handler.py
@@ -85,10 +85,6 @@ class LikeHandler(BaseHandler):
 
             enqueue_task('post-notification', params)
 
-    """TODO:  Create dislike_comment method and replace 
-            ndb.transactional to internal scopes.
-        @author: Maiana Brito 12/04/2018
-    """
     @json_response
     @login_required
     def delete(self, user, post_key, comment_id=None, reply_id=None):

--- a/backend/test/institution_handler_test.py
+++ b/backend/test/institution_handler_test.py
@@ -144,11 +144,11 @@ class InstitutionHandlerTest(TestBaseHandler):
             "Error! User is not allowed to edit institution")
 
     @patch('util.login_service.verify_token', return_value={'email': 'other_user@example.com'})
-    def test_post(self, verify_token):
+    def test_put(self, verify_token):
         """Test the post_handler's post method."""
         # Call the patch method and assert that  it raises an exception
         self.body['data'] = {'sender_name': 'user name updated'}
-        self.testapp.post_json("/api/institutions/%s/invites/%s" % 
+        self.testapp.put_json("/api/institutions/%s/invites/%s" %
             (self.stub.key.urlsafe(), self.invite.key.urlsafe()), self.body,
             headers={'institution-authorization': self.third_inst.key.urlsafe()})
 
@@ -185,7 +185,7 @@ class InstitutionHandlerTest(TestBaseHandler):
         # Check if raise Exception when the user who send patch is not the
         # invitee
         with self.assertRaises(Exception) as raises_context:
-            self.testapp.post_json(
+            self.testapp.put_json(
                 "/api/institutions/%s/invites/%s" % (self.stub.key.urlsafe(), self.invite.key.urlsafe()),
                 [{"op": "replace", "path": "/name", "value": "Nova Inst update"}]
             )
@@ -246,7 +246,7 @@ class InstitutionHandlerTest(TestBaseHandler):
         self.assertEqual(third_user.permissions, {})
 
         self.body['data'] = {'sender_name': 'user name updated'}
-        self.testapp.post_json("/api/institutions/%s/invites/%s"
+        self.testapp.put_json("/api/institutions/%s/invites/%s"
                           % (third_inst.key.urlsafe(), invite.key.urlsafe()), self.body)
 
         first_user = first_user.key.get()

--- a/backend/test/institution_handler_test.py
+++ b/backend/test/institution_handler_test.py
@@ -145,7 +145,7 @@ class InstitutionHandlerTest(TestBaseHandler):
 
     @patch('util.login_service.verify_token', return_value={'email': 'other_user@example.com'})
     def test_put(self, verify_token):
-        """Test the post_handler's post method."""
+        """Test the put method."""
         # Call the patch method and assert that  it raises an exception
         self.body['data'] = {'sender_name': 'user name updated'}
         self.testapp.put_json("/api/institutions/%s/invites/%s" %

--- a/frontend/institution/institutionService.js
+++ b/frontend/institution/institutionService.js
@@ -117,7 +117,7 @@
         service.save = function save(data, institutionKey, inviteKey) {
             var body = {data: data};
             var deffered = $q.defer();
-            $http.post(INSTITUTIONS_URI + "/" + institutionKey + "/invites/" + inviteKey, body).then(function success(info) {
+            $http.put(INSTITUTIONS_URI + "/" + institutionKey + "/invites/" + inviteKey, body).then(function success(info) {
                 deffered.resolve(info.data);
             }, function error(data) {
                 deffered.reject(data);


### PR DESCRIPTION
**Feature/Bug description:**
The method shouldn't be a post once it wasn't creating any new entity, it was only updating a institution's stub to change its state to active and update the data.
**Solution:**
The method became a put, what makes sense because it updates the entity.

**TODO/FIXME:** n/a