### PR TITLE
Fix send invite user frontend

### DIFF
--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -122,7 +122,7 @@
                     MessageService.showToast(response.msg);
                 }, function error(response) {
                     manageMemberCtrl.isLoadingInvite = false;
-                    MessageService.showToast(response.data.msg);
+                    MessageService.showToast(response.msg);
                 });
                 return promise;
             }

--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -108,18 +108,18 @@
             var requestBody = {
                 invite_body: invite,
                 emails: emails
-            }
+            };
             
             if (manageMemberCtrl.isValidAllEmails(emails) && manageMemberCtrl.isUserInviteValid(invite)) {
                 manageMemberCtrl.isLoadingInvite = true;
                 var promise = InviteService.sendInviteUser(requestBody);
                 promise.then(function success(response) {
-                    refreshSentInvitations(requestBody.emails, response.data.invites);
+                    refreshSentInvitations(requestBody.emails, response.invites);
                     manageMemberCtrl.clearInvite(); 
                     manageMemberCtrl.showInvites = true; 
                     manageMemberCtrl.showSendInvite = false;
                     manageMemberCtrl.isLoadingInvite = false;
-                    MessageService.showToast(response.data.msg);
+                    MessageService.showToast(response.msg);
                 }, function error(response) {
                     manageMemberCtrl.isLoadingInvite = false;
                     MessageService.showToast(response.data.msg);

--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -113,13 +113,13 @@
             if (manageMemberCtrl.isValidAllEmails(emails) && manageMemberCtrl.isUserInviteValid(invite)) {
                 manageMemberCtrl.isLoadingInvite = true;
                 var promise = InviteService.sendInviteUser(requestBody);
-                promise.then(function success(response) {
-                    refreshSentInvitations(requestBody.emails, response.invites);
+                promise.then(function success(response_data) {
+                    refreshSentInvitations(requestBody.emails, response_data.invites);
                     manageMemberCtrl.clearInvite(); 
                     manageMemberCtrl.showInvites = true; 
                     manageMemberCtrl.showSendInvite = false;
                     manageMemberCtrl.isLoadingInvite = false;
-                    MessageService.showToast(response.msg);
+                    MessageService.showToast(response_data.msg);
                 }, function error(response) {
                     manageMemberCtrl.isLoadingInvite = false;
                     MessageService.showToast(response.msg);

--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -113,13 +113,13 @@
             if (manageMemberCtrl.isValidAllEmails(emails) && manageMemberCtrl.isUserInviteValid(invite)) {
                 manageMemberCtrl.isLoadingInvite = true;
                 var promise = InviteService.sendInviteUser(requestBody);
-                promise.then(function success(response_data) {
-                    refreshSentInvitations(requestBody.emails, response_data.invites);
+                promise.then(function success(responseData) {
+                    refreshSentInvitations(requestBody.emails, responseData.invites);
                     manageMemberCtrl.clearInvite(); 
                     manageMemberCtrl.showInvites = true; 
                     manageMemberCtrl.showSendInvite = false;
                     manageMemberCtrl.isLoadingInvite = false;
-                    MessageService.showToast(response_data.msg);
+                    MessageService.showToast(responseData.msg);
                 }, function error(response) {
                     manageMemberCtrl.isLoadingInvite = false;
                     MessageService.showToast(response.msg);

--- a/frontend/test/specs/managementMembersControllerSpec.js
+++ b/frontend/test/specs/managementMembersControllerSpec.js
@@ -138,10 +138,9 @@
                     return {
                         then: function(callback) {
                             return callback(
-                                { data: { 
-                                          'msg': 'Os convites estão sendo processados.'.clone,
-                                          'invites': [{ 'email': "teste@gmail.com", 'key': '123' }]
-                                        }
+                                {  
+                                    'msg': 'Os convites estão sendo processados.'.clone,
+                                    'invites': [{ 'email': "teste@gmail.com", 'key': '123' }]
                                 }
                             );
                         }


### PR DESCRIPTION
**Feature/Bug description:** When send a user invitation, an error occurs on the console stating that cannot read property invites of undefined.

**Solution:** Adjust the response of the InviteService.sendInviteUser method so that it no longer uses response.data.invites but response.invites.

**TODO/FIXME:** n/a