### PR TITLE
Fix share event in event's page and in event's details

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -216,6 +216,9 @@
                         templateUrl: "app/event/event_page.html",
                         controller: "EventPageController as eventCtrl",
                     }
+                },
+                params: {
+                    posts: undefined
                 }
             })
             .state("app.manage_institution.edit_info", {

--- a/frontend/event/event.html
+++ b/frontend/event/event.html
@@ -44,7 +44,7 @@
               </div>
               <div flex style="margin-left: -22px;">
                 <md-card>
-                    <event-details event="event" is-event-page=false></event-details>
+                    <event-details event="event" posts="eventCtrl.posts" is-event-page=false></event-details>
                 </md-card>
               </div>
             </div>

--- a/frontend/event/eventController.js
+++ b/frontend/event/eventController.js
@@ -85,6 +85,7 @@
         (function main() {
             eventCtrl.institutionKey = $state.params.institutionKey;
             eventCtrl.loadMoreEvents();
+            eventCtrl.posts = $state.params.posts;
         })();
     });
 })();

--- a/frontend/event/eventDetailsDirective.js
+++ b/frontend/event/eventDetailsDirective.js
@@ -25,7 +25,7 @@
                 clickOutsideToClose: true,
                 locals: {
                     user: eventCtrl.user,
-                    posts: [],
+                    posts: eventCtrl.posts || [],
                     post: event,
                     addPost: true
                 }
@@ -100,7 +100,7 @@
         };
 
         eventCtrl.goToEvent = function goToEvent(event) {
-            $state.go('app.user.event', { eventKey: event.key });
+            $state.go('app.user.event', { eventKey: event.key, posts: eventCtrl.posts });
         };
 
         eventCtrl.endInOtherMonth = function endInOtherMonth() {
@@ -153,6 +153,7 @@
             bindToController: {
                 event: '=',
                 isEventPage: '=',
+                posts: '='
             }
         };
     });

--- a/frontend/event/eventPageController.js
+++ b/frontend/event/eventPageController.js
@@ -21,7 +21,9 @@
         eventCtrl.share = function share(event) {
             var post = new Post({}, eventCtrl.user.current_institution.key);
             post.shared_event = event.key;
-            PostService.createPost(post).then(function success() {
+            PostService.createPost(post).then(function success(response) {
+                if(eventCtrl.posts)
+                    eventCtrl.posts.push(response.data);
                 MessageService.showToast('Evento compartilhado com sucesso!');
             }, function error(response) {
                 MessageService.showToast(response.data.msg);
@@ -74,6 +76,7 @@
 
         (function main() {
             loadEvent($state.params.eventKey);
+            eventCtrl.posts = $state.params.posts;
         })();
     });
 })();

--- a/frontend/event/event_page.html
+++ b/frontend/event/event_page.html
@@ -1,7 +1,7 @@
 <md-content layout="row" id="content" class="body custom-scrollbar" ng-if="!eventCtrl.isDeleted()">
   <div layout="row" flex flex-gt-xs="95" layout-align="end start">
     <div flex flex-gt-xs="95">
-      <event-details event="eventCtrl.event" is-event-page=true></event-details>
+      <event-details event="eventCtrl.event" posts="eventCtrl.posts" is-event-page=true></event-details>
     </div>
   </div>
 </md-content>

--- a/frontend/home/homeController.js
+++ b/frontend/home/homeController.js
@@ -78,7 +78,7 @@
         };
 
         homeCtrl.goToEvent = function goToEvent(event) {
-            $state.go('app.user.event', {eventKey: event.key});
+            $state.go('app.user.event', {eventKey: event.key, posts: homeCtrl.posts});
         };
 
         homeCtrl.newPost = function newPost(event) {

--- a/frontend/institution/institution_events.html
+++ b/frontend/institution/institution_events.html
@@ -19,7 +19,7 @@
                     </div>
                     <div flex style="margin-left: -22px;">
                         <md-card>
-                            <event-details event="event" is-event-page=false></event-details>
+                            <event-details event="event" posts="eventCtrl.posts" is-event-page=false></event-details>
                         </md-card>
                     </div>
                 </div>

--- a/frontend/post/postDetailsDirective.js
+++ b/frontend/post/postDetailsDirective.js
@@ -340,7 +340,7 @@
         };
 
         postDetailsCtrl.goToEvent = function goToEvent(event) {
-            $state.go('app.user.event', {eventKey: event.key});
+            $state.go('app.user.event', {eventKey: event.key, posts: postDetailsCtrl.posts});
         };
 
         postDetailsCtrl.reloadPost = function reloadPost() {

--- a/frontend/post/post_details.html
+++ b/frontend/post/post_details.html
@@ -99,7 +99,7 @@
       <span>por {{postDetailsCtrl.post.shared_event.last_modified_by}} {{postDetailsCtrl.post.last_modified_date | amUtc | amLocal | amCalendar:referenceTime:formats }}.</span>
     </div>
   </div>
-  <event-details ng-if="postDetailsCtrl.showSharedEvent()" event="postDetailsCtrl.post.shared_event" is-event-page=false></event-details>
+  <event-details ng-if="postDetailsCtrl.showSharedEvent()" event="postDetailsCtrl.post.shared_event" is-event-page=false posts="postDetailsCtrl.posts"></event-details>
 
   <!-- BODY SHARED POST -->
   <md-card md-colors="{background: 'default-grey-100'}" ng-if="postDetailsCtrl.showSharedPost()">

--- a/frontend/post/sharePostController.js
+++ b/frontend/post/sharePostController.js
@@ -70,7 +70,7 @@
         shareCtrl.goTo = function goTo() {
             shareCtrl.cancelDialog();
             if (shareCtrl.isEvent()) {
-                $state.go('app.user.event', { eventKey: shareCtrl.post.key });
+                $state.go('app.user.event', { eventKey: shareCtrl.post.key, posts: shareCtrl.posts });
             }
             $state.go('app.post', { postKey: shareCtrl.post.key });
         };

--- a/frontend/post/share_post_dialog.html
+++ b/frontend/post/share_post_dialog.html
@@ -30,7 +30,7 @@
               <b ng-bind-html="sharePostCtrl.postToURL(sharePostCtrl.post.title)"></b>
             </span>
           </br>
-            <event-details ng-if="sharePostCtrl.isEvent()" event="sharePostCtrl.post" is-event-page=false></event-details>
+            <event-details ng-if="sharePostCtrl.isEvent()" event="sharePostCtrl.post" is-event-page=false posts="sharePostCtrl.posts"></event-details>
             <span class="md-subhead" ng-if="!sharePostCtrl.isEvent() && sharePostCtrl.post.text" ng-bind-html="sharePostCtrl.postToURL(sharePostCtrl.post.text)"></span>
             <pdf-view ng-if="sharePostCtrl.showPdfFiles()" pdf-files='sharePostCtrl.post.pdf_files' is-editing="false"></pdf-view>
             <survey-details ng-if="sharePostCtrl.isSurvey()" post="sharePostCtrl.post" posts="sharePostCtrl.posts" user="sharePostCtrl.user"

--- a/frontend/test/specs/eventPageControllerSpec.js
+++ b/frontend/test/specs/eventPageControllerSpec.js
@@ -69,7 +69,7 @@
       mdDialog = $mdDialog;
       AuthService.login(user);
       state = $state;
-
+      state.params.posts = [];
       state.params.eventKey = event_convert_date.key;
       eventCtrl = $controller('EventPageController', {
             scope: scope,
@@ -77,7 +77,8 @@
             eventService: eventService,
             postService : postService,
             messageService : messageService,
-            mdDialog: mdDialog
+            mdDialog: mdDialog,
+            state: state
         });
 
       httpBackend.when('GET', EVENT_URI).respond(event_convert_date);
@@ -95,11 +96,16 @@
   describe('share()', function() {
 
     it('should eventService.createPost be called', function() {
-      spyOn(postService, 'createPost').and.returnValue(deffered.promise);
-      deffered.resolve(post);
+      spyOn(postService, 'createPost').and.callFake(function () {
+        return {
+          then: function (callback) {
+            return callback({data: {}});
+          }
+        };
+      });
       eventCtrl.share(event);
-      scope.$apply();
       expect(postService.createPost).toHaveBeenCalledWith(post);
+      expect(eventCtrl.posts).toEqual([{}]);
     });
   });
 

--- a/frontend/test/specs/sharePostControllerSpec.js
+++ b/frontend/test/specs/sharePostControllerSpec.js
@@ -99,7 +99,7 @@
             shareCtrl.post = event;
             spyOn(state, 'go').and.callThrough();
             shareCtrl.goTo();
-            expect(state.go).toHaveBeenCalledWith('app.user.event', Object({eventKey: shareCtrl.post.key}));
+            expect(state.go).toHaveBeenCalledWith('app.user.event', Object({ eventKey: shareCtrl.post.key, posts: shareCtrl.posts}));
         });
     });
 


### PR DESCRIPTION
**Feature/Bug description:**
It was missing the timeline's posts in eventDetailsController and in EventPageController. Thus, when a event was shared, it wasn't added to the array.
**Solution:**
I've passed through the controllers that call event-details or go to EventPage passing the timeline's posts when changing the state or marking the directive.

**TODO/FIXME:** n/a