### PR TITLE
Redirecting passive notifications to notifications page

### DIFF
--- a/frontend/notification/notificationDirective.js
+++ b/frontend/notification/notificationDirective.js
@@ -213,7 +213,11 @@
 
         notificationCtrl.goTo = function goTo(notification) {
             var state = type_data[notification.entity_type].state;
-            $state.go(state, {key: notification.entity.key});
+            if(state) {
+                $state.go(state, {key: notification.entity.key});
+            } else {
+                notificationCtrl.seeAll();
+            }
         };
 
         notificationCtrl.action = function action(notification, event) {


### PR DESCRIPTION
**Feature/Bug description:** The notifications without states to go does nothing when the user clicks.

**Solution:** Adding a condition to go to notifications page when the notification has no state.

**TODO/FIXME:** n/a