### PR TITLE
Fix search with escapes characters

### DIFF
--- a/backend/search_module/search_institution.py
+++ b/backend/search_module/search_institution.py
@@ -3,6 +3,7 @@
 
 from google.appengine.api import search
 from . import SearchDocument
+from utils import text_normalize
 
 __all__ = ['SearchInstitution']
 
@@ -19,7 +20,6 @@ def institution_has_changes(fields, entity):
                 return True
 
         return False
-
 
 class SearchInstitution(SearchDocument):
     """Search institution's model."""
@@ -134,7 +134,7 @@ class SearchInstitution(SearchDocument):
                 fields_values.append(field_value)
 
         fields_values_string = " OR ".join(fields_values) if fields_values else ""
-        return fields_values_string
+        return text_normalize(fields_values_string)
     
     def updateDocument(self, entity, has_changes=institution_has_changes):
         """Update a Document.

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -8,6 +8,7 @@ import logging
 from app_version import APP_VERSION
 
 from google.appengine.ext import ndb
+from unicodedata import normalize
 
 from oauth2client import client
 from oauth2client.crypt import AppIdentityError
@@ -156,3 +157,8 @@ def to_int(value, exception, message_exception):
         raise exception(message_exception)
 
     return value
+
+def text_normalize(text):
+    normal_form = normalize('NFKD', unicode(text)).encode('ascii', 'ignore')
+    escape_characters = normal_form.encode('unicode-escape')
+    return escape_characters

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -159,6 +159,17 @@ def to_int(value, exception, message_exception):
     return value
 
 def text_normalize(text):
-    normal_form = normalize('NFKD', unicode(text)).encode('ascii', 'ignore')
-    escape_characters = normal_form.encode('unicode-escape')
-    return escape_characters
+    """
+    This method removes all accents and special characters from the passed text 
+    using the NFKD normalization of unicode coding (For more information on this 
+    normalization go to: https://unicode.org/reports/tr15/). This normalization 
+    maps all characters to their similar in normal formal unicode. After 
+    normalization, treat all escape characters so they are considered normal 
+    characters in the text.
+
+    Arguments:
+    text -- Text to normilize
+    """
+    normal_form_text = normalize('NFKD', unicode(text)).encode('ascii', 'ignore')
+    text_ignoring_escape_chars = normal_form_text.encode('unicode-escape')
+    return text_ignoring_escape_chars


### PR DESCRIPTION
**Feature/Bug description:** When performing a search whose searched query has one or more '\', an error is generated on the server due to the fact that '\' is an escape character and is not being handled on the server.

**Solution:** Treat the '\' character in the server as part of the search sentence and not as an escape character, thus allowing the use of '\' in the search.

**TODO/FIXME:** n/a