### PR TITLE
Fix change parent

### DIFF
--- a/frontend/requests/analyseHierarchyRequestController.js
+++ b/frontend/requests/analyseHierarchyRequestController.js
@@ -43,7 +43,8 @@
 
         function confirmLinkRemoval() {
             const isParent = true;
-            InstitutionService.removeLink(child.key, parent.key, isParent).then(
+            const currentParentKey = child.parent_institution.key;
+            InstitutionService.removeLink(child.key, currentParentKey, isParent).then(
                 function success() {
                     acceptRequest();
                 });

--- a/frontend/test/specs/request/analyseHierarchyRequestControllerSpec.js
+++ b/frontend/test/specs/request/analyseHierarchyRequestControllerSpec.js
@@ -171,7 +171,7 @@
                     const isParent = true;
                     expect(institutionService.removeLink).toHaveBeenCalledWith(
                         analyseHierReqCtrl.child.key,
-                        analyseHierReqCtrl.parent.key,
+                        analyseHierReqCtrl.child.parent_institution.key,
                         isParent
                     );
                     expect(requestInvitationService.acceptInstChildrenRequest).toHaveBeenCalledWith(request.key);


### PR DESCRIPTION
**Feature/Bug description:**
Let's say we have 3 institutions: A, B and C. B is C's parent. A wants to be C's parent and send it an invite. When C accepts the invite the link between C and B is not removed because the removeLink method is passing the wrong parameter to the backend. Instead of pass B to remove the link with C it was passing A.

**Solution:**
I've just fixed the parameters.

**TODO/FIXME:** n/a