### PR TITLE
Fix loop when create link between institutions

### DIFF
--- a/backend/models/institution.py
+++ b/backend/models/institution.py
@@ -369,7 +369,7 @@ class Institution(ndb.Model):
             adm_is_child_adm = child.admin == admin_key
             get_next_permissions = get_all or not adm_is_child_adm
             #The child permissions should only be added if the link is confirmed.
-            link_confirmed = child.verify_connection(self)
+            link_confirmed = child.verify_connection(self, 'PARENT')
             if get_next_permissions and link_confirmed:
                 child.get_hierarchy_admin_permissions(get_all, admin_key, permissions)
         
@@ -412,7 +412,7 @@ class Institution(ndb.Model):
             sender_institution_key= sender_institution_key or current_institution_key
         )
 
-    def verify_connection(self, institution_to_verify, verification_type=None):
+    def verify_connection(self, institution_to_verify, verification_type='OTHERWISE'):
         """This method checks if the link between self and institution_to_verify
         is confirmed."""
         #Means that self is institution_to_verify's parent

--- a/backend/models/institution.py
+++ b/backend/models/institution.py
@@ -414,11 +414,14 @@ class Institution(ndb.Model):
 
     def verify_connection(self, institution_to_verify, verification_type='OTHERWISE'):
         """This method checks if the link between self and institution_to_verify
-        is confirmed."""
-        #Means that self is institution_to_verify's parent
-        #parent_link = institution_to_verify.parent_institution == self.key and institution_to_verify.key in self.children_institutions
-        #Means that institution_to_verify is self's parent
-        #child_link = self.parent_institution == institution_to_verify.key and self.key in institution_to_verify.children_institutions
+        is confirmed.
+        
+        Arguments:
+        institution_to_verify -- Institution to verify connection
+        verification_type -- Verification type to be performed. 
+            If the type is PARENT, it checks if the institution being checked is parent, 
+            if CHILDREN checks if it is a child, otherwise it checks both cases.
+        """
         
         switch = {
             'PARENT': lambda child, parent: verify_inst_connection(child, parent),

--- a/backend/test/institution_children_request_handler_test.py
+++ b/backend/test/institution_children_request_handler_test.py
@@ -136,31 +136,45 @@ class InstitutionChildrenRequestHandlerTest(TestBaseHandler):
         request.put()
 
         self.assertTrue(has_permissions(
-            admin, 
-            institution.key.urlsafe(), 
-            permissions.DEFAULT_ADMIN_PERMISSIONS
-        ))
+                admin, 
+                institution.key.urlsafe(), 
+                permissions.DEFAULT_ADMIN_PERMISSIONS
+            ),
+            "Admin must have administrator permissions for this institution"
+        )
 
         self.assertFalse(has_permissions(
-            admin, 
-            other_institution.key.urlsafe(), 
-            permissions.DEFAULT_ADMIN_PERMISSIONS
-        ))
+                admin, 
+                other_institution.key.urlsafe(), 
+                permissions.DEFAULT_ADMIN_PERMISSIONS
+            ),
+            "Admin should not have administrator permissions for this institution"
+        )
 
         self.assertFalse(has_permissions(
-            other_admin, 
-            institution.key.urlsafe(), 
-            permissions.DEFAULT_ADMIN_PERMISSIONS
-        ))
+                other_admin, 
+                institution.key.urlsafe(), 
+                permissions.DEFAULT_ADMIN_PERMISSIONS
+            ),
+            "Other_admin should not have administrator permissions for this institution"
+        )
 
         self.assertTrue(has_permissions(
-            other_admin, 
-            other_institution.key.urlsafe(), 
-            permissions.DEFAULT_ADMIN_PERMISSIONS
-        ))
+                other_admin, 
+                other_institution.key.urlsafe(), 
+                permissions.DEFAULT_ADMIN_PERMISSIONS
+            ),
+            "Other_admin must have administrator permissions for this institution"
+        )
 
-        self.assertFalse(other_institution.verify_connection(institution, 'PARENT'))
-        self.assertFalse(other_institution.verify_connection(institution, 'CHILDREN'))
+        self.assertFalse(
+            other_institution.verify_connection(institution, 'PARENT'),
+            "other_institution should not have confirmed parent link with institution"    
+        )
+        self.assertFalse(
+            other_institution.verify_connection(institution, 'CHILDREN'),
+            "other_institution should not have confirmed children link with institution"
+        )
 
         verify_token._mock_return_value = {'email': admin.email[0]}
         enqueue_task.side_effect = self.enqueue_task
@@ -175,31 +189,45 @@ class InstitutionChildrenRequestHandlerTest(TestBaseHandler):
         other_institution = other_institution.key.get()
 
         self.assertTrue(has_permissions(
-            admin, 
-            institution.key.urlsafe(), 
-            permissions.DEFAULT_ADMIN_PERMISSIONS
-        ))
+                admin, 
+                institution.key.urlsafe(), 
+                permissions.DEFAULT_ADMIN_PERMISSIONS
+            ),
+            "Admin must have administrator permissions for this institution"
+        )
 
         self.assertFalse(has_permissions(
-            admin, 
-            other_institution.key.urlsafe(), 
-            permissions.DEFAULT_ADMIN_PERMISSIONS
-        ))
+                admin, 
+                other_institution.key.urlsafe(), 
+                permissions.DEFAULT_ADMIN_PERMISSIONS
+            ),
+            "Admin should not have administrator permissions for this institution"
+        )
 
         self.assertTrue(has_permissions(
-            other_admin, 
-            institution.key.urlsafe(), 
-            permissions.DEFAULT_ADMIN_PERMISSIONS
-        ))
+                other_admin, 
+                institution.key.urlsafe(), 
+                permissions.DEFAULT_ADMIN_PERMISSIONS
+            ),
+            "Other_admin must have administrator permissions for this institution"
+        )
 
         self.assertTrue(has_permissions(
-            other_admin, 
-            other_institution.key.urlsafe(), 
-            permissions.DEFAULT_ADMIN_PERMISSIONS
-        ))
+                other_admin, 
+                other_institution.key.urlsafe(), 
+                permissions.DEFAULT_ADMIN_PERMISSIONS
+            ),
+            "Other_admin must have administrator permissions for this institution"
+        )
 
-        self.assertFalse(other_institution.verify_connection(institution, 'PARENT'))
-        self.assertTrue(other_institution.verify_connection(institution, 'CHILDREN'))
+        self.assertFalse(
+            other_institution.verify_connection(institution, 'PARENT'),
+            "other_institution should not have confirmed children link with institution"
+        )
+        self.assertTrue(
+            other_institution.verify_connection(institution, 'CHILDREN'),
+            "other_institution should have confirmed children link with institution"
+        )
 
     @patch('util.login_service.verify_token', return_value={'email': 'useradmin@test.com'})
     def test_put_user_not_admin(self, verify_token):

--- a/backend/test/institution_children_request_handler_test.py
+++ b/backend/test/institution_children_request_handler_test.py
@@ -101,6 +101,105 @@ class InstitutionChildrenRequestHandlerTest(TestBaseHandler):
             mock_method.assert_called,
             "Should call the send_message_notification"
         )
+    
+    @patch('handlers.institution_children_request_handler.enqueue_task')
+    @patch('util.login_service.verify_token')
+    def test_put_invite_with_not_confirmed_link(self, verify_token, enqueue_task):
+        """Test put invite with not confirmed children link."""
+        institution = mocks.create_institution()
+        other_institution = mocks.create_institution()
+        admin = mocks.create_user()
+        other_admin = mocks.create_user()
+
+        institution.add_member(admin)
+        other_institution.add_member(other_admin)
+        institution.set_admin(admin.key)
+        other_institution.set_admin(other_admin.key)
+        other_institution.add_child(institution.key)
+        other_institution.parent_institution = institution.key
+
+        admin.add_institution_admin(institution)
+        other_admin.add_institution_admin(other_institution)
+        admin.add_permissions(permissions.DEFAULT_ADMIN_PERMISSIONS, institution.key.urlsafe())
+        other_admin.add_permissions(permissions.DEFAULT_ADMIN_PERMISSIONS, other_institution.key.urlsafe())
+
+        institution.put()
+        other_institution.put()
+        admin.put()
+        other_admin.put()
+
+        request = RequestInstitutionChildren()
+        request.sender_key = other_admin.key
+        request.admin_key = other_admin.key
+        request.institution_requested_key = institution.key
+        request.institution_key = other_institution.key
+        request.put()
+
+        self.assertTrue(has_permissions(
+            admin, 
+            institution.key.urlsafe(), 
+            permissions.DEFAULT_ADMIN_PERMISSIONS
+        ))
+
+        self.assertFalse(has_permissions(
+            admin, 
+            other_institution.key.urlsafe(), 
+            permissions.DEFAULT_ADMIN_PERMISSIONS
+        ))
+
+        self.assertFalse(has_permissions(
+            other_admin, 
+            institution.key.urlsafe(), 
+            permissions.DEFAULT_ADMIN_PERMISSIONS
+        ))
+
+        self.assertTrue(has_permissions(
+            other_admin, 
+            other_institution.key.urlsafe(), 
+            permissions.DEFAULT_ADMIN_PERMISSIONS
+        ))
+
+        self.assertFalse(other_institution.verify_connection(institution, 'PARENT'))
+        self.assertFalse(other_institution.verify_connection(institution, 'CHILDREN'))
+
+        verify_token._mock_return_value = {'email': admin.email[0]}
+        enqueue_task.side_effect = self.enqueue_task
+
+        self.testapp.put(
+            "/api/requests/%s/institution_children" % request.key.urlsafe(),
+            headers={'institution-authorization': institution.key.urlsafe()})
+        
+        admin = admin.key.get()
+        other_admin = other_admin.key.get()
+        institution = institution.key.get()
+        other_institution = other_institution.key.get()
+
+        self.assertTrue(has_permissions(
+            admin, 
+            institution.key.urlsafe(), 
+            permissions.DEFAULT_ADMIN_PERMISSIONS
+        ))
+
+        self.assertFalse(has_permissions(
+            admin, 
+            other_institution.key.urlsafe(), 
+            permissions.DEFAULT_ADMIN_PERMISSIONS
+        ))
+
+        self.assertTrue(has_permissions(
+            other_admin, 
+            institution.key.urlsafe(), 
+            permissions.DEFAULT_ADMIN_PERMISSIONS
+        ))
+
+        self.assertTrue(has_permissions(
+            other_admin, 
+            other_institution.key.urlsafe(), 
+            permissions.DEFAULT_ADMIN_PERMISSIONS
+        ))
+
+        self.assertFalse(other_institution.verify_connection(institution, 'PARENT'))
+        self.assertTrue(other_institution.verify_connection(institution, 'CHILDREN'))
 
     @patch('util.login_service.verify_token', return_value={'email': 'useradmin@test.com'})
     def test_put_user_not_admin(self, verify_token):

--- a/backend/test/institution_parent_request_handler_test.py
+++ b/backend/test/institution_parent_request_handler_test.py
@@ -113,6 +113,107 @@ class InstitutionParentRequestHandlerTest(TestBaseHandler):
             notification_type='ACCEPT_INSTITUTION_LINK',
             message=json.dumps(message)
         )
+    
+    @patch('handlers.institution_parent_request_handler.enqueue_task')
+    @patch('util.login_service.verify_token')
+    def test_put_invite_with_not_confirmed_link(self, verify_token, enqueue_task):
+        """Test put invite with not confirmed children link."""
+        institution = mocks.create_institution()
+        other_institution = mocks.create_institution()
+        admin = mocks.create_user()
+        other_admin = mocks.create_user()
+
+        institution.add_member(admin)
+        other_institution.add_member(other_admin)
+        institution.set_admin(admin.key)
+        other_institution.set_admin(other_admin.key)
+        other_institution.add_child(institution.key)
+        other_institution.parent_institution = institution.key
+
+        admin.add_institution_admin(institution)
+        other_admin.add_institution_admin(other_institution)
+        admin.add_permissions(permissions.DEFAULT_ADMIN_PERMISSIONS, institution.key.urlsafe())
+        other_admin.add_permissions(permissions.DEFAULT_ADMIN_PERMISSIONS, other_institution.key.urlsafe())
+
+        institution.put()
+        other_institution.put()
+        admin.put()
+        other_admin.put()
+
+        request = RequestInstitutionParent()
+        request.sender_key = other_admin.key
+        request.admin_key = other_admin.key
+        request.institution_requested_key = institution.key
+        request.institution_key = other_institution.key
+        request.put()
+
+        self.assertTrue(has_permissions(
+            admin, 
+            institution.key.urlsafe(), 
+            permissions.DEFAULT_ADMIN_PERMISSIONS
+        ))
+
+        self.assertFalse(has_permissions(
+            admin, 
+            other_institution.key.urlsafe(), 
+            permissions.DEFAULT_ADMIN_PERMISSIONS
+        ))
+
+        self.assertFalse(has_permissions(
+            other_admin, 
+            institution.key.urlsafe(), 
+            permissions.DEFAULT_ADMIN_PERMISSIONS
+        ))
+
+        self.assertTrue(has_permissions(
+            other_admin, 
+            other_institution.key.urlsafe(), 
+            permissions.DEFAULT_ADMIN_PERMISSIONS
+        ))
+
+        self.assertFalse(other_institution.verify_connection(institution, 'PARENT'))
+        self.assertFalse(other_institution.verify_connection(institution, 'CHILDREN'))
+
+        verify_token._mock_return_value = {'email': admin.email[0]}
+        enqueue_task.side_effect = self.enqueue_task
+
+        self.testapp.put(
+            "/api/requests/%s/institution_parent" % request.key.urlsafe(),
+            headers={'institution-authorization': institution.key.urlsafe()})
+        
+        admin = admin.key.get()
+        other_admin = other_admin.key.get()
+        institution = institution.key.get()
+        other_institution = other_institution.key.get()
+
+        self.assertTrue(has_permissions(
+            admin, 
+            institution.key.urlsafe(), 
+            permissions.DEFAULT_ADMIN_PERMISSIONS
+        ))
+
+        self.assertTrue(has_permissions(
+            admin, 
+            other_institution.key.urlsafe(), 
+            permissions.DEFAULT_ADMIN_PERMISSIONS
+        ))
+
+        self.assertFalse(has_permissions(
+            other_admin, 
+            institution.key.urlsafe(), 
+            permissions.DEFAULT_ADMIN_PERMISSIONS
+        ))
+
+        self.assertTrue(has_permissions(
+            other_admin, 
+            other_institution.key.urlsafe(), 
+            permissions.DEFAULT_ADMIN_PERMISSIONS
+        ))
+
+        self.assertTrue(other_institution.verify_connection(institution, 'PARENT'))
+        self.assertFalse(other_institution.verify_connection(institution, 'CHILDREN'))
+
+
 
     @patch('util.login_service.verify_token', return_value={'email': 'useradmin@test.com'})
     def test_put_user_not_admin(self, verify_token):

--- a/backend/test/institution_parent_request_handler_test.py
+++ b/backend/test/institution_parent_request_handler_test.py
@@ -148,31 +148,45 @@ class InstitutionParentRequestHandlerTest(TestBaseHandler):
         request.put()
 
         self.assertTrue(has_permissions(
-            admin, 
-            institution.key.urlsafe(), 
-            permissions.DEFAULT_ADMIN_PERMISSIONS
-        ))
+                admin, 
+                institution.key.urlsafe(), 
+                permissions.DEFAULT_ADMIN_PERMISSIONS
+            ),
+            "Admin must have administrator permissions for this institution"
+        )
 
         self.assertFalse(has_permissions(
-            admin, 
-            other_institution.key.urlsafe(), 
-            permissions.DEFAULT_ADMIN_PERMISSIONS
-        ))
+                admin, 
+                other_institution.key.urlsafe(), 
+                permissions.DEFAULT_ADMIN_PERMISSIONS
+            ),
+            "Admin should not have administrator permissions for this institution"
+        )
 
         self.assertFalse(has_permissions(
-            other_admin, 
-            institution.key.urlsafe(), 
-            permissions.DEFAULT_ADMIN_PERMISSIONS
-        ))
+                other_admin, 
+                institution.key.urlsafe(), 
+                permissions.DEFAULT_ADMIN_PERMISSIONS
+            ),
+            "Other_admin should not have administrator permissions for this institution"
+        )
 
         self.assertTrue(has_permissions(
-            other_admin, 
-            other_institution.key.urlsafe(), 
-            permissions.DEFAULT_ADMIN_PERMISSIONS
-        ))
+                other_admin, 
+                other_institution.key.urlsafe(), 
+                permissions.DEFAULT_ADMIN_PERMISSIONS
+            ),
+            "Other_admin must have administrator permissions for this institution"
+        )
 
-        self.assertFalse(other_institution.verify_connection(institution, 'PARENT'))
-        self.assertFalse(other_institution.verify_connection(institution, 'CHILDREN'))
+        self.assertFalse(
+            other_institution.verify_connection(institution, 'PARENT'),
+            "other_institution should not have confirmed parent link with institution"
+        )
+        self.assertFalse(
+            other_institution.verify_connection(institution, 'CHILDREN'),
+            "other_institution should not have confirmed children link with institution"
+        )
 
         verify_token._mock_return_value = {'email': admin.email[0]}
         enqueue_task.side_effect = self.enqueue_task
@@ -187,31 +201,45 @@ class InstitutionParentRequestHandlerTest(TestBaseHandler):
         other_institution = other_institution.key.get()
 
         self.assertTrue(has_permissions(
-            admin, 
-            institution.key.urlsafe(), 
-            permissions.DEFAULT_ADMIN_PERMISSIONS
-        ))
+                admin, 
+                institution.key.urlsafe(), 
+                permissions.DEFAULT_ADMIN_PERMISSIONS
+            ),
+            "Admin must have administrator permissions for this institution"
+        )
 
         self.assertTrue(has_permissions(
-            admin, 
-            other_institution.key.urlsafe(), 
-            permissions.DEFAULT_ADMIN_PERMISSIONS
-        ))
+                admin, 
+                other_institution.key.urlsafe(), 
+                permissions.DEFAULT_ADMIN_PERMISSIONS
+            ),
+            "Admin must have administrator permissions for this institution"
+        )
 
         self.assertFalse(has_permissions(
-            other_admin, 
-            institution.key.urlsafe(), 
-            permissions.DEFAULT_ADMIN_PERMISSIONS
-        ))
+                other_admin, 
+                institution.key.urlsafe(), 
+                permissions.DEFAULT_ADMIN_PERMISSIONS
+            ),
+            "Other_admin should not have administrator permissions for this institution"
+        )
 
         self.assertTrue(has_permissions(
-            other_admin, 
-            other_institution.key.urlsafe(), 
-            permissions.DEFAULT_ADMIN_PERMISSIONS
-        ))
+                other_admin, 
+                other_institution.key.urlsafe(), 
+                permissions.DEFAULT_ADMIN_PERMISSIONS
+            ),
+            "Other_admin must have administrator permissions for this institution"
+        )
 
-        self.assertTrue(other_institution.verify_connection(institution, 'PARENT'))
-        self.assertFalse(other_institution.verify_connection(institution, 'CHILDREN'))
+        self.assertTrue(
+            other_institution.verify_connection(institution, 'PARENT'),
+            "other_institution should have confirmed parent link with institution"
+        )
+        self.assertFalse(
+            other_institution.verify_connection(institution, 'CHILDREN'),
+            "other_institution should not have confirmed children link with institution"    
+        )
 
 
 

--- a/backend/test/model_test/institution_test.py
+++ b/backend/test/model_test/institution_test.py
@@ -391,23 +391,31 @@ class InstitutionTest(TestBase):
         parent_inst = mocks.create_institution()
 
         #There is no link
-        self.assertFalse(child_inst.verify_connection(parent_inst))
+        self.assertFalse(child_inst.verify_connection(parent_inst, 'PARENT'))
+        self.assertFalse(parent_inst.verify_connection(child_inst, 'CHILDREN'))
         self.assertFalse(parent_inst.verify_connection(child_inst))
+        self.assertFalse(child_inst.verify_connection(parent_inst))
         
         child_inst.parent_institution = parent_inst.key
 
         #Just the child is linked to the parent
-        self.assertFalse(child_inst.verify_connection(parent_inst))
+        self.assertFalse(child_inst.verify_connection(parent_inst, 'PARENT'))
+        self.assertFalse(parent_inst.verify_connection(child_inst, 'CHILDREN'))
         self.assertFalse(parent_inst.verify_connection(child_inst))
+        self.assertFalse(child_inst.verify_connection(parent_inst))
 
         parent_inst.children_institutions.append(child_inst.key)
         
         #There is link in two directions
-        self.assertTrue(child_inst.verify_connection(parent_inst))
+        self.assertTrue(child_inst.verify_connection(parent_inst, 'PARENT'))
+        self.assertTrue(parent_inst.verify_connection(child_inst, 'CHILDREN'))
         self.assertTrue(parent_inst.verify_connection(child_inst))
+        self.assertTrue(child_inst.verify_connection(parent_inst))
 
         child_inst.parent_institution = None
 
         #Just the parent is linked to the child
-        self.assertFalse(child_inst.verify_connection(parent_inst))
+        self.assertFalse(child_inst.verify_connection(parent_inst, 'PARENT'))
+        self.assertFalse(parent_inst.verify_connection(child_inst, 'CHILDREN'))
         self.assertFalse(parent_inst.verify_connection(child_inst))
+        self.assertFalse(child_inst.verify_connection(parent_inst))

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -88,7 +88,7 @@ def get_all_parent_admins(child_institution, admins=[]):
     parent_institution = child_institution.parent_institution
     if parent_institution:
         parent_institution = parent_institution.get()
-        link_confirmed = child_institution.verify_connection(parent_institution)
+        link_confirmed = child_institution.verify_connection(parent_institution, 'PARENT')
         if link_confirmed:
             get_all_parent_admins(parent_institution, admins)
     return admins
@@ -99,7 +99,7 @@ def add_permission_to_children(parent, admins, permission):
     and add permission for each of the admin inside of the admins list."""
     for child_key in parent.children_institutions:
         child = child_key.get()
-        if(child.verify_connection(parent)):
+        if(child.verify_connection(parent, 'PARENT')):
             for admin in admins:
                 admin.add_permission(permission, child_key.urlsafe())
             add_permission_to_children(child, admins, permission)
@@ -118,7 +118,7 @@ def remove_permissions(remove_hierarchy, institution):
 
             for child in institution.children_institutions:
                 child = child.get()
-                if(child.verify_connection(institution)):
+                if(child.verify_connection(institution, 'PARENT')):
                     remove_permissions(remove_hierarchy, child)
         else:
             current_permissions = filter_permissions_to_remove(


### PR DESCRIPTION
**Feature/Bug description:** When an institution A sends a request to institution B to be daughter and B rejects, A passes an unconfirmed link to B. If A sends a request for B to be a parent, and B confirms an infinite loop error is generated in the worker.

**Solution:** Modify the verify_connection method on the institution template so that it only verifies whether one institution is the parent or child of other of the other and not both checks at the same time.

**TODO/FIXME:** n/a