### PR TITLE
Fix video and links' descriptions requirements in event creation

### DIFF
--- a/frontend/event/event_dialog.html
+++ b/frontend/event/event_dialog.html
@@ -187,7 +187,7 @@
                       </md-input-container>
                       <md-input-container class="md-block" style="height: 25px;">
                         <label>Descrição</label>
-                        <input class="md-input" ng-model="videoUrl.description" placeholder="Adicione uma descrição para o vídeo..." maxlength="150" />                  
+                        <input ng-required="videoUrl.url" class="md-input" ng-model="videoUrl.description" placeholder="Adicione uma descrição para o vídeo..." maxlength="150" />                  
                       </md-input-container>
                     </div>
                   </div>
@@ -203,7 +203,7 @@
                       </md-input-container>
                       <md-input-container class="md-block" style="height: 25px;">
                         <label>Descrição</label>
-                        <input class="md-input" ng-model="usefulLink.description" placeholder="Adicione uma descrição para o link..." maxlength="150" />                  
+                        <input ng-required="usefulLink.url" class="md-input" ng-model="usefulLink.description" placeholder="Adicione uma descrição para o link..." maxlength="150" />                  
                       </md-input-container>
                     </div>
                   </div>


### PR DESCRIPTION
**Feature/Bug description:**
The was able to insert videos and links without any description in event creation.
**Solution:**
I've changed the descriptions' requirements. Thus, for any video or link inserted, its description is required.



**TODO/FIXME:** n/a