### PR TITLE
Removing AddPostInstitution handler

### DIFF
--- a/backend/handlers/post_collection_handler.py
+++ b/backend/handlers/post_collection_handler.py
@@ -60,12 +60,7 @@ class PostCollectionHandler(BaseHandler):
             created_post = PostFactory.create(post_data, user.key, institution.key)
             user.add_post(created_post)
 
-            params = {
-                'institution_key': institution.key.urlsafe(),
-                'created_post_key': created_post.key.urlsafe()
-            }
-
-            enqueue_task('add-post-institution', params)
+            institution.add_post(created_post)
 
             return created_post
 

--- a/backend/test/post_collection_handler_test.py
+++ b/backend/test/post_collection_handler_test.py
@@ -93,15 +93,10 @@ class PostCollectionHandlerTest(TestBaseHandler):
         self.assertEqual(post_obj.text,
                          'testing new post',
                          "The post's text is not the expected one")
+        self.assertTrue(key_post in self.institution.posts,
+                        "The post is not in user.posts")
 
         calls = [
-            call(
-                "add-post-institution",
-                {
-                    'institution_key': self.institution.key.urlsafe(),
-                    'created_post_key': post.get('key')
-                }
-            ),
             call(
                 'notify-followers',
                 {
@@ -184,15 +179,10 @@ class PostCollectionHandlerTest(TestBaseHandler):
         self.assertEqual(shared_post_obj['text'],
                          self.post.text,
                          "The post's text expected is '%s'" % self.post.text)
+        self.assertTrue(key_post in self.institution.posts,
+                        "The post is not in user.posts")
         
         calls = [
-            call(
-                "add-post-institution",
-                {
-                    'institution_key': self.institution.key.urlsafe(),
-                    'created_post_key': key_post.urlsafe()
-                }
-            ),
             call(
                 'notify-followers',
                 {
@@ -249,6 +239,8 @@ class PostCollectionHandlerTest(TestBaseHandler):
         # Check if the post's attributes are the expected
         self.assertEqual(post_obj.institution, self.institution.key,
                          "The post's institution is not the expected one")
+        self.assertTrue(key_post in self.institution.posts,
+                        "The post is not in user.posts")
 
         shared_event_obj = post['shared_event']
 
@@ -266,13 +258,6 @@ class PostCollectionHandlerTest(TestBaseHandler):
                          "The post's text expected is %s" % event.text)
 
         calls = [
-            call(
-                "add-post-institution",
-                {
-                    'institution_key': self.institution.key.urlsafe(),
-                    'created_post_key': post_obj.key.urlsafe()
-                }
-            ),
             call(
                 'notify-followers',
                 {
@@ -362,15 +347,10 @@ class PostCollectionHandlerTest(TestBaseHandler):
                          "The post's type is 'multiple_choice'")
         self.assertEqual(survey_obj.state, 'published',
                          "The post's state is 'published'")
+        self.assertTrue(key_survey in self.institution.posts,
+                        "The post is not in user.posts")
 
         calls = [
-            call(
-                "add-post-institution",
-                {
-                    'institution_key': self.institution.key.urlsafe(),
-                    'created_post_key': survey_obj.key.urlsafe()
-                }
-            ),
             call(
                 'notify-followers',
                 {

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -399,15 +399,6 @@ class RemoveAdminPermissionsInInstitutionHierarchy(BaseHandler):
                         current_admin, permissions)
         apply_remove_operation(parent_admin, institution, is_not_admin, child_admin_key)
 
-class AddPostInInstitution(BaseHandler):
-    
-    def post(self):
-        institution_key = self.request.get('institution_key')
-        institution = ndb.Key(urlsafe=institution_key).get()
-        created_post_key = self.request.get('created_post_key')
-        created_post = ndb.Key(urlsafe=created_post_key).get()
-
-        institution.add_post(created_post)
 
 class SendInviteHandler(BaseHandler):
 
@@ -504,7 +495,6 @@ app = webapp2.WSGIApplication([
     ('/api/queue/notify-followers', NotifyFollowersHandler),
     ('/api/queue/add-admin-permissions', AddAdminPermissionsInInstitutionHierarchy),
     ('/api/queue/remove-admin-permissions', RemoveAdminPermissionsInInstitutionHierarchy),
-    ('/api/queue/add-post-institution', AddPostInInstitution),
     ('/api/queue/send-invite', SendInviteHandler),
     ('/api/queue/transfer-admin-permissions', TransferAdminPermissionsHandler)
 ], debug=True)


### PR DESCRIPTION
**Feature/Bug description:**
The worker's AddPostInstitution handler was useless once its operations were very simple.
**Solution:**
I've removed the handler and now the post is added in PostCollectionHandler.

**TODO/FIXME:** n/a