### PR TITLE
Fix cancel hierarchy invite

### DIFF
--- a/backend/handlers/invite_institution_handler.py
+++ b/backend/handlers/invite_institution_handler.py
@@ -27,11 +27,6 @@ class InviteInstitutionHandler(BaseHandler):
         invite_key = ndb.Key(urlsafe=invite_urlsafe)
         invite = invite_key.get()
 
-        invite_class_name = invite.__class__.__name__
-        Utils._assert(invite_class_name != 'InviteInstitution',
-                      "The invite's type is %s, but InviteInstitution is the expected one" %invite_class_name,
-                      NotAuthorizedException)
-
         Utils._assert(invite.status != 'sent',
                       "This invitation has already been processed",
                       NotAuthorizedException)

--- a/backend/test/invite_handlers_tests/invite_institution_handler_test.py
+++ b/backend/test/invite_handlers_tests/invite_institution_handler_test.py
@@ -105,38 +105,6 @@ class InviteInstitutionHandlerTest(TestBaseHandler):
             str(raises_context.exception))
 
         expected_message = "Error! This invitation has already been processed"
-        print message_exception
-        self.assertEqual(
-            message_exception,
-            expected_message,
-            "Expected exception message must be equal to %s" % expected_message
-        )
-
-    @patch('util.login_service.verify_token', return_value={'email': 'otheruser@test.com'})
-    def test_delete_with_a_wrong_invite(self, verify_token):
-        """Test delete with a wrong invite."""
-        data = {
-            'invitee': 'otheruser@test.com',
-            'admin_key': self.user_admin.key.urlsafe(),
-            'institution_key': self.inst_test.key.urlsafe(),
-            'suggestion_institution_name': 'test',
-            'type_of_invite': 'INSTITUTION'
-        }
-        self.invite = InviteUser.create(data)
-        self.invite.put()
-
-        with self.assertRaises(Exception) as raises_context:
-            self.testapp.delete(
-                '/api/invites/institution/%s'
-                % self.invite.key.urlsafe()
-            )
-
-        message_exception = self.get_message_exception(
-            str(raises_context.exception))
-
-        invite_class_name = self.invite.__class__.__name__
-        expected_message = "Error! The invite's type is %s, but InviteInstitution is the expected one" %invite_class_name
-
         self.assertEqual(
             message_exception,
             expected_message,

--- a/frontend/invites/inviteService.js
+++ b/frontend/invites/inviteService.js
@@ -16,7 +16,6 @@
             return HttpService.post(INVITES_URI, { data: invite });
         };
 
-
         service.acceptInviteUserAdm = function acceptInviteUserAdm(inviteKey) {
             return HttpService.put(INVITES_URI + '/' + inviteKey + '/institution_adm');
         };
@@ -43,7 +42,6 @@
             return HttpService.delete(url);
         };
         
-
         service.getSentInstitutionInvitations = function getSentInstitutionInvitations() {
             return HttpService.get(INVITES_URI + '/institution');
         };


### PR DESCRIPTION
**Feature/Bug description:**
It wasn't possible to cancel a hierarchy's invite because the only invite that was handled was InviteInstitution.
**Solution:**
I've removed the verfication from the handler.

**TODO/FIXME:** n/a