### PR TITLE
Fix share post dialog

### DIFF
--- a/frontend/post/share_post_dialog.html
+++ b/frontend/post/share_post_dialog.html
@@ -15,7 +15,7 @@
       </div>
       <md-card-content flex>
         <md-card layout-padding md-colors="{background: 'default-grey-100'}" layout="column" flex class="custom-scrollbar share-post">
-          <div layout="row">
+          <div layout="row" style="display: -webkit-box;">
             <img style="width: 40px; height: 40px; border-radius: 50%; margin-right: 8px; display: inline-flex;" ng-src="{{ sharePostCtrl.post.institution_image }}" />
             <div layout="column" flex>
               <b class="small-text-share-post">{{ sharePostCtrl.post.institution_name }}</b>
@@ -29,12 +29,11 @@
             <span ng-if="!sharePostCtrl.isSurvey() && !sharePostCtrl.isEvent()" class="md-text">
               <b ng-bind-html="sharePostCtrl.postToURL(sharePostCtrl.post.title)"></b>
             </span>
-          </br>
             <event-details ng-if="sharePostCtrl.isEvent()" event="sharePostCtrl.post" is-event-page=false></event-details>
             <span class="md-subhead" ng-if="!sharePostCtrl.isEvent() && sharePostCtrl.post.text" ng-bind-html="sharePostCtrl.postToURL(sharePostCtrl.post.text)"></span>
             <pdf-view ng-if="sharePostCtrl.showPdfFiles()" pdf-files='sharePostCtrl.post.pdf_files' is-editing="false"></pdf-view>
-            <survey-details style="display: flex;" layout="column" ng-if="sharePostCtrl.isSurvey()" post="sharePostCtrl.post" posts="sharePostCtrl.posts" user="sharePostCtrl.user"
-              isdialog="true" is-post-page="false" hide show-gt-xs></survey-details>
+            <survey-details layout="column" ng-if="sharePostCtrl.isSurvey()" post="sharePostCtrl.post" posts="sharePostCtrl.posts" user="sharePostCtrl.user"
+              isdialog="true" is-post-page="false" hide-xs show-gt-xs></survey-details>
           </md-card-content>
         </md-card>
       </md-card-content>

--- a/frontend/post/share_post_dialog.html
+++ b/frontend/post/share_post_dialog.html
@@ -22,17 +22,17 @@
               <span class="small-text-share-post">por {{ sharePostCtrl.post.author }}</span>
             </div>
           </div>
-          <md-card-content layout-margin>
+          <md-card-content layout-margin style="margin: 0; padding: 0;">
             <div ng-if="sharePostCtrl.showImage() && !sharePostCtrl.isEvent()" style="height: 13vh;">
               <img class="md-card-image" style="border-radius: 3%; max-width: 100%; height: 100%;" ng-src="{{ sharePostCtrl.post.photo_url }}" />
             </div>
-            <span ng-if="!sharePostCtrl.isSurvey() && !sharePostCtrl.isEvent()" class="md-text">
+            <p ng-if="!sharePostCtrl.isSurvey() && !sharePostCtrl.isEvent()" class="md-text">
               <b ng-bind-html="sharePostCtrl.postToURL(sharePostCtrl.post.title)"></b>
-            </span>
+            </p>
             <event-details ng-if="sharePostCtrl.isEvent()" event="sharePostCtrl.post" is-event-page=false></event-details>
-            <span class="md-subhead" ng-if="!sharePostCtrl.isEvent() && sharePostCtrl.post.text" ng-bind-html="sharePostCtrl.postToURL(sharePostCtrl.post.text)"></span>
+            <p class="md-subhead" ng-if="!sharePostCtrl.isEvent() && sharePostCtrl.post.text" ng-bind-html="sharePostCtrl.postToURL(sharePostCtrl.post.text)"></p>
             <pdf-view ng-if="sharePostCtrl.showPdfFiles()" pdf-files='sharePostCtrl.post.pdf_files' is-editing="false"></pdf-view>
-            <survey-details layout="column" ng-if="sharePostCtrl.isSurvey()" post="sharePostCtrl.post" posts="sharePostCtrl.posts" user="sharePostCtrl.user"
+            <survey-details style="margin: 0;" layout="column" ng-if="sharePostCtrl.isSurvey()" post="sharePostCtrl.post" posts="sharePostCtrl.posts" user="sharePostCtrl.user"
               isdialog="true" is-post-page="false" hide-xs show-gt-xs></survey-details>
           </md-card-content>
         </md-card>

--- a/frontend/post/share_post_dialog.html
+++ b/frontend/post/share_post_dialog.html
@@ -15,14 +15,14 @@
       </div>
       <md-card-content flex>
         <md-card layout-padding md-colors="{background: 'default-grey-100'}" layout="column" flex class="custom-scrollbar share-post">
-          <div layout="row" flex ng-class="sharePostCtrl.showImage() && sharePostCtrl.isEvent() ? 'shared-post-with-image' : 'shared-post-header'">
-            <img style="width: 40px; height: 40px; border-radius: 50%; margin-right: 8px;" ng-src="{{ sharePostCtrl.post.institution_image }}" />
+          <div layout="row">
+            <img style="width: 40px; height: 40px; border-radius: 50%; margin-right: 8px; display: inline-flex;" ng-src="{{ sharePostCtrl.post.institution_image }}" />
             <div layout="column" flex>
               <b class="small-text-share-post">{{ sharePostCtrl.post.institution_name }}</b>
               <span class="small-text-share-post">por {{ sharePostCtrl.post.author }}</span>
             </div>
           </div>
-          <md-card-content layout-margin flex>
+          <md-card-content layout-margin>
             <div ng-if="sharePostCtrl.showImage() && !sharePostCtrl.isEvent()" style="height: 13vh;">
               <img class="md-card-image" style="border-radius: 3%; max-width: 100%; height: 100%;" ng-src="{{ sharePostCtrl.post.photo_url }}" />
             </div>
@@ -33,7 +33,7 @@
             <event-details ng-if="sharePostCtrl.isEvent()" event="sharePostCtrl.post" is-event-page=false></event-details>
             <span class="md-subhead" ng-if="!sharePostCtrl.isEvent() && sharePostCtrl.post.text" ng-bind-html="sharePostCtrl.postToURL(sharePostCtrl.post.text)"></span>
             <pdf-view ng-if="sharePostCtrl.showPdfFiles()" pdf-files='sharePostCtrl.post.pdf_files' is-editing="false"></pdf-view>
-            <survey-details ng-if="sharePostCtrl.isSurvey()" post="sharePostCtrl.post" posts="sharePostCtrl.posts" user="sharePostCtrl.user"
+            <survey-details style="display: flex;" layout="column" ng-if="sharePostCtrl.isSurvey()" post="sharePostCtrl.post" posts="sharePostCtrl.posts" user="sharePostCtrl.user"
               isdialog="true" is-post-page="false" hide show-gt-xs></survey-details>
           </md-card-content>
         </md-card>

--- a/frontend/post/share_post_dialog.html
+++ b/frontend/post/share_post_dialog.html
@@ -16,7 +16,7 @@
       <md-card-content flex>
         <md-card layout-padding md-colors="{background: 'default-grey-100'}" layout="column" flex class="custom-scrollbar share-post">
           <div layout="row" style="display: -webkit-box;">
-            <img style="width: 40px; height: 40px; border-radius: 50%; margin-right: 8px; display: inline-flex;" ng-src="{{ sharePostCtrl.post.institution_image }}" />
+            <img style="width: 40px; height: 40px; border-radius: 50%; margin-right: 8px;" ng-src="{{ sharePostCtrl.post.institution_image }}" />
             <div layout="column" flex>
               <b class="small-text-share-post">{{ sharePostCtrl.post.institution_name }}</b>
               <span class="small-text-share-post">por {{ sharePostCtrl.post.author }}</span>


### PR DESCRIPTION
**Feature/Bug description:** The layout of the post sharing dialog is strange because there is a large space between the post title and its contents.

![screenshot from 2018-06-06 09-04-32](https://user-images.githubusercontent.com/18005317/41037194-e7cc617e-6968-11e8-82df-6fb775d4b66b.png)
![screenshot from 2018-06-06 09-04-43](https://user-images.githubusercontent.com/18005317/41037196-eb4dc2a2-6968-11e8-85f4-29cb3fc132c7.png)
![screenshot from 2018-06-06 09-04-59](https://user-images.githubusercontent.com/18005317/41037198-ef1f90c2-6968-11e8-92c7-c03cbb49d0a1.png)

**Solution:** Using css and angular directives I removed excess white space between the title of the post and its content.

![screenshot from 2018-06-06 09-03-08](https://user-images.githubusercontent.com/18005317/41037178-d9bdf840-6968-11e8-8122-6b5b88382722.png)
![screenshot from 2018-06-06 09-03-40](https://user-images.githubusercontent.com/18005317/41037183-dddb493c-6968-11e8-98e3-0d8edac1e398.png)
![screenshot from 2018-06-06 09-03-56](https://user-images.githubusercontent.com/18005317/41037187-e1d63c54-6968-11e8-9700-53dd0ac0dadd.png)

**TODO/FIXME:** n/a