### PR TITLE
Standardize http services

### DIFF
--- a/frontend/auth/configProfileController.js
+++ b/frontend/auth/configProfileController.js
@@ -150,8 +150,6 @@
             var promise = UserService.deleteInstitution(institution_key);
             promise.then(function success() {
                 removeConection(institution_key);
-            }, function error(response) {
-                MessageService.showToast(response.data.msg);
             });
             return promise;
         }
@@ -203,8 +201,6 @@
             var promise = UserService.deleteAccount();
             promise.then(function success() {
                 AuthService.logout();
-            }, function error(response) {
-                MessageService.showToast(response.data.msg);
             });
             return promise;
         }

--- a/frontend/auth/editProfileController.js
+++ b/frontend/auth/editProfileController.js
@@ -19,8 +19,6 @@
                     ProfileService.editProfile(patch).then(function success() {
                         MessageService.showToast('Perfil editado com sucesso');
                         AuthService.save();
-                    }, function error(response) {
-                        MessageService.showToast(response.data.msg);
                     });
                 }
                 $mdDialog.hide();

--- a/frontend/comment/commentService.js
+++ b/frontend/comment/commentService.js
@@ -3,20 +3,14 @@
 (function() {
     var app = angular.module("app");
 
-    app.service('CommentService', function CommentService($http, $q, AuthService) {
+    app.service('CommentService', function CommentService(HttpService, $q, AuthService) {
         var service = this;
 
         var POST_URI = '/api/posts/';
         service.user = AuthService.getCurrentUser();
 
         service.getComments = function getComments(commentUri) {
-            var deferred = $q.defer();
-            $http.get(commentUri).then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.get(commentUri);
         };
 
         service.createComment = function createComment(postKey, text, institutionKey) {
@@ -30,26 +24,11 @@
                     name: service.user.current_institution.name
                 }
             };
-            $http.post(POST_URI + postKey + '/comments', body).then(
-                function success(response) {
-                    deferred.resolve(response);
-                }, function error(response) {
-                    deferred.reject(response);
-                }
-            );
-            return deferred.promise;
+            return HttpService.post(POST_URI + postKey + '/comments', body);
         };
 
         service.deleteComment = function deleteComment(postKey, commentId) {
-            var deferred = $q.defer();
-            $http.delete(POST_URI + postKey + '/comments/' + commentId).then(
-                function success(response) {
-                    deferred.resolve(response);
-                }, function error(response) {
-                    deferred.reject(response);
-                }
-            );
-            return deferred.promise;
+            return HttpService.delete(POST_URI + postKey + '/comments/' + commentId);
         };
 
         service.replyComment = function createComment(postKey, text, institutionKey, commentId) {
@@ -63,26 +42,11 @@
                     name: service.user.current_institution.name
                 }
             };
-            $http.post(POST_URI + postKey + '/comments/' + commentId + '/replies' , body).then(
-                function success(response) {
-                    deferred.resolve(response);
-                }, function error(response) {
-                    deferred.reject(response);
-                }
-            );
-            return deferred.promise;
+            return HttpService.post(POST_URI + postKey + '/comments/' + commentId + '/replies' , body);
         };
 
         service.deleteReply = function deleteReply(postKey, commentId, replyId) {
-            var deferred = $q.defer();
-            $http.delete(POST_URI + postKey + '/comments/' + commentId + '/replies/' + replyId).then(
-                function success(response) {
-                    deferred.resolve(response);
-                }, function error(response) {
-                    deferred.reject(response);
-                }
-            );
-            return deferred.promise;
+            return HttpService.delete(POST_URI + postKey + '/comments/' + commentId + '/replies/' + replyId);
         };
 
         service.like = function like(postKey, commentId, replyId) {
@@ -94,27 +58,12 @@
                     name: currentInstitutionName
                 }
             };            
-            $http.post(URI, body).then(
-                function success(response) {
-                    deferred.resolve(response);
-                }, function error(response) {
-                    deferred.reject(response);
-                }
-            );
-            return deferred.promise;
+            return HttpService.post(URI, body);
         };
 
         service.dislike = function like(postKey, commentId, replyId) {
-            var deferred = $q.defer();
             var URI = createLikeCommentURI(postKey, commentId, replyId);
-            $http.delete(URI).then(
-                function success(response) {
-                    deferred.resolve(response);
-                }, function error(response) {
-                    deferred.reject(response);
-                }
-            );
-            return deferred.promise;
+            HttpService.delete(URI);
         };
 
         function createLikeCommentURI(postKey, commentId, replyId) {

--- a/frontend/comment/commentService.js
+++ b/frontend/comment/commentService.js
@@ -63,7 +63,7 @@
 
         service.dislike = function like(postKey, commentId, replyId) {
             var URI = createLikeCommentURI(postKey, commentId, replyId);
-            HttpService.delete(URI);
+            return HttpService.delete(URI);
         };
 
         function createLikeCommentURI(postKey, commentId, replyId) {

--- a/frontend/event/eventController.js
+++ b/frontend/event/eventController.js
@@ -36,16 +36,15 @@
         function loadEvents(deferred, getEvents) {
             getEvents(actualPage, eventCtrl.institutionKey).then(function success(response) {
                 actualPage += 1;
-                moreEvents = response.data.next;
+                moreEvents = response.next;
 
-                _.forEach(response.data.events, function(event) {
+                _.forEach(response.events, function(event) {
                     eventCtrl.events.push(event);
                 });
 
                 eventCtrl.isLoadingEvents = false;
                 deferred.resolve();
-            }, function error(response) {
-                MessageService.showToast(response.data.msg);
+            }, function error() {
                 deferred.reject();
                 $state.go("app.user.home");
             });

--- a/frontend/event/eventDetailsDirective.js
+++ b/frontend/event/eventDetailsDirective.js
@@ -46,8 +46,6 @@
             promise.then(function success() {
                 MessageService.showToast('Evento removido com sucesso!');
                 eventCtrl.event.state = "deleted";
-            }, function error(response) {
-                MessageService.showToast(response.data.msg);
             });
             return promise;
         }

--- a/frontend/event/eventDialogController.js
+++ b/frontend/event/eventDialogController.js
@@ -79,8 +79,7 @@
                     .then(function success() {
                         $mdDialog.hide(event);
                         MessageService.showToast('Evento editado com sucesso.');
-                    }, function error(response) {
-                        MessageService.showToast(response.data.msg);
+                    }, function error() {
                         $mdDialog.hide(event);
                     });
             } else {
@@ -301,13 +300,12 @@
                 dialogCtrl.loading = true;
                 EventService.createEvent(event).then(function success(response) {
                     $mdDialog.hide();
-                    dialogCtrl.events.push(response.data);
+                    dialogCtrl.events.push(response);
                     MessageService.showToast('Evento criado com sucesso!');
-                    dialogCtrl.user.addPermissions(['edit_post', 'remove_post'], response.data.key);
-                }, function error(response) {
+                    dialogCtrl.user.addPermissions(['edit_post', 'remove_post'], response.key);
+                }, function error() {
                     dialogCtrl.loading = false;
                     dialogCtrl.blockReturnButton = false;
-                    MessageService.showToast(response.data.msg);
                     $state.go("app.user.events");
                 });
             } else {

--- a/frontend/event/eventPageController.js
+++ b/frontend/event/eventPageController.js
@@ -11,9 +11,8 @@
 
         function loadEvent(eventKey) {
             EventService.getEvent(eventKey).then(function success(response) {
-                eventCtrl.event = response.data;
-            }, function error(response) {
-                MessageService.showToast(response.data.msg);
+                eventCtrl.event = response;
+            }, function error() {
                 $state.go("app.user.home");
             });
         }
@@ -23,10 +22,8 @@
             post.shared_event = event.key;
             PostService.createPost(post).then(function success(response) {
                 if(eventCtrl.posts)
-                    eventCtrl.posts.push(response.data);
+                    eventCtrl.posts.push(response);
                 MessageService.showToast('Evento compartilhado com sucesso!');
-            }, function error(response) {
-                MessageService.showToast(response.data.msg);
             });
         };
 

--- a/frontend/event/eventService.js
+++ b/frontend/event/eventService.js
@@ -3,7 +3,7 @@
 (function() {
     var app = angular.module("app");
 
-    app.service("EventService", function EventService($http, $q) {
+    app.service("EventService", function EventService(HttpService, $q) {
         var service = this;
 
         var EVENT_URI = "/api/events";
@@ -11,63 +11,27 @@
         var LIMIT = "5";
 
         service.createEvent = function createEvent(event) {
-            var deferred = $q.defer();
-            $http.post(EVENT_URI, event).then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.post(EVENT_URI, event);
         };
 
         service.getEvents = function getEvents(page) {
-            var deferred = $q.defer();
-            $http.get(EVENT_URI + '?page=' + page + "&limit=" + LIMIT).then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.get(EVENT_URI + '?page=' + page + "&limit=" + LIMIT);
         };
 
         service.getInstEvents = function getInstEvents(page, institution_key) {
-            var deferred = $q.defer();
-            $http.get(INST_URI + institution_key + '/events?page=' + page + "&limit=" + LIMIT).then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.get(INST_URI + institution_key + '/events?page=' + page + "&limit=" + LIMIT);
         };
 
         service.deleteEvent = function deleteEvent(event) {
-            var deferred = $q.defer();
-            $http.delete(EVENT_URI + '/' + event.key).then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.delete(EVENT_URI + '/' + event.key);
         };
 
         service.getEvent = function getEvent(eventKey) {
-            var deferred = $q.defer();
-            $http.get(EVENT_URI + '/' + eventKey).then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.get(EVENT_URI + '/' + eventKey);
         };
 
         service.editEvent = function editEvent(eventKey, patch) {
-            var deferred = $q.defer();
-            $http.patch(EVENT_URI + '/' + eventKey, patch).then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.patch(EVENT_URI + '/' + eventKey, patch);
         };
     });
 })();

--- a/frontend/home/colorPickerController.js
+++ b/frontend/home/colorPickerController.js
@@ -15,8 +15,6 @@
                 colorPickerCtrl.user.institution_profiles = colorPickerCtrl.newUser.institution_profiles;
                 $mdDialog.cancel();
                 AuthService.save();
-            }, function error(response) {
-                MessageService.showToast(response.data.msg);
             });
             return promise;
         };

--- a/frontend/home/homeController.js
+++ b/frontend/home/homeController.js
@@ -4,7 +4,7 @@
     var app = angular.module("app");
 
     app.controller("HomeController", function HomeController(PostService, AuthService, NotificationService,
-            InstitutionService, $interval, $mdToast, $mdDialog, $state, MessageService, ProfileService, EventService, $q, $http) {
+            InstitutionService, $interval, $mdToast, $mdDialog, $state, MessageService, ProfileService, EventService, $q) {
         var homeCtrl = this;
 
         var ACTIVE = "active";

--- a/frontend/home/homeController.js
+++ b/frontend/home/homeController.js
@@ -156,16 +156,15 @@
         function loadPosts(deferred) {
             PostService.getNextPosts(actualPage).then(function success(response) {
                 actualPage += 1;
-                morePosts = response.data.next;
+                morePosts = response.next;
 
-                _.forEach(response.data.posts, function(post) {
+                _.forEach(response.posts, function(post) {
                     homeCtrl.posts.push(post);
                 });
 
                 homeCtrl.isLoadingPosts = false;
                 deferred.resolve();
-            }, function error(response) {
-                MessageService.showToast(response.data.msg);
+            }, function error() {
                 deferred.reject();
             });
         }
@@ -177,11 +176,10 @@
         function loadEvents() {
             var page = 0;
             EventService.getEvents(page).then(function success(response) {
-                homeCtrl.events = activeEvents(response.data.events);
+                homeCtrl.events = activeEvents(response.events);
                 homeCtrl.events = _.take(homeCtrl.events, LIMITE_EVENTS);
-            }, function error(response) {
-                MessageService.showToast(response.data.msg);
-                    $state.go("app.user.home");
+            }, function error() {
+                $state.go("app.user.home");
             });
         }
 

--- a/frontend/institution/allInstitutionsController.js
+++ b/frontend/institution/allInstitutionsController.js
@@ -52,16 +52,15 @@
         function loadInstitutions(deferred) {
             InstitutionService.getNextInstitutions(actualPage).then(function success(response) {
                 actualPage += 1;
-                moreInstitutions = response.data.next;
+                moreInstitutions = response.next;
 
-                _.forEach(response.data.institutions, function(institution) {
+                _.forEach(response.institutions, function(institution) {
                     allInstitutionsCtrl.institutions.push(institution);
                 });
 
                 allInstitutionsCtrl.isLoadingInstitutions = false;
                 deferred.resolve();
-            }, function error(response) {
-                MessageService.showToast(response.data.msg);
+            }, function error() {
                 deferred.reject();
             });
         }

--- a/frontend/institution/configInstDirective.js
+++ b/frontend/institution/configInstDirective.js
@@ -197,10 +197,7 @@
                     function success(institutionSaved) {
                         updateUser($state.params.inviteKey, institutionSaved);
                         patchIntitution();
-                    },
-                    function error(response) {
-                        MessageService.showToast(response.data.msg);
-                });
+                    });
             } else {
                 patchIntitution();
             }
@@ -250,10 +247,7 @@
                 function success() {
                     if(configInstCtrl.newInstitution)
                         updateUserInstitutions(configInstCtrl.newInstitution);
-                },
-                function error(response) {
-                    MessageService.showToast(response.data.msg);
-            });
+                });
         }
 
         function saveRequestInst() {
@@ -392,33 +386,32 @@
 
         function getLegalNatures() {
             InstitutionService.getLegalNatures().then(function success(response) {
-                configInstCtrl.legalNatures = response.data;
+                configInstCtrl.legalNatures = response;
             });
         }
 
         function getActuationAreas() {
             InstitutionService.getActuationAreas().then(function success(response) {
-                configInstCtrl.actuationArea = response.data;
+                configInstCtrl.actuationArea = response;
             });
         }
 
         function getCountries() {
             $http.get('app/institution/countries.json').then(function success(response) {
-                configInstCtrl.countries = response.data;
+                configInstCtrl.countries = response;
             });
         }
 
         function loadInstitution() {
             InstitutionService.getInstitution(institutionKey).then(function success(response) {
-                configInstCtrl.newInstitution = response.data;
+                configInstCtrl.newInstitution = response;
                 configInstCtrl.suggestedName = configInstCtrl.newInstitution.name;
                 currentPortfoliourl = configInstCtrl.newInstitution.portfolio_url;
                 observer = ObserverRecorderService.register(configInstCtrl.newInstitution);
                 loadAddress(); 
                 setDefaultPhotoUrl();
                 configInstCtrl.loading = false;
-            }, function error(response) {
-                MessageService.showToast(response.data.msg);
+            }, function error() {
                 configInstCtrl.loading = true;
             });
         }

--- a/frontend/institution/institutionCardDirective.js
+++ b/frontend/institution/institutionCardDirective.js
@@ -43,8 +43,6 @@
                 MessageService.showToast("Seguindo "+ institutionCardCtrl.institution.name);
                 institutionCardCtrl.user.follow(institutionCardCtrl.institution);
                 AuthService.save();
-            }, function error() {
-                MessageService.showToast('Não foi possível seguir a instituição.');
             });
             return promise;
         };
@@ -58,8 +56,6 @@
                     institutionCardCtrl.user.unfollow(institutionCardCtrl.institution);
                     AuthService.save();
                     MessageService.showToast("Deixou de seguir "+institutionCardCtrl.institution.name);
-                }, function error() {
-                    MessageService.showToast('Erro ao deixar de seguir instituição.');
                 });
                 return promise;
             }

--- a/frontend/institution/institutionController.js
+++ b/frontend/institution/institutionController.js
@@ -33,17 +33,16 @@
 
         function loadInstitution() {
             InstitutionService.getInstitution(currentInstitutionKey).then(function success(response) {
-                institutionCtrl.institution = new Institution(response.data);
+                institutionCtrl.institution = new Institution(response);
                 checkIfUserIsFollower();
                 institutionCtrl.checkIfUserIsMember();
                 getPortfolioUrl();
                 getActuationArea();
                 getLegalNature();
                 institutionCtrl.isLoadingData = false;
-            }, function error(response) {
+            }, function error() {
                 $state.go("app.user.home");
                 institutionCtrl.isLoadingData = true; 
-                MessageService.showToast(response.data.msg);
             });
         }
 
@@ -69,16 +68,16 @@
             if (morePosts) {
                 InstitutionService.getNextPosts(currentInstitutionKey, actualPage).then(function success(response) {
                     actualPage += 1;
-                    morePosts = response.data.next;
+                    morePosts = response.next;
 
-                    _.forEach(response.data.posts, function(post) {
+                    _.forEach(response.posts, function(post) {
                         institutionCtrl.posts.push(post);
                     });
 
                     institutionCtrl.isLoadingPosts = false;
                     deferred.resolve();
                 }, function error(response) {
-                    MessageService.showToast(response.data.msg);
+                    MessageService.showToast(response.msg);
                     deferred.reject();
                 });
             } else {
@@ -106,8 +105,6 @@
                 institutionCtrl.isUserFollower = true;
                 AuthService.save();
                 MessageService.showToast("Seguindo "+ institutionCtrl.institution.name);
-            }, function error() {
-                MessageService.showToast('Não foi possível seguir a instituição.');
             });
             return promise;
         };
@@ -123,8 +120,6 @@
                     institutionCtrl.user.unfollow(institutionCtrl.institution);
                     institutionCtrl.isUserFollower = false;
                     AuthService.save();
-                }, function error() {
-                    MessageService.showToast('Erro ao deixar de seguir instituição.');
                 });
                 return promise;
             }
@@ -242,14 +237,14 @@
 
         function getLegalNature() {
             InstitutionService.getLegalNatures().then(function success(response) {
-                institutionCtrl.instLegalNature = _.get(response.data, 
+                institutionCtrl.instLegalNature = _.get(response, 
                     institutionCtrl.institution.legal_nature);
             });
         }
 
         function getActuationArea() {
             InstitutionService.getActuationAreas().then(function success(response) {
-                institutionCtrl.instActuationArea = _.get(response.data, 
+                institutionCtrl.instActuationArea = _.get(response, 
                    institutionCtrl.institution.actuation_area);
             });
         }
@@ -312,8 +307,6 @@
             InstitutionService.update(institutionCtrl.institution.key, patch).then(function success(response) {
                 institutionCtrl.institution = response;
                 institutionCtrl.isLoadingCover = false;
-            }, function error(response) {
-                MessageService.showToast(response.data.msg);
             });
         }
 
@@ -427,10 +420,9 @@
 
         function getFollowers() {
             InstitutionService.getFollowers(currentInstitutionKey).then(function success(response) {
-                followersCtrl.followers = response.data;
+                followersCtrl.followers = response;
                 followersCtrl.isLoadingFollowers = false;
-            }, function error(response) {
-                MessageService.showToast(response.data.msg);
+            }, function error() {
                 followersCtrl.isLoadingFollowers = true;
             });
         }

--- a/frontend/institution/institutionLinksController.js
+++ b/frontend/institution/institutionLinksController.js
@@ -45,14 +45,13 @@
 
         function loadInstitution() {
             InstitutionService.getInstitution(currentInstitutionKey).then(function success(response) {
-                instLinksCtrl.institution = response.data;
-                var parentInstitution = response.data.parent_institution;
+                instLinksCtrl.institution = response;
+                var parentInstitution = response.parent_institution;
                 instLinksCtrl.parentInstitution = parentInstitution && parentInstitution.state === "active" ? parentInstitution : {};
-                instLinksCtrl.childrenInstitutions = response.data.children_institutions.filter(inst => inst.state === "active");
+                instLinksCtrl.childrenInstitutions = response.children_institutions.filter(inst => inst.state === "active");
                 instLinksCtrl.isLoadingInsts = false;
-            }, function error(response) {
+            }, function error() {
                 instLinksCtrl.isLoadingInsts = true;
-                MessageService.showToast(response.data.msg);
             });
         }
 

--- a/frontend/institution/institutionService.js
+++ b/frontend/institution/institutionService.js
@@ -2,7 +2,7 @@
     "use strict";
     var app = angular.module("app");
 
-    app.service("InstitutionService", function InstitutionService($http, $q, AuthService) {
+    app.service("InstitutionService", function InstitutionService(HttpService, $q, AuthService) {
         var service = this;
 
         var INSTITUTIONS_URI = "/api/institutions";
@@ -10,174 +10,70 @@
         service.user = AuthService.getCurrentUser();
 
         service.getInstitutions = function getInstitutions() {
-            var deferred = $q.defer();
-            $http.get(INSTITUTIONS_URI).then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.get(INSTITUTIONS_URI);
         };
 
         service.getNextInstitutions = function getNextInstitutions(page) {
-            var deferred = $q.defer();
-            $http.get("/api/institutions?page=" + page + "&limit=" + LIMIT).then(function success(response) {  
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.get("/api/institutions?page=" + page + "&limit=" + LIMIT);
         };
 
         service.searchInstitutions = function searchInstitutions(value, state, type) {
-            var deferred = $q.defer();
-            $http({url: "/api/search/institution",
-                method: "GET",
-                params: {value: value, state: state, type: type}
-            }).then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.get(`/api/search/institution?value=${value}&state=${state}&type=${type}`);
         };
 
         service.follow = function follow(institution_key) {
-            var deferred = $q.defer();
-            $http.post(INSTITUTIONS_URI + "/" + institution_key + "/followers").then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.post(INSTITUTIONS_URI + "/" + institution_key + "/followers");
         };
 
         service.unfollow = function unfollow(institution_key) {
-            var deferred = $q.defer();
-            $http.delete(INSTITUTIONS_URI + "/" + institution_key + "/followers").then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.delete(INSTITUTIONS_URI + "/" + institution_key + "/followers");
         };
 
         service.getNextPosts = function getNextPosts(institution_key, page) {
-            var deferred = $q.defer();
-            $http.get(INSTITUTIONS_URI + "/" + institution_key + "/timeline?page=" + page + "&limit=" + LIMIT).then(function success(response) {
-                service.posts = response.data;
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.get(INSTITUTIONS_URI + "/" + institution_key + "/timeline?page=" + page + "&limit=" + LIMIT);
         };
 
         service.getMembers = function getMembers(institution_key) {
-            var deferred = $q.defer();
-            $http.get(INSTITUTIONS_URI + "/" + institution_key + "/members").then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.get(INSTITUTIONS_URI + "/" + institution_key + "/members");
         };
 
         service.removeMember = function removeMember(institutionKey, member, justification) {
-            var deffered = $q.defer();
-            $http.delete(INSTITUTIONS_URI + "/" + institutionKey + "/members?removeMember=" + member.key + "&justification=" + justification)
-            .then(function success(info) {
-                deffered.resolve(info.data);
-            }, function error(data) {
-                deffered.reject(data);
-            });
-            return deffered.promise;
-        };
+            return HttpService.delete(INSTITUTIONS_URI + "/" + institutionKey + "/members?removeMember=" + member.key + "&justification=" + justification);
+        }; 
 
         service.getFollowers = function getFollowers(institution_key) {
-            var deferred = $q.defer();
-            $http.get(INSTITUTIONS_URI + "/" + institution_key + "/followers").then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.get(INSTITUTIONS_URI + "/" + institution_key + "/followers");
         };
 
         service.getInstitution = function getInstitution(institution_key) {
-            var deferred = $q.defer();
-            $http.get(INSTITUTIONS_URI + "/" + institution_key).then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.get(INSTITUTIONS_URI + "/" + institution_key);
         };
 
         service.save = function save(data, institutionKey, inviteKey) {
             var body = {data: data};
-            var deffered = $q.defer();
-            $http.put(INSTITUTIONS_URI + "/" + institutionKey + "/invites/" + inviteKey, body).then(function success(info) {
-                deffered.resolve(info.data);
-            }, function error(data) {
-                deffered.reject(data);
-            });
-            return deffered.promise;
+            return HttpService.put(INSTITUTIONS_URI + "/" + institutionKey + "/invites/" + inviteKey, body);
         };
 
         service.update = function update(institutionKey, patch) {
-            var deffered = $q.defer();
-            $http.patch(INSTITUTIONS_URI + "/" + institutionKey, patch).then(function success(info) {
-                deffered.resolve(info.data);
-            }, function error(data) {
-                deffered.reject(data);
-            });
-            return deffered.promise;
+            return HttpService.patch(INSTITUTIONS_URI + "/" + institutionKey, patch);
         };
 
         service.removeInstitution = function removeInstitution(institutionKey, removeHierarchy, justification) {
-            var deffered = $q.defer();
-            $http.delete(
-                INSTITUTIONS_URI + "/" + institutionKey,
-                {params: {removeHierarchy: removeHierarchy, justification: justification}}
-            ).then(
-                function success(info) {
-                    deffered.resolve(info.data);
-                }, function error(data) {
-                    deffered.reject(data);
-                }
-            );
-            return deffered.promise;
+            return HttpService.delete(
+                INSTITUTIONS_URI + "/" + institutionKey + `?removeHierarchy=${removeHierarchy}&justification=${justification}`
+            )
         };
 
         service.getLegalNatures = function getLegalNatures() {
-            var deferred = $q.defer();
-            $http.get('app/institution/legal_nature.json').then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.get('app/institution/legal_nature.json');
         };
 
         service.getActuationAreas = function getActuationAreas() {
-            var deferred = $q.defer();
-            $http.get('app/institution/actuation_area.json').then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.get('app/institution/actuation_area.json');
         };
 
         service.removeLink = function removeLink(institutionKey, institutionLink, isParent) {
-            var deffered = $q.defer();
-            $http.delete(INSTITUTIONS_URI + "/" + institutionKey + "/hierarchy/" + institutionLink + "?isParent=" + isParent).then(function success(info) {
-                deffered.resolve(info.data);
-            }, function error(data) {
-                deffered.reject(data);
-            });
-            return deffered.promise;
+            return HttpService.delete(INSTITUTIONS_URI + "/" + institutionKey + "/hierarchy/" + institutionLink + "?isParent=" + isParent);
         };
     });
 })();

--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -151,13 +151,12 @@
 
         function loadInstitution() {
             InstitutionService.getInstitution(currentInstitutionKey).then(function success(response) {
-                manageMemberCtrl.institution = response.data;
+                manageMemberCtrl.institution = response;
                 getMembers();
-                getSentInvitations(response.data.sent_invitations);
+                getSentInvitations(response.sent_invitations);
                 getRequests();
-            }, function error(response) {
+            }, function error() {
                 $state.go('app.institution.timeline', {institutionKey: currentInstitutionKey});
-                MessageService.showToast(response.data.msg);
             });
         }
 
@@ -169,12 +168,11 @@
 
         function getMembers() {
             InstitutionService.getMembers(currentInstitutionKey).then(function success(response) {
-                manageMemberCtrl.members = response.data;
+                manageMemberCtrl.members = response;
                 getAdmin();
                 manageMemberCtrl.isLoadingMembers = false;
-            }, function error(response) {
+            }, function error() {
                 manageMemberCtrl.isLoadingMembers = true;
-                MessageService.showToast(response.data.msg);
             });
         }
 
@@ -243,8 +241,6 @@
             promise.then(function () {
                 InviteService.resendInvite(inviteKey).then(function success() {
                     MessageService.showToast("Convite reenviado com sucesso.");
-                }, function error(response) {
-                    MessageService.showToast(response.data.msg);
                 });
             }, function () {
                 MessageService.showToast('Cancelado.');
@@ -400,8 +396,6 @@
                 InstitutionService.removeMember(currentInstitutionKey, member_obj, removeMemberCtrl.justification).then(function success() {
                     manageMemberCtrl.removeMember(member_obj);
                     $mdDialog.cancel();
-                }, function error(response) {
-                    MessageService.showToast(response.data.msg);
                 });
             };
             

--- a/frontend/institution/removeInstController.js
+++ b/frontend/institution/removeInstController.js
@@ -28,8 +28,6 @@
                     $state.go("app.user.home");
                 }
                 MessageService.showToast("Instituição removida com sucesso.");
-            }, function error(response) {
-                MessageService.showToast(response.data.msg);
             });
         };
 

--- a/frontend/institution/transferAdminController.js
+++ b/frontend/institution/transferAdminController.js
@@ -43,12 +43,10 @@
 
                     let invite = new Invite(data);
 
-                    InviteService.sendInviteUser({invite_body: invite}).then(function success(response) {
+                    InviteService.sendInviteUser({invite_body: invite}).then(function success() {
                         invite.status = 'sent';
                         $mdDialog.hide(invite);
                         MessageService.showToast("Convite enviado com sucesso!");
-                    }, function error(response) {
-                        MessageService.showToast(response.data);
                     });
                 } else {
                     MessageService.showToast('Você já é administrador da instituição, selecione outro membro!');

--- a/frontend/invites/acceptInviteController.js
+++ b/frontend/invites/acceptInviteController.js
@@ -40,7 +40,7 @@
         
         (function main() {
             InviteService.getInvite(invite_id).then(function(response) {
-                controller.invite = response.data;
+                controller.invite = response;
                 if (controller.invite.status === "accepted") {
                     $state.go("signin");
                 }

--- a/frontend/invites/inviteInstHierarchieController.js
+++ b/frontend/invites/inviteInstHierarchieController.js
@@ -48,7 +48,7 @@
                 var suggestionInstName = inviteInstHierCtrl.invite.suggestion_institution_name;
                 promise = InstitutionService.searchInstitutions(suggestionInstName, INSTITUTION_STATE, 'institution');
                 promise.then(function success(response) {
-                    inviteInstHierCtrl.processInvite(response.data, ev);
+                    inviteInstHierCtrl.processInvite(response, ev);
                 });
                 return promise;
             }
@@ -97,8 +97,7 @@
                     deferred.resolve();
                     inviteInstHierCtrl.isLoadingSubmission = false;
                     MessageService.showToast('Convite enviado com sucesso!');
-                }, function error(response) {
-                    MessageService.showToast(response.data.msg);
+                }, function error() {
                     deferred.reject();
                     inviteInstHierCtrl.isLoadingSubmission = false;
                 });
@@ -146,7 +145,7 @@
         function addParentInstitution(institutionRequestedKey) {
             var promise = InstitutionService.getInstitution(institutionRequestedKey);
             promise.then(function(response) {
-                inviteInstHierCtrl.institution.addParentInst(response.data);
+                inviteInstHierCtrl.institution.addParentInst(response);
                 inviteInstHierCtrl.hasParent = true;
             });
             return promise;
@@ -160,7 +159,7 @@
         function addChildrenInstitution(institutionRequestedKey) {
             var promise = InstitutionService.getInstitution(institutionRequestedKey);
             promise.then(function(response) {
-                inviteInstHierCtrl.institution.addChildInst(response.data);
+                inviteInstHierCtrl.institution.addChildInst(response);
             });
             return promise;
         }
@@ -176,9 +175,9 @@
             var promise = InstitutionService.getInstitution(sending_inst_key);
             promise.then(function(response) {
                if (type_of_invite === REQUEST_PARENT) {
-                    inviteInstHierCtrl.institution.addChildInst(response.data);
+                    inviteInstHierCtrl.institution.addChildInst(response);
                } else {
-                    inviteInstHierCtrl.institution.addParentInst(response.data);
+                    inviteInstHierCtrl.institution.addParentInst(response);
                     inviteInstHierCtrl.hasParent = true;
                }
             });
@@ -209,12 +208,11 @@
         function loadInstitution() {
             var promise;
             promise = InstitutionService.getInstitution(institutionKey).then(function success(response) {
-                inviteInstHierCtrl.institution = new Institution(response.data);
+                inviteInstHierCtrl.institution = new Institution(response);
                 inviteInstHierCtrl.hasParent = !_.isEmpty(inviteInstHierCtrl.institution.parent_institution);
                 getRequests();
-            }, function error(response) {
+            }, function error() {
                 $state.go('app.institution.timeline', {institutionKey: institutionKey});
-                MessageService.showToast(response.data.msg);
             });
             return promise;
         }

--- a/frontend/invites/inviteInstitutionController.js
+++ b/frontend/invites/inviteInstitutionController.js
@@ -48,7 +48,7 @@
                 var suggestionInstName = inviteInstCtrl.invite.suggestion_institution_name;
                 promise = InstitutionService.searchInstitutions(suggestionInstName, INSTITUTION_STATE, 'institution');
                 promise.then(function success(response) {
-                    inviteInstCtrl.showDialogOrSendInvite(response.data, ev);
+                    inviteInstCtrl.showDialogOrSendInvite(response, ev);
                 });
                 return promise;
             }
@@ -88,13 +88,11 @@
                     inviteInstCtrl.invite = {};
                     invite.status = 'sent';
                     invite.sender_name = inviteInstCtrl.user.name;
-                    invite.key = response.data.key;
+                    invite.key = response.key;
                     inviteInstCtrl.sent_invitations.push(invite);
                     inviteInstCtrl.showInvites = true;
                     inviteInstCtrl.showSendInvites = false;
                     MessageService.showToast('Convite enviado com sucesso!');
-                }, function error(response) {
-                    MessageService.showToast(response.data.msg);
                 });
             return promise;
         };
@@ -136,8 +134,6 @@
             promise.then(function () {
                 InviteService.resendInvite(inviteKey).then(function success() {
                     MessageService.showToast("Convite reenviado com sucesso.");
-                }, function error(response) {
-                    MessageService.showToast(response.data.msg);
                 });
             }, function () {
                 MessageService.showToast('Cancelado.');
@@ -161,20 +157,18 @@
             RequestInvitationService.getRequestsInst(institution_key).then(function success(requests) {
                 var isSentRequest = createRequestSelector('sent', 'REQUEST_INSTITUTION');
                 inviteInstCtrl.sent_requests = requests.filter(isSentRequest);
-            }, function error(response) {
+            }, function error() {
                 $state.go("app.user.home");
-                MessageService.showToast(response.data.msg);
             });
         }
         
         function loadSentInvitations() {
             InviteService.getSentInstitutionInvitations().then(function success(response) {
-                var requests = response.data;
+                var requests = response;
                 getSentInvitations(requests);
                 getAcceptedInvitations(requests);
-            }, function error(response) {
+            }, function error() {
                 $state.go("app.user.home");
-                MessageService.showToast(response.data.msg);
             });
         }
         

--- a/frontend/invites/inviteService.js
+++ b/frontend/invites/inviteService.js
@@ -3,31 +3,17 @@
 (function() {
     var app = angular.module("app");
 
-    app.service("InviteService", function InviteService($http, $q, HttpService, AuthService) {
+    app.service("InviteService", function InviteService($q, HttpService, AuthService) {
         var service = this;
 
         var INVITES_URI = "/api/invites";
     
         service.getInvite = function(inviteKey) {
-            var deferred = $q.defer();
-            $http.get(INVITES_URI + '/' + inviteKey).then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.get(INVITES_URI + '/' + inviteKey);
         };
 
         service.sendInvite = function sendInvite(invite) {
-            var deferred = $q.defer();
-            $http.post(INVITES_URI, {
-                data: invite
-            }).then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.post(INVITES_URI, { data: invite });
         };
 
 
@@ -40,93 +26,39 @@
         };
 
         service.resendInvite = function resendInvite(inviteKey) {
-            var deferred = $q.defer();
-            $http.post(INVITES_URI + "/" + inviteKey + "/resend", {}).then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.post(INVITES_URI + "/" + inviteKey + "/resend", {});
         };
 
         service.sendInviteInst = function sendInviteInst(invite) {
-            var deferred = $q.defer();
-            $http.post(INVITES_URI + '/institution', {
-                data: invite
-            }).then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.post(INVITES_URI + '/institution', { data: invite });
         };
 
         service.deleteUserInvite = function deleteUserInvite(inviteKey) {
-            var deferred = $q.defer();
             var url = `${INVITES_URI}/user/${inviteKey}`;
-            $http.delete(url).then(function sucess(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.delete(url);
         };
 
         service.deleteInstitutionInvite = function deleteInstitutionInvite(inviteKey) {
-            var deferred = $q.defer();
             var url = `${INVITES_URI}/institution/${inviteKey}`;
-            $http.delete(url).then(function sucess(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.delete(url);
         };
         
 
         service.getSentInstitutionInvitations = function getSentInstitutionInvitations() {
-            var deferred = $q.defer();
-            $http.get(INVITES_URI + '/institution').then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.get(INVITES_URI + '/institution');
         };
 
         service.acceptUserInvite = function acceptUserInvite(patch, invite_key) {
-            var deffered = $q.defer();
             var url = `${INVITES_URI}/user/${invite_key}`;
-            $http.patch(url, patch).then(function success(info) {
-                deffered.resolve(info.data);
-            }, function error(data) {
-                deffered.reject(data);
-            });
-            return deffered.promise;
+            return HttpService.patch(url, patch);
         };
 
         service.sendInviteHierarchy = function sendInviteHierarchy(invite) {
-            var deferred = $q.defer();
-            HttpService.post(INVITES_URI + '/institution_hierarchy', {
-                data: invite
-            }).then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.post(INVITES_URI + '/institution_hierarchy', { data: invite });
         };
 
         service.sendInviteUser = function sendInvite(invite) {
-            var deferred = $q.defer();
-            HttpService.post(INVITES_URI + '/user', {
-                data: invite
-            }).then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.post(INVITES_URI + '/user', { data: invite });
         };
     });
 })();

--- a/frontend/invites/newInviteController.js
+++ b/frontend/invites/newInviteController.js
@@ -64,8 +64,6 @@
                     AuthService.save();
                     $state.go("app.user.home");
                     _.isEmpty(newInviteCtrl.user.invites) && showAlert(event);
-                }, function error(response) {
-                    MessageService.showToast(response.data.msg);
                 });
             return promise;
         };
@@ -134,8 +132,6 @@
                 } else {
                     $state.go("app.user.home");
                 }
-            }, function error(response) {
-                MessageService.showToast(response.data.msg);
             });
             return promise;
         }
@@ -160,7 +156,7 @@
             observer = ObserverRecorderService.register(newInviteCtrl.user);
             newInviteCtrl.checkUserName();
             InviteService.getInvite(newInviteCtrl.inviteKey).then(function success(response) {
-                newInviteCtrl.invite = new Invite(response.data);
+                newInviteCtrl.invite = new Invite(response);
                 if(newInviteCtrl.invite.status === 'sent') {
                     institutionKey = (newInviteCtrl.invite.type_of_invite === "USER") ? newInviteCtrl.invite.institution_key : newInviteCtrl.invite.stub_institution.key;
                     newInviteCtrl.institution = newInviteCtrl.invite.institution;
@@ -168,8 +164,7 @@
                     newInviteCtrl.isAlreadyProcessed = true;
                 }
                 newInviteCtrl.loading = false;
-            }, function error(response) {
-                MessageService.showToast(response.data.msg);
+            }, function error() {
                 newInviteCtrl.loading = true;
             });
         }

--- a/frontend/invites/processInviteUserAdmController.js
+++ b/frontend/invites/processInviteUserAdmController.js
@@ -48,7 +48,7 @@
          */
         function getInvite() {
             InviteService.getInvite(key).then(function success(response) {
-                let invite = new Invite(response.data);
+                let invite = new Invite(response);
 
                 if (invite.status === 'sent' || typeOfDialog === processCtrl.VIEW_INVITE_SENDER) {
                     processCtrl.invite = invite;

--- a/frontend/invites/removeChildController.js
+++ b/frontend/invites/removeChildController.js
@@ -30,10 +30,7 @@
                     removeChildFromParent();
                     removeChildCtrl.closeDialog();
                     MessageService.showToast("Instituição removida com sucesso.");
-                }, function error(response) {
-                    MessageService.showToast(response.data.msg);
-                }
-            );
+                });
         };
     });
 

--- a/frontend/invites/suggestInstitutionController.js
+++ b/frontend/invites/suggestInstitutionController.js
@@ -69,8 +69,8 @@
 
         function sendInviteToExistingInst() {
             InstitutionService.getInstitution(suggestInstCtrl.chosen_institution).then(function(response) {
-                if (!(isLinked(response.data) || isSelf() || isPedingRequest() || isInvited())) {
-                    invite.requested_inst_name = response.data.name;
+                if (!(isLinked(response) || isSelf() || isPedingRequest() || isInvited())) {
+                    invite.requested_inst_name = response.name;
                     inviteController.sendRequestToExistingInst(invite, suggestInstCtrl.chosen_institution).then(
                         function success() {
                             suggestInstCtrl.cancel();

--- a/frontend/notification/notificationDirective.js
+++ b/frontend/notification/notificationDirective.js
@@ -270,10 +270,7 @@
                         dialogProperties.locals.request = request;
                         var isRequestResolved = request.isStatusOn('rejected') || request.isStatusOn('accepted');
                         isRequestResolved ? showResolvedReqDialog(event) : showPendingReqDialog(dialogProperties, event);
-                    }, function error(response) {
-                        MessageService.showToast(response.data.msg);
-                    }
-                );
+                    });
             } else {
                 dialogProperties.locals.key = notification.entity.key;
                 showPendingReqDialog(dialogProperties, event);

--- a/frontend/post/commentDirective.js
+++ b/frontend/post/commentDirective.js
@@ -30,9 +30,8 @@
                             });
                         }
                         commentCtrl.saving = false;
-                    }, function error(response) {
+                    }, function error() {
                         $state.go("app.user.home");
-                        MessageService.showToast(response.data.msg);
                         commentCtrl.saving = false;
                     }
                 );
@@ -46,9 +45,8 @@
                             commentCtrl.comment.likes.push(commentCtrl.user.key);
                         }
                         commentCtrl.saving = false;
-                    }, function error(response) {
+                    }, function error() {
                         $state.go("app.user.home");
-                        MessageService.showToast(response.data.msg);
                         commentCtrl.saving = false;
                     }
                 );
@@ -97,15 +95,14 @@
                 );
 
                 promise.then(function success(response) {
-                    var data = response.data;
+                    var data = response;
                     commentCtrl.comment.replies[data.id] = data;
 
                     commentCtrl.newReply = null;
                     commentCtrl.saving = false;
-                }, function error(error) {
+                }, function error() {
                     commentCtrl.newReply = null;
                     commentCtrl.saving = false;
-                    MessageService.showToast(error.data.msg);
                 });
             }
         };
@@ -115,10 +112,7 @@
                 function success() {
                     delete commentCtrl.comment.replies[reply.id];
                     MessageService.showToast('Comentário excluído com sucesso');
-                }, function error(response) {
-                    MessageService.showToast(response.data.msg);
-                }
-            );
+                });
         };
 
         commentCtrl.deleteComment = function deleteComment() {
@@ -128,10 +122,7 @@
                         .filter(comment => comment.id !== commentCtrl.comment.id);
                     commentCtrl.post.number_of_comments--;
                     MessageService.showToast('Comentário excluído com sucesso');
-                }, function error(response) {
-                    MessageService.showToast(response.data.msg);
-                }
-            );
+                });
         };
 
         commentCtrl.confirmCommentDeletion = function confirmCommentDeletion(event, reply) {

--- a/frontend/post/postDetailsDirective.js
+++ b/frontend/post/postDetailsDirective.js
@@ -40,8 +40,6 @@
                     });
                     postDetailsCtrl.posts.push(postDetailsCtrl.post);
                     MessageService.showToast('Post excluído com sucesso');
-                }, function error(response) {
-                    MessageService.showToast(response.data.msg);
                 });
             }, function() {
                 MessageService.showToast('Cancelado');
@@ -233,8 +231,6 @@
             PostService.addSubscriber(postDetailsCtrl.post.key).then(function success() {
                 MessageService.showToast('Esse post foi marcado como de seu interesse.');
                 postDetailsCtrl.post.subscribers.push(postDetailsCtrl.user.key);
-            }, function error(response) {
-                MessageService.showToast(response.data.msg);
             });
         };
 
@@ -245,7 +241,6 @@
                     return userKey === postDetailsCtrl.user.key;
                 });
             }, function error(response) {
-                MessageService.showToast(response.data.msg);
                 $state.go($state.current);
             });
         };
@@ -284,7 +279,6 @@
                 postDetailsCtrl.savingLike = false;
                 postDetailsCtrl.getLikes(postDetailsCtrl.post);
             }, function error(response) {
-                MessageService.showToast(response.data.msg);
                 $state.go("app.user.home");
                 postDetailsCtrl.savingLike = false;
             });
@@ -300,7 +294,6 @@
                 postDetailsCtrl.savingLike = false;
                 postDetailsCtrl.getLikes(postDetailsCtrl.post);
             }, function error(response) {
-                MessageService.showToast(response.data.msg);
                 $state.go("app.user.home");
                 postDetailsCtrl.savingLike = false;
             });
@@ -354,7 +347,6 @@
             }, function error(response) {
                 postDetailsCtrl.post.type_survey = type_survey;
                 postDetailsCtrl.isLoadingComments = true;
-                MessageService.showToast(response.data.msg);
             }); 
             return promise;
         }
@@ -362,12 +354,11 @@
         postDetailsCtrl.loadComments = function refreshComments() {
             var promise  =  CommentService.getComments(postDetailsCtrl.post.comments);
             promise.then(function success(response) {
-                postDetailsCtrl.post.data_comments = _.values(response.data);
+                postDetailsCtrl.post.data_comments = _.values(response);
                 postDetailsCtrl.post.number_of_comments = _.size(postDetailsCtrl.post.data_comments);
                 postDetailsCtrl.isLoadingComments = false;
             }, function error(response) {
                 postDetailsCtrl.isLoadingComments = true;
-                MessageService.showToast(response.data.msg);
             });
             return promise;
         };
@@ -386,10 +377,8 @@
             if(postDetailsCtrl.isPostPage) {
                 var promise = PostService.getLikes(likesUri);
                 promise.then(function success(response) {
-                    postDetailsCtrl.post.data_likes = response.data;
+                    postDetailsCtrl.post.data_likes = response;
                     postDetailsCtrl.post.number_of_likes = _.size(postDetailsCtrl.post.data_likes);
-                }, function error(response) {
-                    MessageService.showToast(response.data.msg);
                 });
                 return promise;
             }else{
@@ -412,10 +401,9 @@
                 promise = CommentService.createComment(postDetailsCtrl.post.key, newComment, institutionKey);
                 promise.then(function success(response) {
                     postDetailsCtrl.newComment = '';
-                    addComment(postDetailsCtrl.post, response.data);
+                    addComment(postDetailsCtrl.post, response);
                     postDetailsCtrl.savingComment = false;
                 }, function error(response) {
-                    MessageService.showToast(response.data.msg);
                     $state.go("app.user.home");
                 });
             } else {

--- a/frontend/post/postDirective.js
+++ b/frontend/post/postDirective.js
@@ -233,17 +233,16 @@
                     postCtrl.loadingPost = true;
                     PostService.createPost(post).then(function success(response) {
                         postCtrl.clearPost();
-                        posts.push(new Post(response.data));
+                        posts.push(new Post(response));
                         MessageService.showToast('Postado com sucesso!');
                         changeTimelineToStart();
                         $mdDialog.hide();
                         postCtrl.loadingPost = false;
                         const postAuthorPermissions = ["edit_post", "remove_post"];
-                        postCtrl.user.addPermissions(postAuthorPermissions, response.data.key);
-                    }, function error(response) {
+                        postCtrl.user.addPermissions(postAuthorPermissions, response.key);
+                    }, function error() {
                         AuthService.reload().then(function success() {
                             $mdDialog.hide();
-                            MessageService.showToast(response.data.msg);
                             postCtrl.loadingPost = false;
                             $state.go("app.user.home");
                         });
@@ -303,8 +302,6 @@
                             $mdDialog.cancel();
                             MessageService.showToast(response.data.msg);
                         });
-                    }, function error() {
-                        MessageService.showToast("Esse post não pode ser editado pois já possui atividade");
                     });
                 } else {
                     MessageService.showToast('Edição inválida!');

--- a/frontend/post/postDirective.js
+++ b/frontend/post/postDirective.js
@@ -300,7 +300,6 @@
                             $mdDialog.hide(postCtrl.post);
                         }, function error(response) {
                             $mdDialog.cancel();
-                            MessageService.showToast(response.data.msg);
                         });
                     });
                 } else {

--- a/frontend/post/postPageController.js
+++ b/frontend/post/postPageController.js
@@ -22,10 +22,7 @@
             promise.then(function success(response) {
                 postCtrl.post = response;
                 postCtrl.post.data_comments = _.values(postCtrl.post.data_comments);
-            }, function error(response) {
-                if (response.status === 500) {
-                    MessageService.showToast(response.data.msg);
-                }
+            }, function error() {
                 $state.go("app.user.home");
             });
             return promise;

--- a/frontend/post/postService.js
+++ b/frontend/post/postService.js
@@ -3,7 +3,7 @@
 (function() {
     var app = angular.module("app");
 
-    app.service("PostService", function PostService(HttpService, $q, AuthService) {
+    app.service("PostService", function PostService(HttpService, AuthService) {
         var service = this;
         var POSTS_URI = "/api/posts";
         var LIMIT = 10;
@@ -15,14 +15,11 @@
         };
 
         service.getNextPosts = function getNextPosts(page) {
-            var deferred = $q.defer();
-            HttpService.get("/api/user/timeline?page=" + page + "&limit=" + LIMIT).then(function success(response) {
+            var promise = HttpService.get("/api/user/timeline?page=" + page + "&limit=" + LIMIT);
+            promise.then(function success(response) {
                 service.posts = response;
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
             });
-            return deferred.promise;
+            return promise;
         };
 
         service.createPost = function createPost(post) {

--- a/frontend/post/postService.js
+++ b/frontend/post/postService.js
@@ -3,7 +3,7 @@
 (function() {
     var app = angular.module("app");
 
-    app.service("PostService", function PostService($http, $q, AuthService) {
+    app.service("PostService", function PostService(HttpService, $q, AuthService) {
         var service = this;
         var POSTS_URI = "/api/posts";
         var LIMIT = 10;
@@ -11,19 +11,12 @@
         service.user = AuthService.getCurrentUser();
 
         service.get = function getPosts() {
-            var deferred = $q.defer();
-            $http.get("/api/user/timeline").then(function success(response) {
-                service.posts = response.data;
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.get("/api/user/timeline");
         };
 
         service.getNextPosts = function getNextPosts(page) {
             var deferred = $q.defer();
-            $http.get("/api/user/timeline?page=" + page + "&limit=" + LIMIT).then(function success(response) {
+            HttpService.get("/api/user/timeline?page=" + page + "&limit=" + LIMIT).then(function success(response) {
                 service.posts = response.data;
                 deferred.resolve(response);
             }, function error(response) {
@@ -33,7 +26,6 @@
         };
 
         service.createPost = function createPost(post) {
-            var deferred = $q.defer();
             var institutionName = service.user.current_institution ? service.user.current_institution.name : "";
             var body = {
                 post: post,
@@ -41,98 +33,44 @@
                     name: institutionName
                 }
             };
-            $http.post(POSTS_URI, body).then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.post(POSTS_URI, body);
         };
 
         service.likePost = function likePost(post) {
-            var deferred = $q.defer();
             var body = {
                 currentInstitution: {
                     name: service.user.current_institution.name 
                 }
             };
-            $http.post(`${POSTS_URI}/${post.key}/likes`, body)
-            .then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.post(`${POSTS_URI}/${post.key}/likes`, body);
         };
 
         service.dislikePost = function dislikePost(post) {
-            var deferred = $q.defer();
-            $http.delete(POSTS_URI + '/' + post.key + '/likes').then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.delete(POSTS_URI + '/' + post.key + '/likes');
         };
 
         service.deletePost = function deletePost(post) {
-            var deferred = $q.defer();
-            $http.delete(POSTS_URI + '/' + post.key).then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.delete(POSTS_URI + '/' + post.key);
         };
 
         service.getLikes = function getLikes(likesURL) {
-            var deferred = $q.defer();
-            $http.get(likesURL).then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.get(likesURL);
         };
 
         service.save = function save(post_key, patch) {
-            var deffered = $q.defer();
-            $http.patch(POSTS_URI + '/' + post_key, patch).then(function success(info) {
-                deffered.resolve(info.data);
-            }, function error(data) {
-                deffered.reject(data);
-            });
-            return deffered.promise;
+            return HttpService.patch(POSTS_URI + '/' + post_key, patch);
         };
 
         service.getPost = function getPost(postKey) {
-            var deffered = $q.defer();
-            $http.get(POSTS_URI + '/' + postKey).then(function success(info) {
-                deffered.resolve(info.data);
-            }, function error(data) {
-                deffered.reject(data);
-            });
-            return deffered.promise;
+            return HttpService.get(POSTS_URI + '/' + postKey);
         };
 
         service.addSubscriber = function addSubscriber(postKey) {
-            var deffered = $q.defer();
-            $http.post(POSTS_URI + '/' + postKey + '/subscribers').then(function success(info) {
-                deffered.resolve(info.data);
-            }, function error(data) {
-                deffered.reject(data);
-            });
-            return deffered.promise;
+            return HttpService.post(POSTS_URI + '/' + postKey + '/subscribers');
         };
 
         service.removeSubscriber = function removeSubscriber(postKey) {
-            var deffered = $q.defer();
-            $http.delete(POSTS_URI + '/' + postKey + '/subscribers').then(function success(info) {
-                deffered.resolve(info.data);
-            }, function error(data) {
-                deffered.reject(data);
-            });
-            return deffered.promise;
+            return HttpService.delete(POSTS_URI + '/' + postKey + '/subscribers');
         };
     });
 })();

--- a/frontend/post/postService.js
+++ b/frontend/post/postService.js
@@ -17,7 +17,7 @@
         service.getNextPosts = function getNextPosts(page) {
             var deferred = $q.defer();
             HttpService.get("/api/user/timeline?page=" + page + "&limit=" + LIMIT).then(function success(response) {
-                service.posts = response.data;
+                service.posts = response;
                 deferred.resolve(response);
             }, function error(response) {
                 deferred.reject(response);

--- a/frontend/post/sharePostController.js
+++ b/frontend/post/sharePostController.js
@@ -47,12 +47,11 @@
             PostService.createPost(shareCtrl.newPost).then(function success(response) {
                 MessageService.showToast('Compartilhado com sucesso!');
                 $mdDialog.hide();
-                shareCtrl.addPostTimeline(response.data);
+                shareCtrl.addPostTimeline(response);
                 const postAuthorPermissions = ["remove_post"];
-                shareCtrl.user.addPermissions(postAuthorPermissions, response.data.key);
-            }, function error(response) {
+                shareCtrl.user.addPermissions(postAuthorPermissions, response.key);
+            }, function error() {
                 $mdDialog.hide();
-                MessageService.showToast(response.data.msg);
             });
         };
 

--- a/frontend/requests/analyseHierarchyRequestController.js
+++ b/frontend/requests/analyseHierarchyRequestController.js
@@ -38,21 +38,15 @@
                     request.status = 'rejected';
                     $mdDialog.cancel();
                     MessageService.showToast('Solicitação rejeitada com sucesso');
-                }, function error(response) {
-                    MessageService.showToast(response.data.msg);
-                }
-            );
+                });
         };
 
         function confirmLinkRemoval() {
             const isParent = true;
             InstitutionService.removeLink(child.key, parent.key, isParent).then(
-                function success(data) {
+                function success() {
                     acceptRequest();
-                }, function error(response) {
-                    MessageService.showToast(response.data.msg);
-                }
-            );
+                });
         }
 
         function acceptRequest() {
@@ -60,8 +54,6 @@
                 request.status = 'accepted';
                 $mdDialog.hide();
                 MessageService.showToast('Solicitação aceita com sucesso');
-            }, function error(response) {
-                MessageService.showToast(response.data.msg);   
             });
         }
 

--- a/frontend/requests/requestProcessingController.js
+++ b/frontend/requests/requestProcessingController.js
@@ -25,8 +25,6 @@
                 request.status = 'accepted';
                 requestController.hideDialog();
                 refreshUser();
-            }, function error(response) {
-                MessageService.showToast(response.data.msg);
             });
         };
 
@@ -60,8 +58,6 @@
                 request.status = 'rejected';
                 requestController.hideDialog();
                 MessageService.showToast("Solicitação rejeitada!");
-            }, function error(response) {
-                MessageService.showToast(response.data.msg);
             });
         };
 
@@ -116,13 +112,11 @@
         function loadInstitution() {
             var institutionKey = isHierarchyRequest() ? request.institution_requested_key : request.institution_key;
             InstitutionService.getInstitution(institutionKey).then(function success(response) {
-                requestController.institution = response.data;
+                requestController.institution = response;
                 formatPositions();
                 getLegalNature();
                 getActuationArea();
                 selectDialogFlow();
-            }, function error(response) {
-                MessageService.showToast(response.data.msg);
             });
         }
 
@@ -160,12 +154,10 @@
             const institutionKey = requestController.children.key;
             const institutionLinkKey = requestController.children.parent_institution.key;
 
-            InstitutionService.removeLink(institutionKey, institutionLinkKey, isParent).then(function success(data) {
+            InstitutionService.removeLink(institutionKey, institutionLinkKey, isParent).then(function success() {
                 MessageService.showToast('Vínculo removido.');
                 requestController.warnPaternityExistence = false;
                 delete requestController.children.parent_institution;
-            }, function error(response) {
-                MessageService.showToast(response.data.msg);
             });
         };
 
@@ -177,14 +169,14 @@
 
         function getLegalNature() {
             InstitutionService.getLegalNatures().then(function success(response) {
-                requestController.instLegalNature = _.get(response.data,
+                requestController.instLegalNature = _.get(response,
                     requestController.parent.legal_nature);
             });
         }
 
         function getActuationArea() {
             InstitutionService.getActuationAreas().then(function success(response) {
-                requestController.instActuationArea = _.get(response.data,
+                requestController.instActuationArea = _.get(response,
                     requestController.parent.actuation_area);
             });
         }

--- a/frontend/search/searchController.js
+++ b/frontend/search/searchController.js
@@ -23,11 +23,8 @@
             var valueOrKeyword = value ? value : (searchCtrl.search_keyword || "");
             var promise = InstitutionService.searchInstitutions(valueOrKeyword, "active", type);
             promise.then(function success(response) {
-                searchCtrl.institutions = response.data;
-
+                searchCtrl.institutions = response;
                 searchCtrl.loading = true;
-            }, function error(response) {
-                MessageService.showToast(response.data.msg);
             });
             return promise;
         };
@@ -49,7 +46,7 @@
         searchCtrl.goToInstitution = function goToInstitution(institutionId) {
             if (institutionId) {
                 InstitutionService.getInstitution(institutionId).then(function success(response) {
-                    $state.go('app.institution.timeline', { institutionKey: response.data.key });
+                    $state.go('app.institution.timeline', { institutionKey: response.key });
                 });
             }
         };

--- a/frontend/survey/surveyDetailsDirective.js
+++ b/frontend/survey/surveyDetailsDirective.js
@@ -96,11 +96,9 @@
         surveyCtrl.voteService = function(){
             var promise = SurveyService.vote(surveyCtrl.post, surveyCtrl.optionsSelected);
             promise.then(function sucess(response){
-                surveyCtrl.post = response.data;
+                surveyCtrl.post = response;
                 addVote(surveyCtrl.optionsSelected);
                 MessageService.showToast('Voto computado');
-            }, function error(response) {
-                MessageService.showToast(response.data.msg);
             });
             return promise;
         };

--- a/frontend/survey/surveyDirective.js
+++ b/frontend/survey/surveyDirective.js
@@ -75,7 +75,7 @@
                     MessageService.showToast('Postado com sucesso!');
                     surveyCtrl.callback();
                     const postAuthorPermissions = ["remove_post"];
-                    surveyCtrl.user.addPermissions(postAuthorPermissions, response.data.key);
+                    surveyCtrl.user.addPermissions(postAuthorPermissions, response.key);
                     $mdDialog.hide();
                     unobserveNewPost();
                 }, function error() {

--- a/frontend/survey/surveyDirective.js
+++ b/frontend/survey/surveyDirective.js
@@ -67,15 +67,14 @@
                 var survey = createSurvey();
                 var promise = PostService.createPost(survey).then(function success(response) {
                     surveyCtrl.resetSurvey();
-                    surveyCtrl.posts.push(new Post(response.data));
+                    surveyCtrl.posts.push(new Post(response));
                     MessageService.showToast('Postado com sucesso!');
                     surveyCtrl.callback();
                     $mdDialog.hide();
                     unobserveNewPost();
-                }, function error(response) {
+                }, function error() {
                     AuthService.reload().then(function success() {
                         $mdDialog.hide();
-                        MessageService.showToast(response.data.msg);
                         $state.go("app.user.home");
                     });
                 });

--- a/frontend/survey/surveyService.js
+++ b/frontend/survey/surveyService.js
@@ -3,19 +3,13 @@
 (function() {
     var app = angular.module("app");
 
-    app.service("SurveyService", function SurveyService($http, $q) {
+    app.service("SurveyService", function SurveyService(HttpService, $q) {
         var service = this;
 
         var SURVEY_URI = "/api/surveyposts/";
 
         service.vote = function vote(post, options) {
-            var deferred = $q.defer();
-            $http.post(SURVEY_URI + post.key + '/votes', options).then(function success(response) {
-                deferred.resolve(response);
-            }, function error(response) {
-                deferred.reject(response);
-            });
-            return deferred.promise;
+            return HttpService.post(SURVEY_URI + post.key + '/votes', options);
         };
     });
 })();

--- a/frontend/test/specs/colorPickerControllerSpec.js
+++ b/frontend/test/specs/colorPickerControllerSpec.js
@@ -21,13 +21,13 @@
         'current_institution' : institution
     };
    
-    beforeEach(inject(function($controller, $httpBackend, $http, $mdDialog,
+    beforeEach(inject(function ($controller, $httpBackend, HttpService, $mdDialog,
             AuthService, $rootScope, ProfileService) {
         scope = $rootScope.$new();
         httpBackend = $httpBackend;
         rootScope = $rootScope;
         mdDialog = $mdDialog;
-        http = $http;
+        http = HttpService;
         profileService = ProfileService;
 
         colorPickerCtrl = $controller('ColorPickerController', {

--- a/frontend/test/specs/commentControllerSpec.js
+++ b/frontend/test/specs/commentControllerSpec.js
@@ -30,12 +30,12 @@
                 state: 'published'
         }];
 
-    beforeEach(inject(function($controller, $httpBackend, $http, $mdDialog,
+    beforeEach(inject(function ($controller, $httpBackend, HttpService, $mdDialog,
             AuthService, $rootScope, CommentService) {
         scope = $rootScope.$new();
         httpBackend = $httpBackend;
         mdDialog = $mdDialog;
-        http = $http;
+        http = HttpService;
         commentService = CommentService;
 
         httpBackend.when('GET', 'main/main.html').respond(200);

--- a/frontend/test/specs/commentServiceSpec.js
+++ b/frontend/test/specs/commentServiceSpec.js
@@ -14,8 +14,8 @@
 
     beforeEach(module('app'));
 
-    beforeEach(inject(function($http, $httpBackend, $q, $rootScope, CommentService, AuthService) {
-        http = $http;
+    beforeEach(inject(function (HttpService, $httpBackend, $q, $rootScope, CommentService, AuthService) {
+        http = HttpService;
         httpBackend = $httpBackend;
         deferred = $q.defer();
         scope = $rootScope.$new();
@@ -45,6 +45,7 @@
                     error = response;
                 }
             );
+            httpBackend.flush();
         });
 
         it('should call http.get()', function() {
@@ -272,6 +273,7 @@
                 done();
             });
             deferred.resolve();
+            scope.$apply()
             httpBackend.flush();
         });
 
@@ -283,6 +285,7 @@
                 done();
             });
             deferred.resolve();
+            scope.$apply();
             httpBackend.flush();
         });
     });

--- a/frontend/test/specs/configInstDirectiveSpec.js
+++ b/frontend/test/specs/configInstDirectiveSpec.js
@@ -114,7 +114,7 @@ describe('Test ConfigInstDirective', function() {
                     authService: authService,
                     institutionService: institutionService,
                     imageService: imageService
-                });
+            });
         };
 
         editInstCtrl = createCtrl();
@@ -133,7 +133,7 @@ describe('Test ConfigInstDirective', function() {
             spyOn(institutionService, 'getInstitution').and.callFake(function() {
                 return {
                     then: function(callback) {
-                        return callback({data: {name: 'inst', portfolio_url: 'url'}});
+                        return callback({name: 'inst', portfolio_url: 'url'});
                     }
                 };
             });

--- a/frontend/test/specs/eventPageControllerSpec.js
+++ b/frontend/test/specs/eventPageControllerSpec.js
@@ -99,7 +99,7 @@
       spyOn(postService, 'createPost').and.callFake(function () {
         return {
           then: function (callback) {
-            return callback({data: {}});
+            return callback({});
           }
         };
       });

--- a/frontend/test/specs/eventServiceSpec.js
+++ b/frontend/test/specs/eventServiceSpec.js
@@ -42,9 +42,9 @@
 
         beforeEach(module('app'));
 
-        beforeEach(inject(function($httpBackend, EventService, _$http_, $rootScope) {
+        beforeEach(inject(function($httpBackend, EventService, HttpService, $rootScope) {
             httpBackend = $httpBackend;
-            $http = _$http_;
+            $http = HttpService;
             scope = $rootScope.$new();
             service = EventService;
             httpBackend.when('GET', 'main/main.html').respond(200);
@@ -74,7 +74,7 @@
                 });
                 httpBackend.flush();
                 expect($http.post).toHaveBeenCalledWith(EVENT_URI, event);
-                expect(result.data).toEqual(event);
+                expect(result).toEqual(event);
             });
     
             it('getEvent()', function() {
@@ -86,7 +86,7 @@
                 });
                 httpBackend.flush();
                 expect($http.get).toHaveBeenCalledWith(EVENT_URI + '/' + event.key);
-                expect(result.data).toEqual(event);
+                expect(result).toEqual(event);
             });
     
             it('getEvents()', function() {
@@ -98,7 +98,7 @@
                 });
                 httpBackend.flush();
                 expect($http.get).toHaveBeenCalledWith(EVENT_URI + '?page=' + page + "&limit=" + LIMIT);
-                expect(result.data).toEqual(events);
+                expect(result).toEqual(events);
             });
     
             it('getInstEvents()', function() {
@@ -110,7 +110,7 @@
                 });
                 httpBackend.flush();
                 expect($http.get).toHaveBeenCalledWith(INST_URI + institution.key + '/events?page=' + page + "&limit=" + LIMIT);
-                expect(result.data).toEqual(events);
+                expect(result).toEqual(events);
             });
     
             it('deleteEvent()', function() {

--- a/frontend/test/specs/institutionControllerSpec.js
+++ b/frontend/test/specs/institutionControllerSpec.js
@@ -230,7 +230,7 @@
                 spyOn(institutionService, 'getNextPosts').and.callFake(function() {
                     return {
                         then: function(callback) {
-                            callback({data: {posts: posts, next: false}});
+                            callback({posts: posts, next: false});
                         }
                     };
                 });

--- a/frontend/test/specs/institutionServiceSpec.js
+++ b/frontend/test/specs/institutionServiceSpec.js
@@ -29,7 +29,7 @@
             });
             httpBackend.flush();
             expect($http.get).toHaveBeenCalled();
-            expect(result.data).toEqual(institutions);
+            expect(result).toEqual(institutions);
         });
 
         it('Test follow', function() {
@@ -57,7 +57,7 @@
             });
             httpBackend.flush();
             expect($http.get).toHaveBeenCalled();
-            expect(result.data).toEqual(raoni);
+            expect(result).toEqual(raoni);
         });
 
         it('Test getFollowers in success case', function() {
@@ -69,7 +69,7 @@
             });
             httpBackend.flush();
             expect($http.get).toHaveBeenCalled();
-            expect(result.data).toEqual(raoni);
+            expect(result).toEqual(raoni);
         });
 
         it('Test getInstitution in success case', function() {
@@ -81,7 +81,7 @@
             });
             httpBackend.flush();
             expect($http.get).toHaveBeenCalled();
-            expect(result.data).toEqual(institutions[0]);
+            expect(result).toEqual(institutions[0]);
         });
 
         it('Test searchInstitution', function() {
@@ -94,7 +94,7 @@
             });
             httpBackend.flush();
             expect($http.get).toHaveBeenCalled();
-            expect(result.data).toEqual(documents);
+            expect(result).toEqual(documents);
         });
 
         it('Should call http.delete()', function() {

--- a/frontend/test/specs/institutionServiceSpec.js
+++ b/frontend/test/specs/institutionServiceSpec.js
@@ -11,14 +11,14 @@
 
         beforeEach(module('app'));
 
-        beforeEach(inject(function($httpBackend, InstitutionService, _$http_) {
-            httpBackend = $httpBackend;
-            $http = _$http_;
-            service = InstitutionService;
-            httpBackend.when('GET', 'main/main.html').respond(200);
-            httpBackend.when('GET', 'home/home.html').respond(200);
-            httpBackend.when('GET', 'error/error.html').respond(200);
-        }));
+    beforeEach(inject(function ($httpBackend, InstitutionService, HttpService) {
+        httpBackend = $httpBackend;
+        $http = HttpService;
+        service = InstitutionService;
+        httpBackend.when('GET', 'main/main.html').respond(200);
+        httpBackend.when('GET', 'home/home.html').respond(200);
+        httpBackend.when('GET', 'error/error.html').respond(200);
+    }));
 
         it('Test getInstitutions in success case', function() {
             spyOn($http, 'get').and.callThrough();

--- a/frontend/test/specs/inviteInstHierarchieControllerSpec.js
+++ b/frontend/test/specs/inviteInstHierarchieControllerSpec.js
@@ -81,7 +81,7 @@
         spyOn(instService, 'getInstitution').and.callFake(function () {
             return {
                 then: function (callback) {
-                    return callback({ data: institution });
+                    return callback(institution);
                 }
             };
         });
@@ -142,7 +142,7 @@
             spyOn(instService, 'searchInstitutions').and.callFake(function () {
                 return {
                     then: function (callback) {
-                        return callback({data: {}});
+                        return callback({});
                     }
                 };
             });

--- a/frontend/test/specs/inviteServiceSpec.js
+++ b/frontend/test/specs/inviteServiceSpec.js
@@ -13,9 +13,9 @@
 
         beforeEach(module('app'));
 
-        beforeEach(inject(function($httpBackend, InviteService, _$http_) {
+        beforeEach(inject(function ($httpBackend, InviteService, HttpService) {
             httpBackend = $httpBackend;
-            $http = _$http_;
+            $http = HttpService;
             service = InviteService;
             service.user = {
                 name: 'user',
@@ -37,7 +37,7 @@
                 result = data;
                 body['data'] = {invite_body: inviteUser};
                 expect($http.post).toHaveBeenCalledWith(INVITES_URI, body);
-                expect(result.data).toEqual(inviteUser);
+                expect(result).toEqual(inviteUser);
                 done();
             });
             httpBackend.flush();
@@ -51,7 +51,7 @@
                 result = data;
                 body['data'] = {invite_body: inviteInstitution};
                 expect($http.post).toHaveBeenCalledWith(INVITES_URI, body);
-                expect(result.data).toEqual(inviteInstitution);
+                expect(result).toEqual(inviteInstitution);
                 done();
             });
             httpBackend.flush();
@@ -64,7 +64,7 @@
             service.getSentInstitutionInvitations().then(function(data){
                 result = data;
                 expect($http.get).toHaveBeenCalled();
-                expect(result.data).toEqual(invites);
+                expect(result).toEqual(invites);
                 done();
             });
             httpBackend.flush();

--- a/frontend/test/specs/postDetailsControllerSpec.js
+++ b/frontend/test/specs/postDetailsControllerSpec.js
@@ -45,7 +45,7 @@
     var POSTS_URI = "/api/posts";
 
 
-    beforeEach(inject(function($controller, $httpBackend, $http, $mdDialog,
+    beforeEach(inject(function($controller, $httpBackend, HttpService, $mdDialog,
             PostService, AuthService, $mdToast, $rootScope, CommentService, $state) {
         scope = $rootScope.$new();
         rootscope = $rootScope;
@@ -54,7 +54,7 @@
         mdDialog = $mdDialog;
         postService = PostService;
         mdToast = $mdToast;
-        http = $http;
+        http = HttpService;
         state = $state;
         commentService = CommentService;
         commentService.user = user;

--- a/frontend/test/specs/postDirectiveSpec.js
+++ b/frontend/test/specs/postDirectiveSpec.js
@@ -29,7 +29,7 @@
                     'options' : options
                     };
 
-    beforeEach(inject(function($controller, $httpBackend, $http, $q, $mdDialog,
+    beforeEach(inject(function($controller, $httpBackend, HttpService, $q, $mdDialog,
             PostService, AuthService, $mdToast, $rootScope, ImageService) {
         imageService = ImageService;
         scope = $rootScope.$new();
@@ -39,7 +39,7 @@
         mdDialog = $mdDialog;
         postService = PostService;
         mdToast = $mdToast;
-        http = $http;
+        http = HttpService;
         AuthService.login(user);
 
         postCtrl = $controller('PostController', {
@@ -124,7 +124,7 @@
             spyOn(postService, 'createPost').and.callFake(function () {
                 return {
                     then: function (callback) {
-                        return callback({ data: {key: post.key }});
+                        return callback({key: post.key });
                     }
                 };
             });

--- a/frontend/test/specs/postServiceSpec.js
+++ b/frontend/test/specs/postServiceSpec.js
@@ -41,9 +41,9 @@
 
         beforeEach(module('app'));
 
-        beforeEach(inject(function($httpBackend, PostService, _$http_, $rootScope, AuthService) {
+        beforeEach(inject(function($httpBackend, PostService, HttpService, $rootScope, AuthService) {
             httpBackend = $httpBackend;
-            $http = _$http_;
+            $http = HttpService;
             scope = $rootScope.$new();
             service = PostService;
             httpBackend.when('GET', 'main/main.html').respond(200);
@@ -67,7 +67,7 @@
             });
             httpBackend.flush();
             expect($http.get).toHaveBeenCalled();
-            expect(result.data).toEqual(posts);
+            expect(result).toEqual(posts);
         });
 
         it('Test createPost in success case', function() {
@@ -85,7 +85,7 @@
                 }
             }
             expect($http.post).toHaveBeenCalledWith(POSTS_URI, body);
-            expect(result.data).toEqual(posts[0]);
+            expect(result).toEqual(posts[0]);
         });
 
         it('Test likePost in success case', function() {
@@ -125,18 +125,19 @@
             });
             httpBackend.flush();
             expect($http.get).toHaveBeenCalled();
-            expect(result.data).toEqual([like]);
+            expect(result).toEqual([like]);
         });
 
         it('Test save()', function() {
             spyOn($http, 'patch').and.callThrough();
             httpBackend.when('PATCH', POSTS_URI + '/' + posts[0].key)
-                                    .respond(200, {status: 200, msg: "success"});
+                                    .respond(200, {status: 200, msg: "success", data: {msg: ""}});
             var patch = [{op: 'remove', path: 'propertie/1', value: 'test patch'}];
             var result;
-            service.save(posts[0], patch).catch(function(data) {
+            service.save(posts[0].key, patch).then(function(data) {
                 result = data;
-            });
+            }); 
+            httpBackend.flush();
             expect($http.patch).toHaveBeenCalled();
         });
 }));

--- a/frontend/test/specs/processInviteUserAdmControllerSpec.js
+++ b/frontend/test/specs/processInviteUserAdmControllerSpec.js
@@ -44,7 +44,7 @@
         spyOn(InviteService, 'getInvite').and.callFake(function() {
             return {
                 then: function(callback) {
-                    callback({data: invite});
+                    callback(invite);
                 }
             };
         });

--- a/frontend/test/specs/requestProcessingControllerSpec.js
+++ b/frontend/test/specs/requestProcessingControllerSpec.js
@@ -309,7 +309,7 @@
             spyOn(institutionService, 'getInstitution').and.callFake(function () {
                 return {
                     then: function (callback) {
-                        callback({ data: requested_institution });
+                        callback(requested_institution);
                     }
                 };
             });

--- a/frontend/test/specs/searchControllerSpec.js
+++ b/frontend/test/specs/searchControllerSpec.js
@@ -126,7 +126,7 @@
                     return {
                         then: function (callback) {
                             return callback(
-                                {data: [splab, inst, instToTest]}
+                                [splab, inst, instToTest]
                             );
                         }
                     };

--- a/frontend/test/specs/sharePostControllerSpec.js
+++ b/frontend/test/specs/sharePostControllerSpec.js
@@ -39,7 +39,7 @@
 
     beforeEach(module('app'));
 
-    beforeEach(inject(function($controller, $httpBackend, $http, $mdDialog, $q,
+    beforeEach(inject(function ($controller, $httpBackend, HttpService, $mdDialog, $q,
             PostService, AuthService, $rootScope, $state) {
         scope = $rootScope.$new();
         httpBackend = $httpBackend;
@@ -122,7 +122,7 @@
             spyOn(postService, 'createPost').and.callFake(function () {
                 return {
                     then: function (callback) {
-                        return callback({data: newPost});
+                        return callback(newPost);
                     }
                 };
             });
@@ -146,7 +146,7 @@
             spyOn(postService, 'createPost').and.callFake(function () {
                 return {
                     then: function (callback) {
-                        return callback({data: newPost});
+                        return callback(newPost);
                     }
                 };
             });

--- a/frontend/test/specs/surveyServiceSpec.js
+++ b/frontend/test/specs/surveyServiceSpec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-(describe('Test InstitutionService', function () {
+(describe('Test SurveyService', function () {
         var httpBackend, service, $http;
         var SURVEY_URI = "/api/surveyposts/";
         var user = {name: 'User', key: 12345};
@@ -23,9 +23,9 @@
 
         beforeEach(module('app'));
 
-        beforeEach(inject(function($httpBackend, SurveyService, _$http_) {
+    beforeEach(inject(function ($httpBackend, SurveyService, HttpService) {
             httpBackend = $httpBackend;
-            $http = _$http_;
+            $http = HttpService;
             service = SurveyService;
             httpBackend.when('GET', 'main/main.html').respond(200);
             httpBackend.when('GET', 'home/home.html').respond(200);

--- a/frontend/test/specs/userServiceSpec.js
+++ b/frontend/test/specs/userServiceSpec.js
@@ -28,9 +28,9 @@
 
         beforeEach(module('app'));
 
-        beforeEach(inject(function($httpBackend, UserService, _$http_, $rootScope) {
+        beforeEach(inject(function($httpBackend, UserService, HttpService, $rootScope) {
             httpBackend = $httpBackend;
-            $http = _$http_;
+            $http = HttpService;
             scope = $rootScope.$new();
             service = UserService;
             httpBackend.when('GET', 'main/main.html').respond(200);

--- a/frontend/user/profileService.js
+++ b/frontend/user/profileService.js
@@ -5,7 +5,7 @@
 
     var USER_URI = '/api/user';
 
-    app.service("ProfileService", function UserService($mdDialog, $http, $q, AuthService) {
+    app.service("ProfileService", function UserService($mdDialog, HttpService, $q, AuthService) {
         var service = this;
 
         service.showProfile  = function showProfile(userKey, ev) {
@@ -24,13 +24,7 @@
 
         service.editProfile = function editProfile(data) {
             data = JSON.parse(angular.toJson(data));
-            var deffered = $q.defer();
-            $http.patch(USER_URI, data).then(function success(info) {
-                deffered.resolve(info);
-            }, function error(info) {
-                deffered.reject(info);
-            });
-            return deffered.promise;
+            return HttpService.patch(USER_URI, data);
         };
 
     });

--- a/frontend/user/userInactiveController.js
+++ b/frontend/user/userInactiveController.js
@@ -79,7 +79,7 @@
             var deferred = $q.defer();
 
             InstitutionService.getInstitution(institution.id).then(function success(response) {
-                userInactiveCtrl.institutionSelect = response.data;
+                userInactiveCtrl.institutionSelect = response;
                 userInactiveCtrl.hasInstSelect = true;
                 userInactiveCtrl.showFullInformation(institution);
                 userInactiveCtrl.request = {
@@ -140,7 +140,7 @@
             var deferred = $q.defer();
             clearProperties();
             InstitutionService.searchInstitutions(userInactiveCtrl.finalSearch, ACTIVE, 'institution').then(function success(response) {
-                userInactiveCtrl.institutions = response.data;
+                userInactiveCtrl.institutions = response;
                 deferred.resolve(response);
             });
             return deferred.promise;

--- a/frontend/user/userService.js
+++ b/frontend/user/userService.js
@@ -3,60 +3,30 @@
 (function() {
     var app = angular.module("app");
 
-    app.service("UserService", function UserService($http, $q) {
+    app.service("UserService", function UserService(HttpService, $q) {
         var service = this;
 
         var USER_URI = "/api/user";
 
         service.deleteAccount = function deleteAccount() {
-            var deffered = $q.defer();
-            $http.delete(USER_URI).then(function success(info) {
-                deffered.resolve(info.data);
-            }, function error(data) {
-                deffered.reject(data);
-            });
-            return deffered.promise;
+            return HttpService.delete(USER_URI);
         };
 
         service.save = function save(patch) {
             patch = JSON.parse(angular.toJson(patch));
-            var deffered = $q.defer();
-            $http.patch(USER_URI, patch).then(function success(info) {
-                deffered.resolve(info.data);
-            }, function error(data) {
-                deffered.reject(data);
-            });
-            return deffered.promise;
+            return HttpService.patch(USER_URI, patch);
         };
 
         service.getUser = function getUser(userKey) {
-            var deffered = $q.defer();
-            $http.get(USER_URI + "/" + userKey + "/profile").then(function loadUser(info) {
-                deffered.resolve(info.data);
-            }, function error(data) {
-                deffered.reject(data);
-            });
-            return deffered.promise;
+            return HttpService.get(USER_URI + "/" + userKey + "/profile");
         };
 
         service.load = function load() {
-            var deffered = $q.defer();
-            $http.get(USER_URI).then(function loadUser(info) {
-                deffered.resolve(info.data);
-            }, function error(data) {
-                deffered.reject(data);
-            });
-            return deffered.promise;
+            return HttpService.get(USER_URI);
         };
 
         service.deleteInstitution = function deleteInstitution(institution_key) {
-            var deffered = $q.defer();
-            $http.delete(USER_URI + '/institutions/' + institution_key + '/institutional-operations').then(function success(info) {
-                deffered.resolve(info.data);
-            }, function error(data) {
-                deffered.reject(data);
-            });
-            return deffered.promise;
+            return HttpService.delete(USER_URI + '/institutions/' + institution_key + '/institutional-operations');
         };
     });
 })();

--- a/frontend/utils/httpService.js
+++ b/frontend/utils/httpService.js
@@ -10,6 +10,7 @@
         var GET = 'GET';
         var PUT = 'PUT';
         var DELETE = 'DELETE';
+        var PATCH = 'PATCH';
 
         service.get = function getMethod(url) {
             return request(GET, url);
@@ -25,6 +26,10 @@
 
         service.delete = function deleteMethod(url) {
             return request(DELETE, url);
+        };
+
+        service.patch = function patchMethod(url, data) {
+            return request(PATCH, url, data);
         };
 
         function request(method, url, data) {

--- a/support/auth/userService.js
+++ b/support/auth/userService.js
@@ -3,19 +3,13 @@
 
     var support = angular.module("support");
 
-    support.service("UserService", function UserService($http, $q) {
+    support.service("UserService", function UserService(HttpService, $q) {
         var service = this;
 
         var USER_URI = "/api/user";
 
         service.load = function load() {
-            var deffered = $q.defer();
-            $http.get(USER_URI).then(function loadUser(info) {
-                deffered.resolve(info.data);
-            }, function error(data) {
-                deffered.reject(data);
-            });
-            return deffered.promise;
+            return HttpService.get(USER_URI);
         };
     });
 })();


### PR DESCRIPTION
**Feature/Bug description:**
Some of the frontend's requests weren't using HttpService, what makes the code dirty.
It was like:
```javascript
$http.method(url, body).then(function success(response) {
     deferred.resolve(response);
}, function error(response) {
    deferred.reject(response);
});
return deferred.promise
```
**Solution:**
I've changed these requests using the HttpService.
Now, It is like:
```javascript
return HttpService.method(url, body);
```

With this approach we gotta be careful, mainly in the controllers, because the response returned by HttpService is the original response.data, so, we only have to take, as the request's response, the response and not response.data anymore.

for example:
previously the getPost function was like that:
```javascript
function getPost(postKey) {
  InviteService.getPost(postKey).then(function success(response) {
     ctrl.post = response.data;
  });
}
```

now it is like:
```javascript
function getPost(postKey) {
  InviteService.getPost(postKey).then(function success(response) {
     ctrl.post = response;
  });
}
```

for last but not least, the HttpService calls MessageService.showToast in the request's error function, so, we don't have to do that in the controllers anymore.

**TODO/FIXME:** Remove service.posts = response from postService.getNextPosts. Apparently this array isn't being used in anywhere. 