### PR TITLE
Send notification to adms when the user remove the account

### DIFF
--- a/backend/handlers/user_handler.py
+++ b/backend/handlers/user_handler.py
@@ -41,6 +41,19 @@ def remove_user_from_institutions(user):
         institution = institution_key.get()
         institution.remove_member(user)
 
+def notify_admins(user):
+    """Notify the admins about the user removal."""
+    for institution_key in user.institutions:
+        admin_key = institution_key.get().admin
+        notification_message = user.create_notification_message(
+            user.key, institution_key)
+            send_message_notification(
+                receiver_key=admin_key.urlsafe(),
+                notification_type='DELETED_USER',
+                entity_key=institution_key.urlsafe(),
+                message=notification_message
+            )
+
 
 class UserHandler(BaseHandler):
     """User Handler."""
@@ -71,6 +84,7 @@ class UserHandler(BaseHandler):
         """
         user.state = 'inactive'
 
+        notify_admins(user)
         remove_user_from_institutions(user)
         user.disable_account()
 

--- a/backend/handlers/user_handler.py
+++ b/backend/handlers/user_handler.py
@@ -9,7 +9,7 @@ from util import login_required
 from models import User
 from utils import json_response
 from models import InstitutionProfile
-
+from service_messages import send_message_notification
 from util import JsonPatch
 
 from . import BaseHandler
@@ -47,12 +47,12 @@ def notify_admins(user):
         admin_key = institution_key.get().admin
         notification_message = user.create_notification_message(
             user.key, institution_key)
-            send_message_notification(
-                receiver_key=admin_key.urlsafe(),
-                notification_type='DELETED_USER',
-                entity_key=institution_key.urlsafe(),
-                message=notification_message
-            )
+        send_message_notification(
+            receiver_key=admin_key.urlsafe(),
+            notification_type='DELETED_USER',
+            entity_key=institution_key.urlsafe(),
+            message=notification_message
+        )
 
 
 class UserHandler(BaseHandler):

--- a/backend/test/user_handlers_tests/user_handler_test.py
+++ b/backend/test/user_handlers_tests/user_handler_test.py
@@ -95,8 +95,9 @@ class UserHandlerTest(TestBaseHandler):
             "The institutions_admin is different from the expected one"
         )
 
+    @patch('handlers.user_handler.send_message_notification')
     @patch('util.login_service.verify_token')
-    def test_delete(self, verify_token):
+    def test_delete(self, verify_token, send_notification):
         """Test the user_handler's delete method."""
         verify_token._mock_return_value = {'email': self.other_user.email[0]}
         # check the user properties before delete it
@@ -140,6 +141,8 @@ class UserHandlerTest(TestBaseHandler):
         self.assertEquals(self.other_user.follows, [self.other_institution.key, self.institution.key], "Institutions followed by user should not be empty")
         self.assertEquals(self.other_user.permissions, {}, "User permissions should be empty")
         self.assertEquals(self.other_user.institution_profiles, [], "User permissions should be empty")
+
+        send_notification.assert_called()
 
 
     @patch('util.login_service.verify_token')

--- a/frontend/notification/notificationDirective.js
+++ b/frontend/notification/notificationDirective.js
@@ -186,6 +186,9 @@
             "ACCEPT_INVITE_HIERARCHY": {
                 icon: "account_balance",
             },
+            "DELETED_USER": {
+                icon: "clear"
+            }
         };
 
         notificationCtrl.markAsRead = function markAsRead(notification) {

--- a/frontend/notification/notificationMessageCreatorService.js
+++ b/frontend/notification/notificationMessageCreatorService.js
@@ -43,7 +43,8 @@
             'ACCEPT_INVITE_USER_ADM': messageCreator('Aceitou seu convite para ser administrador de ', SINGLE_INST),
             'REJECT_INVITE_USER_ADM': messageCreator('Rejeitou seu convite para ser administrador de ', SINGLE_INST),
             'ACCEPT_INVITE_HIERARCHY': messageCreator('Aceitou seu convite e estabeleceu vínculo entre ', DOUBLE_INST),
-            'TRANSFER_ADM_PERMISSIONS': messageCreator('Você agora possui permissões para administrar ', SINGLE_INST)
+            'TRANSFER_ADM_PERMISSIONS': messageCreator('Você agora possui permissões para administrar ', SINGLE_INST),
+            'DELETED_USER': messageCreator('Removeu sua conta na Plataforma CIS')
         };
 
 

--- a/frontend/notification/notificationMessageCreatorService.js
+++ b/frontend/notification/notificationMessageCreatorService.js
@@ -44,7 +44,7 @@
             'REJECT_INVITE_USER_ADM': messageCreator('Rejeitou seu convite para ser administrador de ', SINGLE_INST),
             'ACCEPT_INVITE_HIERARCHY': messageCreator('Aceitou seu convite e estabeleceu vínculo entre ', DOUBLE_INST),
             'TRANSFER_ADM_PERMISSIONS': messageCreator('Você agora possui permissões para administrar ', SINGLE_INST),
-            'DELETED_USER': messageCreator('Removeu sua conta na Plataforma CIS')
+            'DELETED_USER': messageCreator('Removeu sua conta na Plataforma Virtual CIS', NO_INST)
         };
 
 


### PR DESCRIPTION
**Feature/Bug description:**
Send notification to adms when the user remove the account
**Solution:**
Call send_message_notification to each institution in user_handler's delete method.

![screenshot from 2018-06-15 10-32-51](https://user-images.githubusercontent.com/23387866/41470951-915d5aa6-7088-11e8-9d28-f4054557d61f.png)


**TODO/FIXME:** n/a