### PR TITLE
Fix create event

### DIFF
--- a/frontend/event/event_dialog.html
+++ b/frontend/event/event_dialog.html
@@ -72,14 +72,14 @@
                         <input mdc-datetime-picker="" short-time="false" date="true" time="true" type="text" format="DD-MM-YYYY HH:mm"
                           placeholder="Data inicial" ng-model="controller.event.start_time" class="md-input" today-text="Hoje" min-date="controller.now"
                           max-date="controller.event.end_time" cancel-text="Cancelar" ng-change="controller.createInitDate()" required
-                          ng-disabled="controller.isEventOutdated()"/>
+                          ng-disabled="controller.isEventOutdated() && controller.isEditing"/>
                     </md-input-container>
                     <md-input-container style="margin: 0" flex="45">
                         <input mdc-datetime-picker="" ng-change="controller.changeDate('endTime')" date="true" time="true"
                           type="text" today-text="Hoje" placeholder="Data final" class="md-input" format="DD-MM-YYYY HH:mm"
                           min-date="controller.startTime" max-date="null"
                           ng-model="controller.event.end_time" cancel-text="Cancelar"
-                          ng-disabled="!controller.event.start_time || controller.isEventOutdated()" required>
+                          ng-disabled="!controller.event.start_time || (controller.isEventOutdated() && controller.isEditing)" required>
                         <div ng-messages>
                           <div ng-show="!controller.event.start_time"
                               style="opacity: 0.9; margin-top: 2px; font-size: 0.8em;">


### PR DESCRIPTION
**Feature/Bug description:** When trying to create an event and put the end date exactly the same as the start date, the user is unable to finish creating the event and can not change the dates.

**Solution:** In the field of dates where there is a check that checks if the event is over, I've added a new check that checks whether the event is being created or edited. If it is being created, the date can be changed, otherwise it can not.

**TODO/FIXME:** n/a