### PR TITLE
Remove duplicated showToast in sendUserInvite

### DIFF
--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -122,7 +122,6 @@
                     MessageService.showToast(responseData.msg);
                 }, function error(response) {
                     manageMemberCtrl.isLoadingInvite = false;
-                    MessageService.showToast(response.msg);
                 });
                 return promise;
             }


### PR DESCRIPTION
**Feature/Bug description:**
The showToast was been called twice, once by managementMembersController and another by HttpService. This occurs because inviteService calls HttpService and managementMembersController calls InviteService.

**Solution:**
Remove showToast from managementMembersController.sendUserInvite()

**TODO/FIXME:** n/a