### PR TITLE
Fix vote survey

### DIFF
--- a/backend/handlers/vote_handler.py
+++ b/backend/handlers/vote_handler.py
@@ -32,3 +32,4 @@ class VoteHandler(BaseHandler):
                      'key': user.key.urlsafe()}
 
         survey.vote(user_dict, options_selected)
+        self.response.write(json.dumps(survey.make(self.request.host)))

--- a/backend/test/vote_handler_test.py
+++ b/backend/test/vote_handler_test.py
@@ -87,6 +87,7 @@ def initModels(cls):
     cls.user_post.title = 'Survey with Multiple choice'
     cls.user_post.text = 'Description of survey'
     cls.user_post.number_votes = 0
+    cls.user_post.last_modified_by = cls.user.key
     cls.user_post.deadline = datetime.datetime(2020, 07, 25, 12, 30, 15)
     cls.user_post.options = [{'id': 0,
                               'text': 'first option',

--- a/frontend/post/postDetailsDirective.js
+++ b/frontend/post/postDetailsDirective.js
@@ -345,7 +345,7 @@
 
         postDetailsCtrl.reloadPost = function reloadPost() {
             var type_survey = postDetailsCtrl.post.type_survey;
-            postDetailsCtrl.post.type_survey = false;
+            postDetailsCtrl.post.type_survey = '';
             var promise = PostService.getPost(postDetailsCtrl.post.key);
             promise.then(function success(response) {
                 response.data_comments = Object.values(response.data_comments);

--- a/frontend/post/post_details.html
+++ b/frontend/post/post_details.html
@@ -133,7 +133,7 @@
         <iframe ng-src="{{ postDetailsCtrl.getVideoUrl(postDetailsCtrl.post.shared_post) }}"></iframe>
       </div>
       <p></p>
-      <a ng-if="!postDetailsCtrl.post.shared_post.type_survey"
+      <a ng-if="!postDetailsCtrl.isSharedSurvey()"
       href class="md-text hyperlink" ng-click="postDetailsCtrl.goToPost(postDetailsCtrl.post.shared_post)">
         <span>{{ postDetailsCtrl.post.shared_post.title }}</span>
       </a>
@@ -146,8 +146,9 @@
           <md-icon>more_horiz</md-icon>
         </a>
       </div>
-      <pdf-view ng-if="postDetailsCtrl.showSharedPostText()" pdf-files='postDetailsCtrl.post.shared_post.pdf_files' is-editing="false"></pdf-view>
-      <survey-details ng-if="postDetailsCtrl.post.shared_post.type_survey" 
+      <pdf-view ng-if="postDetailsCtrl.showSharedPostText()" 
+        pdf-files='postDetailsCtrl.post.shared_post.pdf_files' is-editing="false"></pdf-view>
+      <survey-details ng-if="postDetailsCtrl.isSharedSurvey()" 
         post="postDetailsCtrl.post.shared_post" posts="postDetailsCtrl.posts" 
         user="postDetailsCtrl.user" isdialog="false"></survey-details>
     </md-card-content>

--- a/frontend/survey/surveyDetailsDirective.js
+++ b/frontend/survey/surveyDetailsDirective.js
@@ -63,10 +63,9 @@
                 var dialog = MessageService.showConfirmationDialog(ev,
                     'Confirmar voto', 'Seu voto será permanente. Deseja confirmar?');
                 dialog.then(function() {
-                    surveyCtrl.voteService().then(function (response) {
-                        surveyCtrl.post = response.data
-                        syncSharedPosts();
+                    surveyCtrl.voteService().then(function () {                        
                         surveyCtrl.reloadPost();
+                        syncSharedPosts();
                     });
                 }, function() {
                     MessageService.showToast('Cancelado');
@@ -96,7 +95,8 @@
 
         surveyCtrl.voteService = function(){
             var promise = SurveyService.vote(surveyCtrl.post, surveyCtrl.optionsSelected);
-            promise.then(function sucess(){
+            promise.then(function sucess(response){
+                surveyCtrl.post = response.data;
                 addVote(surveyCtrl.optionsSelected);
                 MessageService.showToast('Voto computado');
             });
@@ -131,6 +131,7 @@
                              'photo_url': surveyCtrl.user.photo_url,
                              'key': Utils.getKeyFromUrl(surveyCtrl.user.key) };
                 option.voters.push(voter);
+                surveyCtrl.post.options[option.id] = option;
             });
         }
 

--- a/frontend/survey/surveyDetailsDirective.js
+++ b/frontend/survey/surveyDetailsDirective.js
@@ -63,7 +63,8 @@
                 var dialog = MessageService.showConfirmationDialog(ev,
                     'Confirmar voto', 'Seu voto será permanente. Deseja confirmar?');
                 dialog.then(function() {
-                    surveyCtrl.voteService().then(function () {
+                    surveyCtrl.voteService().then(function (response) {
+                        surveyCtrl.post = response.data
                         syncSharedPosts();
                         surveyCtrl.reloadPost();
                     });

--- a/frontend/test/specs/surveyDetailsDirectiveSpec.js
+++ b/frontend/test/specs/surveyDetailsDirectiveSpec.js
@@ -108,7 +108,7 @@
 
         it('should added vote in option', function(done) {
             promise.should.be.fulfilled.then(function() {                
-                expect(surveyService.vote).toHaveBeenCalledWith(surveyCtrl.post, surveyCtrl.optionsSelected);
+                expect(surveyService.vote).toHaveBeenCalledWith(survey, surveyCtrl.optionsSelected);
                 expect(surveyCtrl.post.options[0].number_votes).toEqual(1);
                 expect(surveyCtrl.post.options[0].voters[0].key).toContain(surveyCtrl.user.key);
             }).should.notify(done);

--- a/frontend/test/specs/surveyDetailsDirectiveSpec.js
+++ b/frontend/test/specs/surveyDetailsDirectiveSpec.js
@@ -107,8 +107,8 @@
         });
 
         it('should added vote in option', function(done) {
-            promise.should.be.fulfilled.then(function() {
-                expect(surveyService.vote).toHaveBeenCalledWith(survey, surveyCtrl.optionsSelected);
+            promise.should.be.fulfilled.then(function() {                
+                expect(surveyService.vote).toHaveBeenCalledWith(surveyCtrl.post, surveyCtrl.optionsSelected);
                 expect(surveyCtrl.post.options[0].number_votes).toEqual(1);
                 expect(surveyCtrl.post.options[0].voters[0].key).toContain(surveyCtrl.user.key);
             }).should.notify(done);

--- a/frontend/test/specs/surveyDetailsDirectiveSpec.js
+++ b/frontend/test/specs/surveyDetailsDirectiveSpec.js
@@ -79,7 +79,7 @@
             spyOn(surveyCtrl, 'voteService').and.callFake(function() {
                 return {
                     then: function(callback) {
-                        return callback();
+                        return callback(survey);
                     }
                 }
             });
@@ -102,13 +102,13 @@
             surveyCtrl.optionsSelected = [options[0]];
             spyOn(surveyCtrl.posts, 'map');
             httpBackend.expect('POST', "/api/surveyposts/" + surveyCtrl.post.key + '/votes').
-                respond(surveyCtrl.optionsSelected);
+                respond(surveyCtrl.post);
             promise = surveyCtrl.voteService();
         });
 
         it('should added vote in option', function(done) {
             promise.should.be.fulfilled.then(function() {
-                expect(surveyService.vote).toHaveBeenCalledWith(surveyCtrl.post, surveyCtrl.optionsSelected);
+                expect(surveyService.vote).toHaveBeenCalledWith(survey, surveyCtrl.optionsSelected);
                 expect(surveyCtrl.post.options[0].number_votes).toEqual(1);
                 expect(surveyCtrl.post.options[0].voters[0].key).toContain(surveyCtrl.user.key);
             }).should.notify(done);


### PR DESCRIPTION
**Feature/Bug description:** If there is the survey and search survey, and any user votes for the original search, the search share options disappear. As the type_survey variable of the search is changed to false, the function that ranks if the post is the search does not recognize the post as such.

**Solution:** Put return in the request when voting the survey, and update the options of the survey.

**TODO/FIXME:** n/a