### PR TITLE
Fix the left menu in institution managment page

### DIFF
--- a/frontend/institution/management_institution_page.html
+++ b/frontend/institution/management_institution_page.html
@@ -6,7 +6,7 @@
   <!-- LEFT SIDE PANEL -->
     <md-sidenav class="md-sidenav-left" md-component-id="leftNav" md-whiteframe="4" layout="row"
     md-is-locked-open="$mdMedia('gt-sm')" flex-gt-md="25">
-      <md-content class="custom-scrollbar" layout="column" hide show-gt-sm
+      <md-content class="custom-scrollbar" layout="column"
       md-colors="{background: 'grey-100'}" flex>
         <div class="container">
           <div class="row">


### PR DESCRIPTION
**Feature/Bug description:** The left menu for small screens don't show your content in the institution managment page.

![screenshot from 2018-05-29 16-36-15](https://user-images.githubusercontent.com/20300259/40681104-9513f664-635e-11e8-951d-26faff5374bf.png)


**Solution:** Removing the "hide" tag resolve the problem.

![screenshot from 2018-05-29 16-30-13](https://user-images.githubusercontent.com/20300259/40681140-ad8d0fbe-635e-11e8-9409-e97bb99fc15d.png)


**TODO/FIXME:** n/a