### PR TITLE
Add branch line in institution profile

### DIFF
--- a/frontend/user/profile.html
+++ b/frontend/user/profile.html
@@ -32,6 +32,11 @@
                                     Email institucional:</b></span>
                                 <span md-colors="{color: 'default-grey-600'}"><b>{{profileCtrl.showProperty(profile.email)}}</b></span>
                               </h5>
+                              <h5 layout-gt-sm="row" style="margin: 0;font-weight: normal;">
+                                <span style="margin-right: 3px;" md-colors="{color: 'default-teal-600'}"><b>
+                                    Ramal:</b></span>
+                                <span md-colors="{color: 'default-grey-600'}"><b>{{profileCtrl.showProperty(profile.branch_line)}}</b></span>
+                              </h5>
                             </div>
                         </md-list-item>
                     </md-list>


### PR DESCRIPTION
**Feature/Bug description:** When viewing the user's institutional profile, the branch line field does not exist.

![screenshot from 2018-06-15 10-13-27](https://user-images.githubusercontent.com/18005317/41469773-ed76e70c-7084-11e8-82e9-f1a7fd2fc9f4.png)

**Solution:** I added the branch line field in the user's institutional profile view.

![screenshot from 2018-06-15 10-12-18](https://user-images.githubusercontent.com/18005317/41469779-f4ff6a76-7084-11e8-9fe2-149667ebefed.png)

**TODO/FIXME:** n/a