### PR TITLE
Refact function reload of auth service

### DIFF
--- a/frontend/auth/authService.js
+++ b/frontend/auth/authService.js
@@ -162,7 +162,7 @@
 
         service.updateUser = function updateUser(data){
             return Object.assign(userInfo, data);
-        }
+        };
 
         service.sendEmailVerification = function sendEmailVerification(user) {
             var auth_user = user || authObj.$getAuth();

--- a/frontend/auth/authService.js
+++ b/frontend/auth/authService.js
@@ -21,8 +21,6 @@
         */
         var onLogoutListeners = [];
 
-        var REFRESH_USER_EVENT = 'ACCEPTED_LINK';
-
         var versionAvailable = false;
 
         Object.defineProperty(service, 'user', {
@@ -192,12 +190,6 @@
             if (userInfo) return userInfo.emailVerified;
             return false;
         };
-
-        function eventListener() {
-            $rootScope.$on(REFRESH_USER_EVENT, function (event) {
-                service.reload();
-            })
-        }
         
         /**
         * Execute each function stored to be thriggered when user logout
@@ -244,6 +236,5 @@
         }
 
         init();
-        eventListener();
     });
 })();

--- a/frontend/auth/authService.js
+++ b/frontend/auth/authService.js
@@ -150,11 +150,8 @@
         service.reload = function reload() {
             var deferred = $q.defer();
             UserService.load().then(function success(userLoaded) {
-                var firebaseUser = {
-                    accessToken: userInfo.accessToken,
-                    emailVerified: userInfo.emailVerified
-                };
-                configUser(userLoaded, firebaseUser);
+                service.updateUser(userLoaded);
+                service.save();
                 deferred.resolve(userInfo);
             }, function error(error) {
                 MessageService.showToast(error);
@@ -162,6 +159,10 @@
             });
             return deferred.promise;
         };
+
+        service.updateUser = function updateUser(data){
+            return Object.assign(userInfo, data);
+        }
 
         service.sendEmailVerification = function sendEmailVerification(user) {
             var auth_user = user || authObj.$getAuth();

--- a/frontend/notification/notificationDirective.js
+++ b/frontend/notification/notificationDirective.js
@@ -240,13 +240,7 @@
         }
 
         notificationCtrl.refreshUser = function refreshUser() {
-            UserService.load().then(function success(response) {
-                notificationCtrl.user.institutions = response.institutions;
-                notificationCtrl.user.follows = response.follows;	
-                notificationCtrl.user.institution_profiles = response.institution_profiles;	
-                notificationCtrl.user.permissions = response.permissions;
-                AuthService.save();
-            });
+            AuthService.reload();
         };
 
         function notificationListener() {

--- a/frontend/requests/requestProcessingController.js
+++ b/frontend/requests/requestProcessingController.js
@@ -4,7 +4,7 @@
     var app = angular.module('app');
 
     app.controller('RequestProcessingController', function RequestProcessingController(AuthService, RequestInvitationService,
-        MessageService, InstitutionService, UserService, request, $state, $mdDialog) {
+        MessageService, InstitutionService, request, $state, $mdDialog) {
         var requestController = this;
 
         var REQUEST_PARENT = "REQUEST_INSTITUTION_PARENT";
@@ -29,10 +29,7 @@
         };
 
         function refreshUser() {
-            UserService.load().then(function success(response) {
-                requestController.user.permissions = response.permissions;
-                AuthService.save();
-            });
+            AuthService.reload();
         }
 
         function resolveRequest() {

--- a/frontend/survey/surveyDirective.js
+++ b/frontend/survey/surveyDirective.js
@@ -79,7 +79,7 @@
                     $mdDialog.hide();
                     unobserveNewPost();
                 }, function error() {
-                    AuthService.reload().then(function success(responseUser) {
+                    AuthService.reload().then(function success() {
                         $mdDialog.hide();
                         $state.go("app.user.home");
                     });

--- a/frontend/test/specs/notification/notificationControllerSpec.js
+++ b/frontend/test/specs/notification/notificationControllerSpec.js
@@ -3,9 +3,9 @@
 (describe('Test NotificationController', function() {
 
     var notCtrl, httpBackend, scope, createCtrl, state, notificationService
-    var authService, notificationListenerService, userService, http;
+    var authService, notificationListenerService, http;
 
-    var EVENTS_TO_UPDATE_USER = ["DELETED_INSTITUTION", "DELETE_MEMBER",
+    var EVENTS_TO_UPDATE_USER = ["DELETED_INSTITUTION", "DELETE_MEMBER", "ACCEPTED_LINK",
                                 "ACCEPT_INSTITUTION_LINK", "TRANSFER_ADM_PERMISSIONS"];
     
     var institution = {
@@ -48,11 +48,10 @@
     beforeEach(module('app'));
 
     beforeEach(inject(function($controller, $httpBackend, $rootScope, NotificationService,
-            $state, AuthService, NotificationListenerService, UserService) {
+            $state, AuthService, NotificationListenerService) {
         httpBackend = $httpBackend;
         scope = $rootScope.$new();
         state = $state;
-        userService = UserService;
         authService = AuthService;
         notificationService = NotificationService;
         notificationListenerService = NotificationListenerService;
@@ -169,38 +168,38 @@
 
     describe('Main Controller listenners', function(){
         it("Should call userService load when event 'DELETED_INSTITUTION' was create.", function(){
-            spyOn(userService, 'load').and.callThrough();
+            spyOn(authService, 'reload').and.callThrough();
             spyOn(notCtrl, 'refreshUser').and.callThrough();
 
             scope.$emit("DELETED_INSTITUTION", {});
-            expect(userService.load).toHaveBeenCalled();
+            expect(authService.reload).toHaveBeenCalled();
             expect(notCtrl.refreshUser).not.toHaveBeenCalled();
         });
 
         it("Should call userService load when event 'DELETE_MEMBER' was create.", function(){
-            spyOn(userService, 'load').and.callThrough();
+            spyOn(authService, 'reload').and.callThrough();
             spyOn(notCtrl, 'refreshUser').and.callThrough();
 
             scope.$emit("DELETE_MEMBER", {});
-            expect(userService.load).toHaveBeenCalled();
+            expect(authService.reload).toHaveBeenCalled();
             expect(notCtrl.refreshUser).not.toHaveBeenCalled();
         });
 
         it("Should call userService load when event 'ACCEPT_INSTITUTION_LINK' was create.", function(){
-            spyOn(userService, 'load').and.callThrough();
+            spyOn(authService, 'reload').and.callThrough();
             spyOn(notCtrl, 'refreshUser').and.callThrough();
 
             scope.$emit("ACCEPT_INSTITUTION_LINK", {});
-            expect(userService.load).toHaveBeenCalled();
+            expect(authService.reload).toHaveBeenCalled();
             expect(notCtrl.refreshUser).not.toHaveBeenCalled();
         });
 
         it("Should NOT call userService load when event 'EVENT' was create.", function(){
-            spyOn(userService, 'load').and.callThrough();
+            spyOn(authService, 'reload').and.callThrough();
             spyOn(notCtrl, 'refreshUser').and.callThrough();
 
             scope.$emit("EVENT", {});
-            expect(userService.load).not.toHaveBeenCalled();
+            expect(authService.reload).not.toHaveBeenCalled();
             expect(notCtrl.refreshUser).not.toHaveBeenCalled();
         });
     });

--- a/frontend/user/user.js
+++ b/frontend/user/user.js
@@ -187,6 +187,10 @@ User.prototype.isInstitutionRequested = function isInstitutionRequested(institut
     return this.institutions_requested.includes(institutionKey);
 };
 
+User.prototype.updateUser = function updateUser(data) {
+    return Object.assign(this, data);
+};
+
 function updateFollowInstitution(follows, institution) {
     var index = _.findIndex(follows, ['key', institution.key]);
     follows[index].acronym = institution.acronym;

--- a/frontend/user/user.js
+++ b/frontend/user/user.js
@@ -187,10 +187,6 @@ User.prototype.isInstitutionRequested = function isInstitutionRequested(institut
     return this.institutions_requested.includes(institutionKey);
 };
 
-User.prototype.updateUser = function updateUser(data) {
-    return Object.assign(this, data);
-};
-
 function updateFollowInstitution(follows, institution) {
     var index = _.findIndex(follows, ['key', institution.key]);
     follows[index].acronym = institution.acronym;

--- a/frontend/user/userService.js
+++ b/frontend/user/userService.js
@@ -8,7 +8,7 @@
 
         var USER_URI = "/api/user";
 
-        service.NOTIFICATIONS_TO_UPDATE_USER = ["DELETED_INSTITUTION", "DELETE_MEMBER", 'ACCEPTED_LINK',
+        service.NOTIFICATIONS_TO_UPDATE_USER = ["DELETED_INSTITUTION", "DELETE_MEMBER", "ACCEPTED_LINK",
                                                 "ACCEPT_INSTITUTION_LINK", "TRANSFER_ADM_PERMISSIONS"];
 
         service.deleteAccount = function deleteAccount() {

--- a/frontend/user/userService.js
+++ b/frontend/user/userService.js
@@ -8,7 +8,7 @@
 
         var USER_URI = "/api/user";
 
-        service.NOTIFICATIONS_TO_UPDATE_USER = ["DELETED_INSTITUTION", "DELETE_MEMBER",
+        service.NOTIFICATIONS_TO_UPDATE_USER = ["DELETED_INSTITUTION", "DELETE_MEMBER", 'ACCEPTED_LINK',
                                                 "ACCEPT_INSTITUTION_LINK", "TRANSFER_ADM_PERMISSIONS"];
 
         service.deleteAccount = function deleteAccount() {


### PR DESCRIPTION
**Feature/Bug description:**  Refactoring the reload function used when is necessary to update user and save in cache. Before, this method created the new user. All notifications that need to be updated by the user must be described in the userService for the observer to be created, the ACCEPT_LINK notification being created observer in the AuthService.

**Solution:**  This method updates the properties of the user, so in notifications that need to refresh user call this method. Change notification to userService.

**TODO/FIXME:** n/a