### PR TITLE
Fix vote in shared survey post

### DIFF
--- a/frontend/post/post_details.html
+++ b/frontend/post/post_details.html
@@ -149,7 +149,7 @@
       <pdf-view ng-if="postDetailsCtrl.showSharedPostText()" pdf-files='postDetailsCtrl.post.shared_post.pdf_files' is-editing="false"></pdf-view>
       <survey-details ng-if="postDetailsCtrl.post.shared_post.type_survey" 
         post="postDetailsCtrl.post.shared_post" posts="postDetailsCtrl.posts" 
-        user="postDetailsCtrl.user" isdialog="false"></survey-details>
+        user="postDetailsCtrl.user" reload-post="postDetailsCtrl.reloadPost" isdialog="false"></survey-details>
     </md-card-content>
   </md-card>
 


### PR DESCRIPTION
**Feature/Bug description:** When voting on a poll that was shared, the vote does not appear to the user and on the console, an error message appears stating that the reloadPost method is not a function.

**Solution:** Pass the reloadPost function from the postDetailsController to the survey-directive.

**TODO/FIXME:** n/a