### PR TITLE
Remove none option from hierarchy invite's view

### DIFF
--- a/frontend/invites/invite_institution_hierarchie.html
+++ b/frontend/invites/invite_institution_hierarchie.html
@@ -35,7 +35,6 @@
 
             <md-radio-button value="INSTITUTION_PARENT" class="md-primary">É a instituição superior</md-radio-button>
             <md-radio-button value="INSTITUTION_CHILDREN" class="md-primary">É uma subordinada de {{inviteInstHierCtrl.institution.name}}</md-radio-button>
-            <md-radio-button ng-disabled="true" value="suggestion_invite" class="md-primary">Nenhuma</md-radio-button>
 
           </md-radio-group>
           <section layout="row" layout="column" layout-align="end center" layout-wrap>


### PR DESCRIPTION
**Feature/Bug description:**
There was a useless and disabled md-radio-button.
**Solution:**
Remove the button.

![screenshot from 2018-06-13 13-55-02](https://user-images.githubusercontent.com/23387866/41366483-9df4a20a-6f12-11e8-9641-1e3fe35d8fd4.png)

**TODO/FIXME:** n/a