### PR TITLE
Fix delete user account

### DIFF
--- a/backend/handlers/user_handler.py
+++ b/backend/handlers/user_handler.py
@@ -36,7 +36,8 @@ def define_entity(dictionary):
 
 def remove_user_from_institutions(user):
     """Remove user from all your institutions."""
-    for institution_key in user.institutions:
+    for i in range(len(user.institutions) -1, -1, -1):
+        institution_key = user.institutions[i]
         institution = institution_key.get()
         institution.remove_member(user)
         institution.unfollow(user.key)

--- a/backend/test/user_handler_test.py
+++ b/backend/test/user_handler_test.py
@@ -39,11 +39,21 @@ class UserHandlerTest(TestBaseHandler):
         cls.institution.add_member(cls.user)
         cls.institution.add_member(cls.other_user)
         cls.institution.change_state('active')
+        # create other institution
+        cls.other_institution = mocks.create_institution()
+        cls.other_institution.admin = cls.other_user.key
+        cls.other_institution.follow(cls.user.key)
+        cls.other_institution.follow(cls.other_user.key)
+        cls.other_institution.add_member(cls.user)
+        cls.other_institution.add_member(cls.other_user)
+        cls.other_institution.change_state('active')
         # update user
         cls.user.institutions.append(cls.institution.key)
         cls.user.add_institution_admin(cls.institution.key)
         # update other_user
+        cls.other_user.add_institution(cls.other_institution.key)
         cls.other_user.add_institution(cls.institution.key)
+        cls.other_user.follow(cls.other_institution.key)
         cls.other_user.follow(cls.institution.key)
         inst_profile_data = {
             "office": "Member",
@@ -91,9 +101,9 @@ class UserHandlerTest(TestBaseHandler):
         verify_token._mock_return_value = {'email': self.other_user.email[0]}
         # check the user properties before delete it
         self.assertEquals(self.other_user.state, "active", "The user state should be 'active'")
-        self.assertEquals(self.other_user.institutions, [self.institution.key], 
+        self.assertEquals(self.other_user.institutions, [self.other_institution.key, self.institution.key], 
             "The institution key should be in user institutions")
-        self.assertEquals(self.other_user.follows, [self.institution.key], 
+        self.assertEquals(self.other_user.follows, [self.other_institution.key, self.institution.key], 
             "The institution key should be in user follows")
         self.assertTrue(self.other_user.institution_profiles != [],
             "The user institution profiles should not be empty")

--- a/backend/test/user_handler_test.py
+++ b/backend/test/user_handler_test.py
@@ -126,18 +126,18 @@ class UserHandlerTest(TestBaseHandler):
         # assert institution has no longer the deleted user
         self.assertTrue(self.other_user.key not in self.institution.members, 
             "The user key should not be in institution members") 
-        self.assertTrue(self.other_user.key not in self.institution.followers, 
-            "The user key should not be in institution followers") 
+        self.assertTrue(self.other_user.key in self.institution.followers, 
+            "The user key should be in institution followers") 
         # assert other_institution has no longer the deleted user
         self.assertTrue(self.other_user.key not in self.other_institution.members, 
             "The user key should not be in institution members") 
-        self.assertTrue(self.other_user.key not in self.other_institution.followers, 
-            "The user key should not be in institution followers") 
+        self.assertTrue(self.other_user.key in self.other_institution.followers, 
+            "The user key should be in institution followers") 
 
         # assert user has no longer institutions and permissions
         self.assertEquals(self.other_user.state, "inactive", "The user state should be 'inactive'")
         self.assertEquals(self.other_user.institutions, [], "User institutions should be empty")
-        self.assertEquals(self.other_user.follows, [self.institution.key], "User institutions should not be empty")
+        self.assertEquals(self.other_user.follows, [self.other_institution.key, self.institution.key], "User institutions should not be empty")
         self.assertEquals(self.other_user.permissions, {}, "User permissions should be empty")
         self.assertEquals(self.other_user.institution_profiles, [], "User permissions should be empty")
 

--- a/backend/test/user_handler_test.py
+++ b/backend/test/user_handler_test.py
@@ -121,11 +121,17 @@ class UserHandlerTest(TestBaseHandler):
         # update user and institution
         self.other_user = self.other_user.key.get()
         self.institution = self.institution.key.get()
+        self.other_institution = self.other_institution.key.get()
         
         # assert institution has no longer the deleted user
         self.assertTrue(self.other_user.key not in self.institution.members, 
             "The user key should not be in institution members") 
         self.assertTrue(self.other_user.key not in self.institution.followers, 
+            "The user key should not be in institution followers") 
+        # assert other_institution has no longer the deleted user
+        self.assertTrue(self.other_user.key not in self.other_institution.members, 
+            "The user key should not be in institution members") 
+        self.assertTrue(self.other_user.key not in self.other_institution.followers, 
             "The user key should not be in institution followers") 
 
         # assert user has no longer institutions and permissions

--- a/backend/test/user_handler_test.py
+++ b/backend/test/user_handler_test.py
@@ -137,7 +137,7 @@ class UserHandlerTest(TestBaseHandler):
         # assert user has no longer institutions and permissions
         self.assertEquals(self.other_user.state, "inactive", "The user state should be 'inactive'")
         self.assertEquals(self.other_user.institutions, [], "User institutions should be empty")
-        self.assertEquals(self.other_user.follows, [self.other_institution.key, self.institution.key], "User institutions should not be empty")
+        self.assertEquals(self.other_user.follows, [self.other_institution.key, self.institution.key], "Institutions followed by user should not be empty")
         self.assertEquals(self.other_user.permissions, {}, "User permissions should be empty")
         self.assertEquals(self.other_user.institution_profiles, [], "User permissions should be empty")
 


### PR DESCRIPTION
**Feature/Bug description:** If you have more than one institution deleting your account, some institutions are not removed because of how it is iterating over user institutions.
For example, the user has the following array [InstA, InstB]. For in its first step remove InstA, the second step would remove InstB, however, InstB is at index 0 of the array.

**Solution:** Iterate by user's institutions at the end.

**TODO/FIXME:** n/a