### PR TITLE
Fix comment a post whose institution is not active

### DIFF
--- a/backend/handlers/event_collection_handler.py
+++ b/backend/handlers/event_collection_handler.py
@@ -50,8 +50,8 @@ class EventCollectionHandler(BaseHandler):
         institution_key = ndb.Key(urlsafe=data['institution_key'])
         institution = institution_key.get()
 
-        Utils._assert(institution.state == 'inactive',
-                      "The institution has been deleted", NotAuthorizedException)
+        Utils._assert(not institution.is_active(),
+                      "This institution is not active", NotAuthorizedException)
 
         event = Event.create(data, user, institution)
         event.put()

--- a/backend/handlers/institution_followers_handler.py
+++ b/backend/handlers/institution_followers_handler.py
@@ -42,8 +42,8 @@ class InstitutionFollowersHandler(BaseHandler):
         institution_key = ndb.Key(urlsafe=url_string)
         institution = institution_key.get()
 
-        Utils._assert(institution.state == 'inactive',
-                      "The institution has been deleted", NotAuthorizedException)
+        Utils._assert(not institution.is_active(),
+                      "This institution is not active", NotAuthorizedException)
 
         if(not type(institution) is Institution):
             raise Exception("Key is not an Institution")
@@ -59,8 +59,8 @@ class InstitutionFollowersHandler(BaseHandler):
         institution_key = ndb.Key(urlsafe=url_string)
         institution = institution_key.get()
 
-        Utils._assert(institution.state == 'inactive',
-                      "The institution has been deleted", NotAuthorizedException)
+        Utils._assert(not institution.is_active(),
+                      "This institution is not active", NotAuthorizedException)
         
         Utils._assert(institution.name == 'Ministério da Saúde',
                       "The institution can not be unfollowed", NotAuthorizedException)

--- a/backend/handlers/institution_handler.py
+++ b/backend/handlers/institution_handler.py
@@ -84,8 +84,8 @@ class InstitutionHandler(BaseHandler):
         """Handle GET Requests."""
         obj_key = ndb.Key(urlsafe=url_string)
         obj = obj_key.get()
-        Utils._assert(obj.state == 'inactive',
-                      "The institution has been deleted", NotAuthorizedException)
+        Utils._assert(not obj.is_active(),
+                      "This institution is not active", NotAuthorizedException)
         assert type(obj) is Institution, "Key is not an Institution"
         institution_json = Utils.toJson(obj, host=self.request.host)
         if(obj.admin):
@@ -112,8 +112,8 @@ class InstitutionHandler(BaseHandler):
         data = self.request.body
         institution = ndb.Key(urlsafe=institution_key).get()
 
-        Utils._assert(institution.state == 'inactive',
-                      "The institution has been deleted", NotAuthorizedException)
+        Utils._assert(not institution.is_active(),
+                      "This institution is not active", NotAuthorizedException)
 
         JsonPatch.load(data, institution)
         institution.put()

--- a/backend/handlers/institution_hierarchy_handler.py
+++ b/backend/handlers/institution_hierarchy_handler.py
@@ -53,10 +53,10 @@ class InstitutionHierarchyHandler(BaseHandler):
                       "Key is not an institution", EntityException)
         Utils._assert(not type(institution_link) is Institution,
                       "Key is not an institution", EntityException)
-        Utils._assert(institution.state == 'inactive',
-                      "The institution has been deleted", NotAuthorizedException)
-        Utils._assert(institution_link.state == 'inactive',
-                      "The institution has been deleted", NotAuthorizedException)
+        Utils._assert(not institution.is_active(),
+                      "This institution is not active", NotAuthorizedException)
+        Utils._assert(not institution_link.is_active(),
+                      "This institution is not active", NotAuthorizedException)
 
         institution.remove_link(institution_link, is_parent)
         admin = institution_link.admin

--- a/backend/handlers/invite_institution_collection_handler.py
+++ b/backend/handlers/invite_institution_collection_handler.py
@@ -57,8 +57,8 @@ class InviteInstitutionCollectionHandler(BaseHandler):
             institution.key.urlsafe()
         )
 
-        Utils._assert(institution.state == 'inactive',
-                      "The institution has been deleted", NotAuthorizedException)
+        Utils._assert(not institution.is_active(),
+                      "This institution is not active", NotAuthorizedException)
 
         invite.put()
         invite.stub_institution_key.get().addInvite(invite)

--- a/backend/handlers/invite_user_handler.py
+++ b/backend/handlers/invite_user_handler.py
@@ -78,7 +78,7 @@ class InviteUserHandler(BaseHandler):
             "The user is already a member", NotAuthorizedException)
         
         Utils._assert(not institution.is_active(), 
-            "The institution is not active.", NotAuthorizedException)
+            "This institution is not active.", NotAuthorizedException)
 
         invite.change_status('accepted')
 

--- a/backend/handlers/like_handler.py
+++ b/backend/handlers/like_handler.py
@@ -93,8 +93,8 @@ class LikeHandler(BaseHandler):
         post = ndb.Key(urlsafe=post_key).get()
         institution = post.institution.get()
 
-        Utils._assert(institution.state == 'inactive',
-                      "The institution has been deleted", NotAuthorizedException)
+        Utils._assert(not institution.is_active(),
+                      "This institution is not active", NotAuthorizedException)
         
         if comment_id:
             comment = post.get_comment(comment_id)

--- a/backend/handlers/post_collection_handler.py
+++ b/backend/handlers/post_collection_handler.py
@@ -45,8 +45,8 @@ class PostCollectionHandler(BaseHandler):
 
         institution = ndb.Key(urlsafe=institution_key).get()
 
-        Utils._assert(institution.state == 'inactive',
-                      "The institution has been deleted",
+        Utils._assert(not institution.is_active(),
+                      "This institution is not active",
                       NotAuthorizedException)
 
         permission = get_permission(post_data)

--- a/backend/handlers/post_comment_handler.py
+++ b/backend/handlers/post_comment_handler.py
@@ -77,8 +77,8 @@ class PostCommentHandler(BaseHandler):
         post = ndb.Key(urlsafe=post_key).get()
         institution = post.institution.get()
         
-        Utils._assert(institution.state == 'inactive',
-                      "The institution has been deleted", NotAuthorizedException)
+        Utils._assert(not institution.is_active(),
+                      "This institution is not active", NotAuthorizedException)
         Utils._assert(post.state == 'deleted',
                       "Can not delete comment in deleted post", NotAuthorizedException)
         

--- a/backend/handlers/post_comment_handler.py
+++ b/backend/handlers/post_comment_handler.py
@@ -46,7 +46,10 @@ class PostCommentHandler(BaseHandler):
         body = json.loads(self.request.body)
         comment_data = body['commentData']
         post = ndb.Key(urlsafe=post_key).get()
+        institution = post.institution.get()
 
+        Utils._assert(not institution.is_active(),
+            "This institution is not active", EntityException)
         Utils._assert(post.state == 'deleted',
                       "This post has been deleted", EntityException)
 

--- a/backend/handlers/reply_comment_handler.py
+++ b/backend/handlers/reply_comment_handler.py
@@ -48,8 +48,8 @@ class ReplyCommentHandler(BaseHandler):
         post = ndb.Key(urlsafe=post_key).get()
         institution = post.institution.get()
 
-        Utils._assert(institution.state == 'inactive',
-                      "The institution has been deleted", NotAuthorizedException)
+        Utils._assert(not institution.is_active(),
+                      "This institution is not active", NotAuthorizedException)
         Utils._assert(post.state == 'deleted',
                       "This post has been deleted", EntityException)
 
@@ -92,8 +92,8 @@ class ReplyCommentHandler(BaseHandler):
         post = ndb.Key(urlsafe=post_key).get()
         institution = post.institution.get()
         
-        Utils._assert(institution.state == 'inactive',
-                      "The institution has been deleted", NotAuthorizedException)
+        Utils._assert(not institution.is_active(),
+                      "This institution is not active", NotAuthorizedException)
         
         comment = post.get_comment(comment_id)
         replies = comment.get('replies')

--- a/backend/handlers/resend_invite_handler.py
+++ b/backend/handlers/resend_invite_handler.py
@@ -30,7 +30,7 @@ class ResendInviteHandler(BaseHandler):
                 invite.institution_key.urlsafe())
 
         institution = invite.institution_key.get()
-        Utils._assert(institution.state == 'inactive',
-                        "The institution has been deleted", NotAuthorizedException)
+        Utils._assert(not institution.is_active(),
+                      "This institution is not active", NotAuthorizedException)
 
         invite.send_invite(host, user.current_institution)

--- a/backend/handlers/vote_handler.py
+++ b/backend/handlers/vote_handler.py
@@ -24,8 +24,8 @@ class VoteHandler(BaseHandler):
         options_selected = json.loads(self.request.body)
 
         institution = survey.institution.get()
-        Utils._assert(institution.state == 'inactive',
-                      "The institution has been deleted", NotAuthorizedException)
+        Utils._assert(not institution.is_active(),
+                      "This institution is not active", NotAuthorizedException)
 
         Utils._assert(user.key in survey.voters,
                       "You've already voted in this survey", NotAuthorizedException)

--- a/backend/models/post.py
+++ b/backend/models/post.py
@@ -62,8 +62,8 @@ class Comment(ndb.Model):
             raise FieldException("Institution can not be empty")
 
         institution = ndb.Key(urlsafe=data['institution_key']).get()
-        Utils._assert(institution.state == 'inactive',
-                      "The institution has been deleted",
+        Utils._assert(not institution.is_active(),
+                      "This institution is not active",
                       NotAuthorizedException)
         comment = Comment()
         comment.text = data['text']

--- a/backend/test/event_collection_handler_test.py
+++ b/backend/test/event_collection_handler_test.py
@@ -139,6 +139,7 @@ def initModels(cls):
     cls.certbio.members = [cls.user.key]
     cls.certbio.followers = [cls.user.key]
     cls.certbio.admin = cls.user.key
+    cls.certbio.state = "active"
     cls.certbio.put()
 
     """ Update User."""

--- a/backend/test/institution_collection_handler_test.py
+++ b/backend/test/institution_collection_handler_test.py
@@ -31,18 +31,14 @@ class InstitutionCollectionHandlerTest(TestBaseHandler):
         user = mocks.create_user('user@example.com')
         # new Institution FIRST INST
         first_inst = mocks.create_institution('FIRST INST')
-        first_inst.state = "active"
         first_inst.put()
-        # new Institution SECOND INST with pending state default 
-        second_inst = mocks.create_institution('SECOND INST')
         # new Institution THIRD INST
         third_inst = mocks.create_institution('THIRD INST')
-        third_inst.state = "active"
         third_inst.put()
 
         # Call the get method
         all_institutions = self.testapp.get("/api/institutions?page=0&&limit=2").json
-        
+
         self.assertEqual(len(all_institutions), 2,
                          "The length of all institutions list should be 2")
 

--- a/backend/test/institution_followers_handler_test.py
+++ b/backend/test/institution_followers_handler_test.py
@@ -62,7 +62,7 @@ class InstitutionFollowersHandlerTest(TestBaseHandler):
                               self.other_institution.key.urlsafe())
         exception_message = self.get_message_exception(ex.exception.message)
         self.assertTrue(exception_message ==
-                        "Error! The institution has been deleted")
+                        "Error! This institution is not active")
 
     @patch('util.login_service.verify_token', return_value={'email': 'second_user@ccc.ufcg.edu.br'})
     def test_delete(self, verify_token):

--- a/backend/test/invite_institution_collection_handler_test.py
+++ b/backend/test/invite_institution_collection_handler_test.py
@@ -117,8 +117,8 @@ class InviteInstitutionCollectionHandlerTest(TestBaseHandler):
         message = self.get_message_exception(ex.exception.message)
         self.assertEqual(
             message,
-            "Error! The institution has been deleted",
-            "Expected exception message must be equal to 'Error! The institution has been deleted'") 
+            "Error! This institution is not active",
+            "Expected exception message must be equal to 'Error! This institution is not active'")
         
         # assert the invite was not sent to the invitee
         send_invite.assert_not_called()

--- a/backend/test/invite_user_handler_test.py
+++ b/backend/test/invite_user_handler_test.py
@@ -163,7 +163,7 @@ class InviteUserHandlerTest(TestBaseHandler):
         message_exception = self.get_message_exception(
             str(raises_context.exception))
         
-        expected_message = "Error! The institution is not active."
+        expected_message = "Error! This institution is not active."
 
         self.assertEqual(
             message_exception,

--- a/backend/test/mocks.py
+++ b/backend/test/mocks.py
@@ -57,6 +57,7 @@ def create_institution(name=None):
     institution.address = create_address()
     institution.description = "description"
     institution.institutional_email = "%s@email.com" %inst_hash
+    institution.state = "active"
     institution.put()
     return institution
 

--- a/backend/test/user_timeline_handler_test.py
+++ b/backend/test/user_timeline_handler_test.py
@@ -108,6 +108,7 @@ def initModels(cls):
     cls.institution.members = [cls.user.key]
     cls.institution.followers = [cls.user.key]
     cls.institution.admin = cls.user.key
+    cls.institution.state = "active"
     cls.institution.put()
 
     # POST of user To institution

--- a/backend/test/vote_handler_test.py
+++ b/backend/test/vote_handler_test.py
@@ -93,6 +93,7 @@ def initModels(cls):
     cls.institution.members = [cls.user.key]
     cls.institution.followers = [cls.user.key]
     cls.institution.admin = cls.user.key
+    cls.institution.state = 'active'
     cls.institution.put()
     # Survey post of User To SPLAB
     cls.user_post = SurveyPost()

--- a/frontend/utils/messageService.js
+++ b/frontend/utils/messageService.js
@@ -10,7 +10,6 @@
             "auth/email-already-in-use": "Email informado já está cadastrado.",
             "auth/wrong-password": "Senha incorreta ou usuário não possui senha.",
             "auth/user-not-found": "Usuário não existe.",
-            "Error! The institution has been deleted": "A instituição está inativa.",
             "Error! The user must be interested at his post": "O autor deve ser interessado em seu post.",
             "Error! The end time must be after the current time": "A data final do evento deve ser posterior a data atual!",
             "Error! The event basic data can not be changed after it has ended": "As informações básicas do evento não podem ser alteradas após sua data de termino!",
@@ -20,7 +19,7 @@
             "Error! This post has been deleted": "Esse post foi removido.",
             "Error! User already liked this comment.": "O usuário já curtiu esse comentário.",
             "The invites are being processed.": "Os convites estão sendo processados.",
-            "Error! The institution is not active.": "Essa instituição não está ativa.",
+            "Error! This institution is not active.": "Essa instituição não está ativa.",
             "Error! Invalid Current Institution! User is not an active member.": "Usuário não é um membro ativo.",
             "Error! This invitation has already been processed": "Esse convite já foi processado.",
             "Error! Invitation type not allowed": "Tipo de convite não permitido.",
@@ -38,8 +37,7 @@
             "Error! You've already voted in this survey": "Você já votou nessa enquete",
             "Error! User is not allowed to edit this post": "O usuário não tem permissão para editar essa publicação.",
             "Error! This post cannot be updated": "A publicação não pode ser editada.",
-            "Error! You don't have permission to publish post.": "Você não tem permissão para publicar post nesta instituição",
-            "Error! This institution is not active": "Essa instituição não está ativa"
+            "Error! You don't have permission to publish post.": "Você não tem permissão para publicar post nesta instituição"
         };
 
         service.showToast = function showToast(message) {

--- a/frontend/utils/messageService.js
+++ b/frontend/utils/messageService.js
@@ -38,7 +38,8 @@
             "Error! You've already voted in this survey": "Você já votou nessa enquete",
             "Error! User is not allowed to edit this post": "O usuário não tem permissão para editar essa publicação.",
             "Error! This post cannot be updated": "A publicação não pode ser editada.",
-            "Error! You don't have permission to publish post.": "Você não tem permissão para publicar post nesta instituição"
+            "Error! You don't have permission to publish post.": "Você não tem permissão para publicar post nesta instituição",
+            "Error! This institution is not active": "Essa instituição não está ativa"
         };
 
         service.showToast = function showToast(message) {


### PR DESCRIPTION
**Feature/Bug description:**
It was allowed to comment in a post whose institution was inactive.
**Solution:**
I've added a verification in post_comment_handler to block this flow.

**TODO/FIXME:** n/a