### PR TITLE
Fix pending hierarchy invitation's analyze button

### DIFF
--- a/frontend/invites/invite_institution_hierarchie.html
+++ b/frontend/invites/invite_institution_hierarchie.html
@@ -196,7 +196,7 @@
                     <h3 style="color: red">{{inviteInstHierCtrl.showMessage(request)}}</h3>
                   </div>
                 </div>
-                <div flex layout-align="end center" hide show-gt-xs>
+                <div layout="row" flex layout-align="end center" hide show-gt-xs>
                   <p class="hollow-button" md-colors="{color: 'teal-500'}">ANALISAR</p>
                 </div>
               </md-list-item>


### PR DESCRIPTION
**Feature/Bug description:**
It was missing the layout property at analyze button's div
**Solution:**
I've set the layout property.

![screenshot from 2018-06-15 08-54-17](https://user-images.githubusercontent.com/23387866/41466775-0dde4c20-707a-11e8-8bee-645fb7f54329.png)


**TODO/FIXME:** n/a