### PR TITLE
Move create notifications messages to other service

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -187,6 +187,7 @@
   <script src="app/imageUpload/cropImageController.js"></script>
 
   <!-- Notifications Library -->
+  <script src="app/notification/notificationMessageCreatorService.js"></script>
   <script src="app/notification/notificationService.js"></script>
   <script src="app/notification/notificationDirective.js"></script>
 

--- a/frontend/notification/notificationMessageCreatorService.js
+++ b/frontend/notification/notificationMessageCreatorService.js
@@ -1,7 +1,7 @@
 'use strict';
 
 (function() {
-    var app = angula.module('app');
+    var app = angular.module('app');
 
     app.service("NotificationMessageCreatorService", function() {
         var service = this;

--- a/frontend/notification/notificationMessageCreatorService.js
+++ b/frontend/notification/notificationMessageCreatorService.js
@@ -1,0 +1,67 @@
+'use strict';
+
+(function() {
+    var app = angula.module('app');
+
+    app.service("NotificationMessageCreatorService", function() {
+        var service = this;
+
+        /** Types of notification based on 
+         *  the number of institutions mentioned on it **/
+        var NO_INST = 'no_institution';
+        var SINGLE_INST = 'single_institution';
+        var DOUBLE_INST = 'double_institutions';
+   
+        var MESSAGE_ASSEMBLERS = {
+            'COMMENT': messageCreator('Comentou em um post de ', SINGLE_INST),
+            'POST': messageCreator('Publicou um novo post de ', SINGLE_INST),
+            'SURVEY_POST': messageCreator('Publicou uma nova enquete de ', SINGLE_INST),
+            'SHARED_POST': messageCreator('Compartilhou um post de ', SINGLE_INST),
+            'INVITE': messageCreator('Te enviou um novo convite via ', SINGLE_INST),
+            'REMOVE_INSTITUTION_LINK': messageCreator('Removeu a conexão entre ', DOUBLE_INST),
+            'DELETED_INSTITUTION': messageCreator('Removeu ', SINGLE_INST),
+            'REQUEST_USER': messageCreator('Solicitou ser membro de ', SINGLE_INST),
+            'REQUEST_INSTITUTION_PARENT': messageCreator('Solicitou um novo vínculo entre ', DOUBLE_INST),
+            'REQUEST_INSTITUTION_CHILDREN': messageCreator('Solicitou um novo vínculo entre ', DOUBLE_INST),
+            'REQUEST_INSTITUTION': messageCreator('Deseja criar uma nova institutição', NO_INST),
+            'REPLY_COMMENT': messageCreator('Respondeu ao seu comentário no post de ', SINGLE_INST),
+            'LIKE_COMMENT': messageCreator('Curtiu seu comentário no post de ', SINGLE_INST),
+            'LIKE_POST': messageCreator('Curtiu um post de ', SINGLE_INST),
+            'REJECT_INSTITUTION_LINK': messageCreator('Rejeitou sua solicitação de vínculo entre ', DOUBLE_INST),
+            'ACCEPT_INSTITUTION_LINK': messageCreator('Aceitou sua solicitação de vínculo entre ', DOUBLE_INST),
+            'REJECT_INVITE_USER': messageCreator('Rejeitou o convite para ser membro de ', SINGLE_INST),
+            'ACCEPT_INVITE_USER': messageCreator('Aceitou o convite para ser membro de ', SINGLE_INST),
+            'REJECT_INVITE_INSTITUTION': messageCreator('Rejeitou o seu convite para ser administrador', NO_INST),
+            'ACCEPT_INVITE_INSTITUTION': messageCreator('Aceitou o seu convite para ser administrador', NO_INST),
+            'DELETE_MEMBER': messageCreator('Removeu você de ', SINGLE_INST),
+            'LEFT_INSTITUTION': messageCreator('O usuário removeu o vínculo de membro com ', SINGLE_INST),
+            'ACCEPTED_LINK': messageCreator('Aceitou sua solicitação de vínculo com ', SINGLE_INST),
+            'REJECTED_LINK': messageCreator('Rejeitou sua solicitação de vínculo com ', SINGLE_INST),
+            'SHARED_EVENT': messageCreator('Compartilhou um evento de ', SINGLE_INST),
+            'DELETED_POST': messageCreator('Deletou o seu post em ', SINGLE_INST),
+            'USER_ADM': messageCreator('Indicou você para ser administrador da instituição ', SINGLE_INST),
+            'ACCEPT_INVITE_USER_ADM': messageCreator('Aceitou seu convite para ser administrador de ', SINGLE_INST),
+            'REJECT_INVITE_USER_ADM': messageCreator('Rejeitou seu convite para ser administrador de ', SINGLE_INST),
+            'ACCEPT_INVITE_HIERARCHY': messageCreator('Aceitou seu convite e estabeleceu vínculo entre ', DOUBLE_INST)
+        };
+
+
+        service.assembleMessage = function assembleMessage(entity_type, mainInst, otherInst) {
+            var assembler = MESSAGE_ASSEMBLERS[entity_type];
+            return assembler(mainInst, otherInst);
+        };
+
+        function messageCreator(message, notificationType) {
+            return function (mainInst, otherInst) {
+                switch(notificationType) {
+                    case DOUBLE_INST: 
+                        return message + `${mainInst} e ${otherInst}`; 
+                    case SINGLE_INST:
+                        return message + (mainInst || otherInst); 
+                    default:
+                        return message;
+                }
+            };            
+        }
+    });
+})();

--- a/frontend/notification/notificationService.js
+++ b/frontend/notification/notificationService.js
@@ -3,51 +3,13 @@
 (function() {
     var app = angular.module("app");
 
-    app.service("NotificationService", function NotificationService($firebaseArray,  MessageService, AuthService, $rootScope) {
+    app.service("NotificationService", function NotificationService($firebaseArray,  MessageService, AuthService, $rootScope,
+        NotificationMessageCreatorService) {
         var service = this;
 
         var ref = firebase.database().ref();
 
         service.firebaseArrayNotifications;
-
-        /** Types of notification based on 
-         *  the number of institutions mentioned on it **/
-        var NO_INST = 'no_institution';
-        var SINGLE_INST = 'single_institution';
-        var DOUBLE_INST = 'double_institutions';
-
-        var MESSAGE_ASSEMBLERS = {
-            'COMMENT': messageCreator('Comentou em um post de ', SINGLE_INST),
-            'POST': messageCreator('Publicou um novo post de ', SINGLE_INST),
-            'SURVEY_POST': messageCreator('Publicou uma nova enquete de ', SINGLE_INST),
-            'SHARED_POST': messageCreator('Compartilhou um post de ', SINGLE_INST),
-            'INVITE': messageCreator('Te enviou um novo convite via ', SINGLE_INST),
-            'REMOVE_INSTITUTION_LINK': messageCreator('Removeu a conexão entre ', DOUBLE_INST),
-            'DELETED_INSTITUTION': messageCreator('Removeu ', SINGLE_INST),
-            'REQUEST_USER': messageCreator('Solicitou ser membro de ', SINGLE_INST),
-            'REQUEST_INSTITUTION_PARENT': messageCreator('Solicitou um novo vínculo entre ', DOUBLE_INST),
-            'REQUEST_INSTITUTION_CHILDREN': messageCreator('Solicitou um novo vínculo entre ', DOUBLE_INST),
-            'REQUEST_INSTITUTION': messageCreator('Deseja criar uma nova institutição', NO_INST),
-            'REPLY_COMMENT': messageCreator('Respondeu ao seu comentário no post de ', SINGLE_INST),
-            'LIKE_COMMENT': messageCreator('Curtiu seu comentário no post de ', SINGLE_INST),
-            'LIKE_POST': messageCreator('Curtiu um post de ', SINGLE_INST),
-            'REJECT_INSTITUTION_LINK': messageCreator('Rejeitou sua solicitação de vínculo entre ', DOUBLE_INST),
-            'ACCEPT_INSTITUTION_LINK': messageCreator('Aceitou sua solicitação de vínculo entre ', DOUBLE_INST),
-            'REJECT_INVITE_USER': messageCreator('Rejeitou o convite para ser membro de ', SINGLE_INST),
-            'ACCEPT_INVITE_USER': messageCreator('Aceitou o convite para ser membro de ', SINGLE_INST),
-            'REJECT_INVITE_INSTITUTION': messageCreator('Rejeitou o seu convite para ser administrador', NO_INST),
-            'ACCEPT_INVITE_INSTITUTION': messageCreator('Aceitou o seu convite para ser administrador', NO_INST),
-            'DELETE_MEMBER': messageCreator('Removeu você de ', SINGLE_INST),
-            'LEFT_INSTITUTION': messageCreator('O usuário removeu o vínculo de membro com ', SINGLE_INST),
-            'ACCEPTED_LINK': messageCreator('Aceitou sua solicitação de vínculo com ', SINGLE_INST),
-            'REJECTED_LINK': messageCreator('Rejeitou sua solicitação de vínculo com ', SINGLE_INST),
-            'SHARED_EVENT': messageCreator('Compartilhou um evento de ', SINGLE_INST),
-            'DELETED_POST': messageCreator('Deletou o seu post em ', SINGLE_INST),
-            'USER_ADM': messageCreator('Indicou você para ser administrador da instituição ', SINGLE_INST),
-            'ACCEPT_INVITE_USER_ADM': messageCreator('Aceitou seu convite para ser administrador de ', SINGLE_INST),
-            'REJECT_INVITE_USER_ADM': messageCreator('Rejeitou seu convite para ser administrador de ', SINGLE_INST),
-            'ACCEPT_INVITE_HIERARCHY': messageCreator('Aceitou seu convite e estabeleceu vínculo entre ', DOUBLE_INST)
-        };
 
         var POST_NOTIFICATION = 'POST';
         var CHILD_ADDED = "child_added";
@@ -61,7 +23,7 @@
              * DATE: 10/05/2018
              */
             var otherInst = (notification.to && notification.to.institution_name) || notification.from.institution_name;
-            var message = assembleMessage(entity_type, mainInst, otherInst);
+            var message = NotificationMessageCreatorService.assembleMessage(entity_type, mainInst, otherInst);
             return message;
         };
 
@@ -119,24 +81,6 @@
 
         function isNew(notification) {
             return notification.status === "NEW";
-        }
-
-        function assembleMessage(entity_type, mainInst, otherInst) {
-            var assembler = MESSAGE_ASSEMBLERS[entity_type];
-            return assembler(mainInst, otherInst);
-        }
-
-        function messageCreator(message, notificationType) {
-            return function (mainInst, otherInst) {
-                switch(notificationType) {
-                    case DOUBLE_INST: 
-                        return message + `${mainInst} e ${otherInst}`; 
-                    case SINGLE_INST:
-                        return message + (mainInst || otherInst); 
-                    default:
-                        return message;
-                }
-            };            
         }
 
         /**


### PR DESCRIPTION
**Feature/Bug description:** Due to a large number of notifications in the system, the service notificationsService has become very large because all the notification messages are created in it.

**Solution:** Create a new service (NotificationMessageCreatorService) that is responsible for creating notification messages, removing this responsibility from the notificationService.

**TODO/FIXME:** n/a