### PR TITLE
Refact send invite hierarchy

### DIFF
--- a/backend/handlers/invite_collection_handler.py
+++ b/backend/handlers/invite_collection_handler.py
@@ -37,7 +37,7 @@ class InviteCollectionHandler(BaseHandler):
         body = json.loads(self.request.body)
         data = body['data']
         host = self.request.host
-        invite = data['invite_body'] if data.get('invite_body') is not None else data
+        invite = data['invite_body']
         type_of_invite = invite.get('type_of_invite')
 
         Utils._assert(type_of_invite == 'INSTITUTION',

--- a/backend/test/invite_collection_handler_test.py
+++ b/backend/test/invite_collection_handler_test.py
@@ -105,12 +105,12 @@ class InviteCollectionHandlerTest(TestBaseHandler):
     def test_post_invite_institution_parent(self, verify_token):
         #Test the invite_collection_handler's post method in case to parent institution.
 
-        invite = self.testapp.post_json("/api/invites", {'data': {
+        invite = self.testapp.post_json("/api/invites", {'data': { 'invite_body': {
             'invitee': 'user1@gmail.com',
             'admin_key': self.admin.key.urlsafe(),
             'type_of_invite': 'INSTITUTION_PARENT',
             'suggestion_institution_name': 'Institution Parent',
-            'institution_key': self.institution.key.urlsafe()}},
+            'institution_key': self.institution.key.urlsafe()}}},
             headers={'Institution-Authorization': self.institution.key.urlsafe()})
 
         # Retrieve the entities

--- a/backend/test/invite_collection_handler_test.py
+++ b/backend/test/invite_collection_handler_test.py
@@ -58,12 +58,12 @@ class InviteCollectionHandlerTest(TestBaseHandler):
     @patch('util.login_service.verify_token', return_value=ADMIN)
     def test_post_invite_institution(self, verify_token):
 
-        invite = self.testapp.post_json("/api/invites", {'data': {
+        invite = self.testapp.post_json("/api/invites", {'data': { 'invite_body': {
             'invitee': 'ana@gmail.com',
             'admin_key': self.admin.key.urlsafe(),
             'type_of_invite': 'INSTITUTION_PARENT',
             'suggestion_institution_name': 'New Institution',
-            'institution_key': self.institution.key.urlsafe()}},
+            'institution_key': self.institution.key.urlsafe()}}},
             headers={'Institution-Authorization': self.institution.key.urlsafe()})
 
         # Retrieve the entities
@@ -88,11 +88,11 @@ class InviteCollectionHandlerTest(TestBaseHandler):
         # institution and not specify the suggestion institution name.
 
         with self.assertRaises(Exception) as raises_context:
-            self.testapp.post_json("/api/invites", {'data': {
+            self.testapp.post_json("/api/invites", {'data': { 'invite_body': {
                 'invitee': 'ana@gmail.com',
                 'admin_key': self.admin.key.urlsafe(),
                 'institution_key': self.institution.key.urlsafe(),
-                'type_of_invite': 'INSTITUTION_PARENT'}})
+                'type_of_invite': 'INSTITUTION_PARENT'}}})
 
         message_exception = self.get_message_exception(str(raises_context.exception))
         self.assertEqual(

--- a/frontend/invites/inviteService.js
+++ b/frontend/invites/inviteService.js
@@ -19,10 +19,10 @@
             return deferred.promise;
         };
 
-        service.sendInvite = function sendInvite(invite) {
+        service.sendInvite = function sendInvite(invite_body) {
             var deferred = $q.defer();
             $http.post(INVITES_URI, {
-                data: invite
+                data: {invite_body}
             }).then(function success(response) {
                 deferred.resolve(response);
             }, function error(response) {

--- a/frontend/test/specs/inviteServiceSpec.js
+++ b/frontend/test/specs/inviteServiceSpec.js
@@ -35,7 +35,7 @@
             var result;
             service.sendInvite(inviteUser).then(function(data){
                 result = data;
-                body['data'] = inviteUser;
+                body['data'] = {invite_body:inviteUser};
                 expect($http.post).toHaveBeenCalledWith(INVITES_URI, body);
                 expect(result.data).toEqual(inviteUser);
                 done();
@@ -50,7 +50,7 @@
             service.sendInvite(inviteInstitution).then(function(data){
                 result = data;
                 body['data'] = inviteInstitution;
-                expect($http.post).toHaveBeenCalledWith(INVITES_URI, {data: inviteInstitution});
+                expect($http.post).toHaveBeenCalledWith(INVITES_URI, {data: {invite_body: inviteInstitution}});
                 expect(result.data).toEqual(inviteInstitution);
                 done();
             });


### PR DESCRIPTION
**Feature/Bug description:** The way the hierarchy and user invitations were being sent was inconsistent because in the user invitation the data is in the invite body attribute and the hierarchy is in the attribute data.

**Solution:** I've put the invitation invitations data on the invite_body as well as the user's data.

**TODO/FIXME:** n/a