### PR TITLE
Fix remove user account

### DIFF
--- a/backend/handlers/user_handler.py
+++ b/backend/handlers/user_handler.py
@@ -39,7 +39,6 @@ def remove_user_from_institutions(user):
     for institution_key in user.institutions:
         institution = institution_key.get()
         institution.remove_member(user)
-        institution.unfollow(user.key)
 
 
 class UserHandler(BaseHandler):

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -342,7 +342,6 @@ class User(ndb.Model):
         to remove all his institutions.
         """
         self.institutions = []
-        self.follows = []
         self.permissions = {}
         self.put()
         

--- a/backend/test/user_handler_test.py
+++ b/backend/test/user_handler_test.py
@@ -115,13 +115,13 @@ class UserHandlerTest(TestBaseHandler):
         # assert institution has no longer the deleted user
         self.assertTrue(self.other_user.key not in self.institution.members, 
             "The user key should not be in institution members") 
-        self.assertTrue(self.other_user.key not in self.institution.followers, 
-            "The user key should not be in institution followers") 
+        self.assertTrue(self.other_user.key in self.institution.followers, 
+            "The user key should be in institution followers") 
 
         # assert user has no longer institutions and permissions
         self.assertEquals(self.other_user.state, "inactive", "The user state should be 'inactive'")
         self.assertEquals(self.other_user.institutions, [], "User institutions should be empty")
-        self.assertEquals(self.other_user.follows, [], "User institutions should be empty")
+        self.assertEquals(self.other_user.follows, [self.institution.key], "User institutions should not be empty")
         self.assertEquals(self.other_user.permissions, {}, "User permissions should be empty")
         self.assertEquals(self.other_user.institution_profiles, [], "User permissions should be empty")
 


### PR DESCRIPTION
**Feature/Bug description:** When a user deletes the account, the list of institutions that he or she follows is deleted.

**Solution:** Do not remove the list of institutions that the user follows when he deletes the account.

**TODO/FIXME:** n/a