### PR TITLE
Improving post_handler's patch method

### DIFF
--- a/backend/handlers/post_handler.py
+++ b/backend/handlers/post_handler.py
@@ -86,27 +86,22 @@ class PostHandler(BaseHandler):
 
     @json_response
     @login_required
-    def patch(self, user, url_string):
+    def patch(self, user, post_urlsafe):
         """Handler PATCH Requests."""
         data = self.request.body
 
-        try:
-            post = ndb.Key(urlsafe=url_string).get()
+        post = ndb.Key(urlsafe=post_urlsafe).get()
 
-            Utils._assert(post.has_activity(),
-                          "The user can not update this post",
-                          NotAuthorizedException)
+        Utils._assert(post.has_activity(),
+                        "The user can not update this post",
+                        NotAuthorizedException)
 
-            user.check_permission("edit_post",
-                                  "User is not allowed to edit this post",
-                                  url_string)
+        user.check_permission("edit_post",
+                                "User is not allowed to edit this post",
+                                post_urlsafe)
 
-            """Apply patch."""
-            JsonPatch.load(data, post)
+        """Apply patch."""
+        JsonPatch.load(data, post)
 
-            """Update post."""
-            post.put()
-        except Exception as error:
-            self.response.set_status(Utils.FORBIDDEN)
-            self.response.write(Utils.getJSONError(
-                Utils.FORBIDDEN, error.message))
+        """Update post."""
+        post.put()

--- a/backend/test/post_handler_test.py
+++ b/backend/test/post_handler_test.py
@@ -83,7 +83,7 @@ class PostHandlerTest(TestBaseHandler):
     def test_patch(self, verify_token):
         """Test the post_handler's patch method."""
 
-        exception_message = "User is not allowed to edit this post"
+        exception_message = "Error! User is not allowed to edit this post"
         expected_alert = "Expected: " + exception_message + ". But got: "
 
         # Call the patch method and assert that  it raises an exception
@@ -145,6 +145,7 @@ class PostHandlerTest(TestBaseHandler):
                                         "value": "testando"}]
                                     )
 
+        exception_message = "Error! The user can not update this post"
         raises_context_message = self.get_message_exception(str(raises_context.exception))
         self.assertEqual(
             raises_context_message,


### PR DESCRIPTION
**Feature/Bug description:**
There was an unnecessary try except block. Besides, the key received as param was named without the pattern.
**Solution:**
Remove try except block and rename url_string.

**TODO/FIXME:** n/a