### PR TITLE
Fix shared post's title

### DIFF
--- a/frontend/post/post_details.html
+++ b/frontend/post/post_details.html
@@ -134,9 +134,9 @@
         <iframe ng-src="{{ postDetailsCtrl.getVideoUrl(postDetailsCtrl.post.shared_post) }}"></iframe>
       </div>
       <p></p>
-      <a ng-if="!postDetailsCtrl.isSharedSurvey()"
-      href class="md-text hyperlink" ng-click="postDetailsCtrl.goToPost(postDetailsCtrl.post.shared_post)">
-        <span>{{ postDetailsCtrl.post.shared_post.title }}</span>
+      <a ng-if="!postDetailsCtrl.isSharedSurvey()" href class="md-title hyperlink" 
+        ng-click="postDetailsCtrl.goToPost(postDetailsCtrl.post.shared_post)">
+        <span class="md-headline">{{ postDetailsCtrl.post.shared_post.title }}</span>
       </a>
       <p class="text" ng-if="postDetailsCtrl.showSharedPostText()"
         ng-bind-html="postDetailsCtrl.postToURL(postDetailsCtrl.post.shared_post).text" ></p>


### PR DESCRIPTION
**Feature/Bug description:**
It was missing some classes to be equal to the regular post's title.
**Solution:**
I've inserted these classes.

![screenshot from 2018-06-21 14-24-42](https://user-images.githubusercontent.com/23387866/41735241-8bede82a-755f-11e8-89fa-48dd94a36f53.png)


**TODO/FIXME:** n/a