### PR TITLE
Fix the verification of permissions to children links

### DIFF
--- a/frontend/invites/inviteInstHierarchieController.js
+++ b/frontend/invites/inviteInstHierarchieController.js
@@ -377,7 +377,9 @@
 
         inviteInstHierCtrl.canRemoveInst = function canRemoveInst(institution) {
             var hasChildrenLink = institution.parent_institution === inviteInstHierCtrl.institution.key;
-            return inviteInstHierCtrl.user.permissions.remove_inst[institution.key] && hasChildrenLink;
+            var removeInstPermission = inviteInstHierCtrl.user.permissions.remove_inst;
+            return removeInstPermission
+                && removeInstPermission[institution.key] && hasChildrenLink;
         };
 
         inviteInstHierCtrl.linkParentStatus = function linkParentStatus() {


### PR DESCRIPTION
**Feature/Bug description:** The console show errors when try to get the permission to your children institutions.

**Solution:** Verifying, after get permission, if has the field of remove_inst.

**TODO/FIXME:** n/a