### PR TITLE
Fix link's status in institution's page

### DIFF
--- a/frontend/institution/institutionLinksController.js
+++ b/frontend/institution/institutionLinksController.js
@@ -40,7 +40,7 @@
         };
 
         instLinksCtrl.childStatus = function childStatus(institution) {
-            return institution.parent_institution ? "confirmado" : "não confirmado";
+            return institution.parent_institution && institution.parent_institution === instLinksCtrl.institution.key ? "confirmado" : "não confirmado";
         };
 
         function loadInstitution() {

--- a/frontend/test/specs/institution/institutionLinksControllerSpec.js
+++ b/frontend/test/specs/institution/institutionLinksControllerSpec.js
@@ -13,12 +13,18 @@
         children_institutions: [{key: '987654321'}]
     };
 
+    var institution = {
+        acronym: 'institution',
+        key: '987654321',
+        parent_institution: parentInstitutionTest
+    };
+
     var childrenInstitutionsTest = [
         {
             name: 'childrenInst1',
             key: 'chldKey1',
             state: 'active',
-            parent_institution: parentInstitutionTest
+            parent_institution: institution.key
         },
         {
             name: 'childrenInst2',
@@ -28,12 +34,7 @@
         }
     ];
 
-    var institution = {
-        acronym: 'institution',
-        key: '987654321',
-        parent_institution: parentInstitutionTest,
-        children_institutions: childrenInstitutionsTest
-    };
+    institution.children_institutions = childrenInstitutionsTest;
 
     beforeEach(module('app'));
 


### PR DESCRIPTION
**Feature/Bug description:**
The childStatus function was verifying only if the child institution has parent instead of check if the parent is the institution whose page is loaded.
**Solution:**
I've added the missing verification.

**TODO/FIXME:** n/a