### PR TITLE
Fix notify posts' subscribers when there is a new comment

### DIFF
--- a/backend/handlers/post_comment_handler.py
+++ b/backend/handlers/post_comment_handler.py
@@ -54,17 +54,15 @@ class PostCommentHandler(BaseHandler):
         post.add_comment(comment)
         entity_type = 'COMMENT'
 
-        user_is_the_post_author = post.author == user.key
-        if(not user_is_the_post_author):
-            params = {
-                'receiver_key': post.author.urlsafe(),
-                'sender_key': user.key.urlsafe(),
-                'entity_key': post.key.urlsafe(),
-                'entity_type': entity_type,
-                'current_institution': user.current_institution.urlsafe(),
-                'sender_institution_key': post.institution.urlsafe()
-            }
-            enqueue_task('post-notification', params)
+        params = {
+            'receiver_key': post.author.urlsafe(),
+            'sender_key': user.key.urlsafe(),
+            'entity_key': post.key.urlsafe(),
+            'entity_type': entity_type,
+            'current_institution': user.current_institution.urlsafe(),
+            'sender_institution_key': post.institution.urlsafe()
+        }
+        enqueue_task('post-notification', params)
 
         self.response.write(json.dumps(Utils.toJson(comment)))
 

--- a/backend/test/post_comment_handler_test.py
+++ b/backend/test/post_comment_handler_test.py
@@ -127,7 +127,8 @@ class PostCommentHandlerTest(TestBaseHandler):
         self.body['commentData'] = self.other_comment
         self.testapp.post_json(
             URL_POST_COMMENT % self.user_post.key.urlsafe(),
-            self.body
+            self.body,
+            headers={'institution-authorization': self.institution.key.urlsafe()}
         )
 
         # Update post
@@ -138,7 +139,7 @@ class PostCommentHandlerTest(TestBaseHandler):
                           "Expected size of comment's list should be one")
 
         # assert the notification was not sent
-        enqueue_task.assert_not_called()
+        enqueue_task.assert_called()
 
     @patch('util.login_service.verify_token', return_value={'email': OTHER_USER_EMAIL})
     def test_delete(self, verify_token):
@@ -203,7 +204,8 @@ class PostCommentHandlerTest(TestBaseHandler):
         # Added comment of user
         self.response = self.testapp.post_json(
             URL_POST_COMMENT % self.user_post.key.urlsafe(),
-            self.body
+            self.body,
+            headers={'institution-authorization': self.institution.key.urlsafe()}
         ).json
         # ID of comment
         self.id_comment = self.response["id"]
@@ -261,7 +263,8 @@ class PostCommentHandlerTest(TestBaseHandler):
         # Added comment
         self.response = self.testapp.post_json(
             URL_POST_COMMENT % self.user_post.key.urlsafe(),
-            self.body
+            self.body,
+            headers={'institution-authorization': self.institution.key.urlsafe()}
         ).json
 
         # When other_user try delete comment from user.


### PR DESCRIPTION
**Feature/Bug description:**
There was a wrong if statement in post_comment_handler what was blocking the sending notification when the comment was sent by the post's author. This verification is done in the queue.
**Solution:**
Remove the if statement.

**TODO/FIXME:** n/a