### PR TITLE
Fix request-controller's aux functions

### DIFF
--- a/frontend/requests/requestProcessingController.js
+++ b/frontend/requests/requestProcessingController.js
@@ -97,12 +97,16 @@
         };
 
         requestController.getChildrenInstName = function getChildrenInstName(size) {
-            return Utils.limitString(requestController.children.name ||
-                requestController.children.sender_name, size);
+            const returnValue = requestController.children ? 
+              Utils.limitString(requestController.children.name ||
+              requestController.children.sender_name, size) : "";
+            return returnValue;
         };
 
         requestController.getChildrenInstEmail = function getChildrenInstEmail(size) {
-            return Utils.limitString(requestController.children.institutional_email, size);
+            const returnValue = requestController.children ? 
+              Utils.limitString(requestController.children.institutional_email, size) : "";
+            return returnValue;
         };	
 
         requestController.isAnotherCountry = function isAnotherCountry() {


### PR DESCRIPTION
**Feature/Bug description:**
Some functions, like getChildrenInstName, was trying to access requestController.children before its existence.
**Solution:**
I've added a verification before each return statement in this functions. This verification checks if requestController.children exists yet.

**TODO/FIXME:** n/a