### PR TITLE
Fix getCountries and getInstitution

### DIFF
--- a/backend/handlers/institution_handler.py
+++ b/backend/handlers/institution_handler.py
@@ -84,7 +84,7 @@ class InstitutionHandler(BaseHandler):
         """Handle GET Requests."""
         obj_key = ndb.Key(urlsafe=url_string)
         obj = obj_key.get()
-        Utils._assert(not obj.is_active(),
+        Utils._assert(obj == "inactive",
                       "This institution is not active", NotAuthorizedException)
         assert type(obj) is Institution, "Key is not an Institution"
         institution_json = Utils.toJson(obj, host=self.request.host)

--- a/frontend/institution/configInstDirective.js
+++ b/frontend/institution/configInstDirective.js
@@ -398,7 +398,7 @@
 
         function getCountries() {
             $http.get('app/institution/countries.json').then(function success(response) {
-                configInstCtrl.countries = response;
+                configInstCtrl.countries = response.data;
             });
         }
 


### PR DESCRIPTION
**Feature/Bug description:**

1. The configInstDirective makes the request using $http to get the countries. The response is different from HttpService.

2. The institution_handler's get method was checking if the institution wasn't active, but some requests that are handled there  works with pending institutions.

**Solution:**
The getCountries method is now getting the correct data by doing response.data.
I've checked if the institution is inactive instead.

![screenshot from 2018-06-15 09-02-11](https://user-images.githubusercontent.com/23387866/41467343-85ca9156-707c-11e8-818b-6662a5e8a45f.png)


**TODO/FIXME:** n/a