### PR TITLE
Adding white background in institution cover photo

### DIFF
--- a/frontend/institution/base_institution_page.html
+++ b/frontend/institution/base_institution_page.html
@@ -36,7 +36,7 @@
                     </div>
                 </div>
                 <div md-colors="{background: 'light-green-500'}" style="margin: 0; height: 11em; overflow: hidden;">
-                    <img ng-if="institutionCtrl.showImageCover()" ng-src="{{institutionCtrl.institution.cover_photo}}" style="width: 100%;"/>
+                    <img ng-if="institutionCtrl.showImageCover()" ng-src="{{institutionCtrl.institution.cover_photo}}" style="width: 100%; background: white;"/>
                     <load-circle style="filter: alpha(opacity=100);" add-layout-fill="true" layout="row" 
                         layout-align="center center" ng-if="institutionCtrl.isLoadingCover"></load-circle>
                 </div>


### PR DESCRIPTION
**Feature/Bug description:** The background of the cover of an institution is light green and this does a strange visualization.
![screenshot from 2018-06-08 17-42-58](https://user-images.githubusercontent.com/20300259/41180189-d4224c92-6b43-11e8-853f-b3af54b46e03.png)

**Solution:** Adding a white background to improve visualization of PNG images.

![screenshot from 2018-06-08 17-40-51](https://user-images.githubusercontent.com/20300259/41180222-e8596ede-6b43-11e8-9d4d-69af3551ba19.png)

**TODO/FIXME:** n/a