### PR TITLE
Translating post error message

### DIFF
--- a/frontend/utils/messageService.js
+++ b/frontend/utils/messageService.js
@@ -37,7 +37,8 @@
             "Error! You've already voted in this survey": "Você já votou nessa enquete",
             "Error! User is not allowed to edit this post": "O usuário não tem permissão para editar essa publicação.",
             "Error! This post cannot be updated": "A publicação não pode ser editada.",
-            "Error! You don't have permission to publish post.": "Você não tem permissão para publicar post nesta instituição"
+            "Error! You don't have permission to publish post.": "Você não tem permissão para publicar post nesta instituição",
+            "Error! The user can not remove this post": "Você não tem permissão para remover esse post"
         };
 
         service.showToast = function showToast(message) {


### PR DESCRIPTION
**Feature/Bug description:**
The error message related to lack of permission to remove post wasn't translated in the frontend.

**Solution:**
I've inserted the message and its translation to the msg object.

![screenshot from 2018-06-21 14-01-33](https://user-images.githubusercontent.com/23387866/41734036-33a083e2-755c-11e8-87a4-51a8fb894a7e.png)


**TODO/FIXME:** n/a