### PR TITLE
Fix the header of shared event with image

### DIFF
--- a/frontend/post/share_post_dialog.html
+++ b/frontend/post/share_post_dialog.html
@@ -15,7 +15,7 @@
       </div>
       <md-card-content flex>
         <md-card layout-padding md-colors="{background: 'default-grey-100'}" layout="column" flex class="custom-scrollbar share-post">
-          <div layout="row" flex>
+          <div layout="row" flex ng-class="sharePostCtrl.showImage() && sharePostCtrl.isEvent() ? 'shared-post-with-image' : 'shared-post-header'">
             <img style="width: 40px; height: 40px; border-radius: 50%; margin-right: 8px;" ng-src="{{ sharePostCtrl.post.institution_image }}" />
             <div layout="column" flex>
               <b class="small-text-share-post">{{ sharePostCtrl.post.institution_name }}</b>

--- a/frontend/styles/custom.css
+++ b/frontend/styles/custom.css
@@ -1129,3 +1129,10 @@ md-input-container:not(.md-input-invalid).md-input-has-value .inputEmail {
     line-height: 21px; 
     padding: 5px;
 }
+
+.shared-post-with-image {
+    height: 20vh;
+}
+.shared-post-header {
+    height: 15vh;
+}


### PR DESCRIPTION
**Feature/Bug description:** The header of view to share event are broken.

![screenshot from 2018-05-29 14-41-10](https://user-images.githubusercontent.com/20300259/40675582-884acd64-634e-11e8-86e0-f310d80827de.png)

**Solution:** Define the heigth to show header completely.

![screenshot from 2018-05-29 14-44-51](https://user-images.githubusercontent.com/20300259/40675719-e14d2178-634e-11e8-9cd7-bfff77ec2851.png)


**TODO/FIXME:** n/a