### PR TITLE
Fix invalid request notification

### DIFF
--- a/frontend/institution/institution.js
+++ b/frontend/institution/institution.js
@@ -66,3 +66,7 @@ Institution.prototype.getFullAddress = function getFullAddress() {
         return fullAddress;
     }
 };
+
+Institution.prototype.isStateOn = function (state) {
+    return this.state === state;
+};

--- a/frontend/institution/managementMembersController.js
+++ b/frontend/institution/managementMembersController.js
@@ -110,7 +110,7 @@
                 emails: emails
             };
             
-            if (manageMemberCtrl.isValidAllEmails(emails) && manageMemberCtrl.isUserInviteValid(invite)) {
+            if (manageMemberCtrl.isValidAllEmails(emails) && invite.isValid()) {
                 manageMemberCtrl.isLoadingInvite = true;
                 var promise = InviteService.sendInviteUser(requestBody);
                 promise.then(function success(responseData) {
@@ -124,6 +124,8 @@
                     manageMemberCtrl.isLoadingInvite = false;
                 });
                 return promise;
+            } else if(!invite.isValid()) {
+                MessageService.showToast('Convite inválido!');
             }
         };
 
@@ -216,15 +218,6 @@
 
         manageMemberCtrl.toggleElement = function toggleElement(flagName) {
             manageMemberCtrl[flagName] = !manageMemberCtrl[flagName];
-        };
-
-        manageMemberCtrl.isUserInviteValid = function isUserInviteValid(invite) {
-            var isValid = true;
-            if (! invite.isValid()) {
-                isValid = false;
-                MessageService.showToast('Convite inválido!');
-            }
-            return isValid;
         };
 
         manageMemberCtrl.resendInvite = function resendInvite(inviteKey, event) {

--- a/frontend/invites/invite.js
+++ b/frontend/invites/invite.js
@@ -3,17 +3,18 @@
 function Invite(data) {
     data = data || {};
     _.extend(this, data);
+
+    this.institution = new Institution(this.institution);
+    this.requested_institution = this.requested_institution &&
+        new Institution(this.requested_institution);
 }
 
 Invite.prototype.isValid = function isValid() {
-    var isInviteeNecessary = this.type_of_invite != 'USER';
-    var hasNoInvitee = (_.isUndefined(this.invitee) || _.isEmpty(this.invitee)) && isInviteeNecessary;
-    var hasNoType = _.isUndefined(this.type_of_invite) || _.isEmpty(this.type_of_invite);
-
-    if (hasNoInvitee || hasNoType) {
-        return false;
-    }
-    return true;
+    const hasType = isValueValid(this.type_of_invite);
+    const hasInviteeWhenNeeded = this.type_of_invite == 'USER' || isValueValid(this.invitee);
+    const areInstitutionsValid = this.isInstitutionActive() && this.isRequestedInstActive();
+    
+    return hasType && hasInviteeWhenNeeded && areInstitutionsValid; 
 };
 
 Invite.prototype.isStatusOn = function isStatusOn(value) {
@@ -27,3 +28,19 @@ Invite.prototype.setStatus = function (status) {
 Invite.prototype.setType = function (typeOfInvite) {
     this.type_of_invite = typeOfInvite;
 };
+
+Invite.prototype.isSent = function () {
+    return this.isStatusOn('sent');
+};
+
+Invite.prototype.isInstitutionActive = function () {
+    return this.institution.isStateOn('active');
+};
+
+Invite.prototype.isRequestedInstActive = function () {
+    return this.requested_institution ? this.requested_institution.isStateOn('active') : true;
+};
+
+function isValueValid(value) {
+    return  !(_.isUndefined(value) || _.isEmpty(value));
+}

--- a/frontend/invites/invite.js
+++ b/frontend/invites/invite.js
@@ -12,9 +12,7 @@ function Invite(data) {
 Invite.prototype.isValid = function isValid() {
     const hasType = isValueValid(this.type_of_invite);
     const hasInviteeWhenNeeded = this.type_of_invite == 'USER' || isValueValid(this.invitee);
-    const areInstitutionsValid = this.isInstitutionActive() && this.isRequestedInstActive();
-    
-    return hasType && hasInviteeWhenNeeded && areInstitutionsValid; 
+    return hasType && hasInviteeWhenNeeded; 
 };
 
 Invite.prototype.isStatusOn = function isStatusOn(value) {
@@ -29,17 +27,11 @@ Invite.prototype.setType = function (typeOfInvite) {
     this.type_of_invite = typeOfInvite;
 };
 
-Invite.prototype.isSent = function () {
-    return this.isStatusOn('sent');
-};
-
-Invite.prototype.isInstitutionActive = function () {
-    return this.institution.isStateOn('active');
-};
-
-Invite.prototype.isRequestedInstActive = function () {
-    return this.requested_institution ? this.requested_institution.isStateOn('active') : true;
-};
+Invite.prototype.areInstitutionsValid = function () {
+    const isInstitutionActive = this.institution.isStateOn('active');
+    const isRequestedInstActive = this.requested_institution ? this.requested_institution.isStateOn('active') : true;
+    return isInstitutionActive && isRequestedInstActive;
+}
 
 function isValueValid(value) {
     return  !(_.isUndefined(value) || _.isEmpty(value));

--- a/frontend/notification/notificationService.js
+++ b/frontend/notification/notificationService.js
@@ -3,7 +3,7 @@
 (function() {
     var app = angular.module("app");
 
-    app.service("NotificationService", function NotificationService($firebaseArray,  MessageService, AuthService, $rootScope,
+    app.service("NotificationService", function NotificationService($firebaseArray, AuthService, $rootScope,
         NotificationMessageCreatorService) {
         var service = this;
 

--- a/frontend/requests/requestDialogService.js
+++ b/frontend/requests/requestDialogService.js
@@ -32,7 +32,7 @@
         service.showRequestDialog = function showRequestDialog(notification, event, dialogProperties) {
             getRequest(notification.entity.key, notification.entity_type).then(
                 function success(data) {
-                    var request = new Invite(data);                    
+                    var request = new Invite(data);
                     selectDialogToShow(request, event, dialogProperties);
                 }, function error(response) {
                     MessageService.showToast(response.data.msg);
@@ -66,9 +66,9 @@
 
         function selectDialogToShow(request, event, dialogProperties) {
             let requestType = request.type_of_invite;
-            requestType = request.isValid() ? requestType : INVALID_REQUEST;
-            requestType = request.isSent() ? requestType : RESOLVED_REQUEST;
-            
+            requestType = request.isStatusOn('sent') ? requestType : RESOLVED_REQUEST;
+            requestType = request.areInstitutionsValid() ? requestType : INVALID_REQUEST;
+
             switch(requestType) {
                 case RESOLVED_REQUEST:
                     service.showResolvedReqDialog(event); break;

--- a/frontend/requests/requestDialogService.js
+++ b/frontend/requests/requestDialogService.js
@@ -7,6 +7,15 @@
     MessageService) {
         var service = this;
 
+        const REQUEST_USER = 'REQUEST_USER';
+        const REQUEST_INSTITUTION = 'REQUEST_INSTITUTION';
+        const REQUEST_PARENT = 'REQUEST_INSTITUTION_PARENT';
+        const REQUEST_CHILDREN = 'REQUEST_INSTITUTION_CHILDREN';
+        const ACCEPT_USER_ADM = 'ACCEPT_INVITE_USER_ADM';
+        const USER_ADM = 'USER_ADM';
+        const RESOLVED_REQUEST = 'RESOLVED_REQUEST';
+        const INVALID_REQUEST = 'INVALID_REQUEST';
+
         service.showHierarchyDialog = function showHierarchyDialog(request, event) {
             var promise = $mdDialog.show({
                 controller: 'AnalyseHierarchyRequestController',
@@ -30,42 +39,15 @@
                 }
             );
         };
-        
-        function selectDialogToShow(request, event, dialogProperties) {
-            var isRequestResolved = request.isStatusOn('rejected') || request.isStatusOn('accepted');
-            
-            if(isRequestResolved) {
-                service.showResolvedReqDialog(event);
-                return;
-            }
-
-            switch(request.type_of_invite) {
-                case "REQUEST_INSTITUTION_PARENT":
-                case "REQUEST_INSTITUTION_CHILDREN":
-                    service.showHierarchyDialog(request, event);
-                    break;
-                default:
-                    dialogProperties.locals.request = request;
-                    service.showPendingReqDialog(dialogProperties, event);
-            }
-        }
 
         service.showResolvedReqDialog = function (event) {
-            function ResolvedRequesCtrl($mdDialog) {
-                var controll = this;
-                controll.hide = function hide() {
-                    $mdDialog.hide();
-                };
-            }
+            const message = "Esta solicitação já foi resolvida";
+            MessageService.showMessageDialog(event, message);
+        };
 
-            $mdDialog.show({
-                templateUrl: "app/requests/resolved_request_dialog.html",
-                controller: ResolvedRequesCtrl,
-                controllerAs: 'ctrl',
-                parent: angular.element(document.body),
-                targetEvent: event,
-                clickOutsideToClose:true
-            });
+        service.showInvalidReqDialog = function (event) {
+            const message = "Esta solicitação não é mais válida";
+            MessageService.showMessageDialog(event, message);
         };
 
         service.showPendingReqDialog = function (dialogProperties, event) {
@@ -82,18 +64,38 @@
             });
         };
 
+        function selectDialogToShow(request, event, dialogProperties) {
+
+            let requestType = request.type_of_invite;
+                requestType = request.isValid() ? requestType : INVALID_REQUEST;
+                requestType = request.isSent() ? requestType : RESOLVED_REQUEST;
+            
+            switch(requestType) {
+                case RESOLVED_REQUEST:
+                    service.showResolvedReqDialog(event); break;
+                case INVALID_REQUEST:
+                    service.showInvalidReqDialog(event); break;
+                case REQUEST_PARENT:
+                case REQUEST_CHILDREN:
+                    service.showHierarchyDialog(request, event); break;
+                default:
+                    dialogProperties.locals.request = request;
+                    service.showPendingReqDialog(dialogProperties, event);
+            }
+        }
+
         function getRequest(invitekey, entityType) {
             switch(entityType) {
-                case 'REQUEST_USER':
+                case REQUEST_USER:
                     return RequestInvitationService.getRequest(invitekey);
-                case 'REQUEST_INSTITUTION':
+                case REQUEST_INSTITUTION:
                     return RequestInvitationService.getRequestInst(invitekey);
-                case 'REQUEST_INSTITUTION_CHILDREN':
+                case REQUEST_CHILDREN:
                     return RequestInvitationService.getInstChildrenRequest(invitekey);
-                case 'REQUEST_INSTITUTION_PARENT':
+                case REQUEST_PARENT:
                     return RequestInvitationService.getInstParentRequest(invitekey);
-                case 'USER_ADM':
-                case 'ACCEPT_INVITE_USER_ADM':
+                case USER_ADM:
+                case ACCEPT_USER_ADM:
                     return InviteService.getInvite(invitekey);
             } 
         }

--- a/frontend/requests/requestDialogService.js
+++ b/frontend/requests/requestDialogService.js
@@ -32,7 +32,7 @@
         service.showRequestDialog = function showRequestDialog(notification, event, dialogProperties) {
             getRequest(notification.entity.key, notification.entity_type).then(
                 function success(data) {
-                    var request = new Invite(data);
+                    var request = new Invite(data);                    
                     selectDialogToShow(request, event, dialogProperties);
                 }, function error(response) {
                     MessageService.showToast(response.data.msg);
@@ -65,10 +65,9 @@
         };
 
         function selectDialogToShow(request, event, dialogProperties) {
-
             let requestType = request.type_of_invite;
-                requestType = request.isValid() ? requestType : INVALID_REQUEST;
-                requestType = request.isSent() ? requestType : RESOLVED_REQUEST;
+            requestType = request.isValid() ? requestType : INVALID_REQUEST;
+            requestType = request.isSent() ? requestType : RESOLVED_REQUEST;
             
             switch(requestType) {
                 case RESOLVED_REQUEST:

--- a/frontend/test/specs/institution/institutionSpec.js
+++ b/frontend/test/specs/institution/institutionSpec.js
@@ -38,7 +38,7 @@ describe('Test Institution Model:', function() {
             key: 'instKey'
         };
 
-        institution = new Institution(data, {});
+        institution = new Institution(data);
     });
 
     describe('isValidAddress()', function() {
@@ -195,6 +195,22 @@ describe('Test Institution Model:', function() {
             var sameInst = Object.assign({}, testInst);
             institution.addChildInst(sameInst);
             expect(institution.children_institutions.length).toEqual(1);
+        });
+    });
+
+    describe('isStateOn()', function () {
+
+        it('should be on active state', function () {
+            expect(institution.isStateOn('active')).toBeTruthy();
+        });
+
+        it('should be not be on inactive state', function () {
+            expect(institution.isStateOn('inactive')).toBeFalsy();
+        });
+
+        it('should be on pending state', function () {
+            institution.state = 'pending';
+            expect(institution.isStateOn('pending')).toBeTruthy();
         });
     });
 });

--- a/frontend/test/specs/institution/managementMembersControllerSpec.js
+++ b/frontend/test/specs/institution/managementMembersControllerSpec.js
@@ -154,7 +154,8 @@
                     institution_key: '987654321',
                     admin_key: '54321',
                     sender_name: 'User',
-                    key: '123'
+                    key: '123',
+                    invitee: 'invitee@email'
                 };
                 manageMemberCtrl.emails = [{ email: "teste@gmail.com" }]
                 var newInvite = new Invite(manageMemberCtrl.invite);
@@ -178,15 +179,6 @@
             });
         });
 
-        describe('isUserInviteValid()', function() {
-
-            it('should be true with new invite', function() {
-                var newInvite = new Invite({type_of_invite: 'USER',
-                                            institution_key: '987654321',
-                                            admin_key: '12345'});
-                expect(manageMemberCtrl.isUserInviteValid(newInvite)).toBe(true);
-            });
-        });
 
         describe('isValidAllEmails()', function() {
 

--- a/frontend/test/specs/invites/inviteSpec.js
+++ b/frontend/test/specs/invites/inviteSpec.js
@@ -1,0 +1,61 @@
+"use strict";
+
+(fdescribe("Test Invite model", function () {
+
+    let invite, institution, requestedInstitution;
+
+    beforeEach(function () {
+
+        institution = new Institution({
+            state: 'active'
+        });
+
+        requestedInstitution = new Institution({
+            state: 'active'
+        });
+
+        invite = new Invite({
+            institution: institution,
+            requested_isntitution: requestedInstitution,
+            type_of_invite: 'USER',
+            invitee: 'user@email'
+        });
+
+    });
+
+    describe('Test isValid', function () {
+
+        it('should be true', function () {
+            expect(invite.isValid()).toBeTruthy();
+        });
+
+        it('should be false, when there no type_of_invite', function () {
+            invite.type_of_invite = '';
+            expect(invite.isValid()).toBeFalsy();
+        });
+
+        it('should be false, when there is no invitee when it is needed', function () {
+            invite.type_of_invite = 'INSTITUTION_REQUEST';
+            invite.invitee = '';
+            expect(invite.isValid()).toBeFalsy();
+        })
+    });
+    
+    describe('Test areInstitutionsValid', function () {
+
+        it('should be true, when both institutions are active', function () {
+            expect(invite.areInstitutionsValid()).toBe(true);
+        });
+
+        it('should be false, when request institution is not active', function () {
+            institution.state = "inactive";
+            expect(invite.areInstitutionsValid()).toBe(true);
+        });
+
+        it('should be false, when request requested_institution is not active', function () {
+            requestedInstitution.state = "inactive";
+            expect(invite.areInstitutionsValid()).toBe(true);
+        });
+    });
+
+}))

--- a/frontend/test/specs/invites/inviteSpec.js
+++ b/frontend/test/specs/invites/inviteSpec.js
@@ -1,6 +1,6 @@
 "use strict";
 
-(fdescribe("Test Invite model", function () {
+(describe("Test Invite model", function () {
 
     let invite, institution, requestedInstitution;
 

--- a/frontend/test/specs/invites/newInviteControllerSpec.js
+++ b/frontend/test/specs/invites/newInviteControllerSpec.js
@@ -6,17 +6,17 @@
         mdDialog, authService;
     var INVITES_URI = "/api/invites/";
 
-    var institution = {
-            name: 'institution',
-            key: '987654321',
-            institutions_admin: [],
-            sent_invitations: []
-    };
-    var otherInstitution = {
+    var institution = new Institution({
+        name: 'institution',
+        key: '987654321',
+        institutions_admin: [],
+        sent_invitations: []
+    });
+    var otherInstitution = new Institution({
         name: 'otherInstitution',
         key: '123456789',
         sent_invitations: []
-    };
+    });
     var inviteData = {
         invitee: "user@gmail.com",
         key: 'xyzcis',
@@ -81,7 +81,7 @@
         });
 
         it('should exist institution', function() {
-            expect(newInviteCtrl.institution).toEqual(otherInstitution);
+            expect(newInviteCtrl.institution).toEqual(new Institution(otherInstitution));
         });
 
         it('inviteKey should be "xyzcis"', function() {

--- a/frontend/test/specs/invites/processInviteUserAdmControllerSpec.js
+++ b/frontend/test/specs/invites/processInviteUserAdmControllerSpec.js
@@ -9,7 +9,8 @@
         key: "institutuion_key",
         admin: user,
         members: [user],
-        name: 'institution'
+        name: 'institution',
+        trusted: true
     };
 
     var processInviteUserAdmCtrl, messageService, inviteService, mdDialog, authService, controller;

--- a/frontend/test/specs/request/requestDialogServiceSpec.js
+++ b/frontend/test/specs/request/requestDialogServiceSpec.js
@@ -13,7 +13,7 @@
 
     var requestInvitationService, inviteService, mdDialog,
     service, request, event, notification, dialogProperties,
-    httpBackend;
+    httpBackend, institution, requestedInst;
 
     beforeEach(module('app'));
 
@@ -25,7 +25,18 @@
         inviteService = InviteService;
         mdDialog = $mdDialog;
         httpBackend = $httpBackend;
+
         event = {};
+
+        institution = {
+            key: 'inst-key',
+            state: 'active'
+        };
+
+        requestedInst = {
+            key: 'requestedInst-key',
+            state: 'active'
+        };
 
         dialogProperties = {
             locals: {}
@@ -33,8 +44,11 @@
 
         request = new Invite({
             status: 'sent',
-            type_of_invite: '',
-            key: 'request-key'
+            type_of_invite: 'SOME_TYPE',
+            key: 'request-key',
+            institution: institution,
+            requested_institution: requestedInst,
+            invitee: "invitee"
         });
 
         notification = {
@@ -42,6 +56,11 @@
             entity: request,
         };
     }));
+
+    afterEach(function() {
+        httpBackend.verifyNoOutstandingExpectation();
+        httpBackend.verifyNoOutstandingRequest();
+    });
 
     describe('Test showHierarchyDialog', function () {
 

--- a/frontend/test/specs/request/requestDialogServiceSpec.js
+++ b/frontend/test/specs/request/requestDialogServiceSpec.js
@@ -132,7 +132,7 @@
 
         describe("Test selectDialog", function () {
             
-            describe("Test select resolved request dialog", function () {
+            describe("Test showResolvedReqDialog", function () {
 
                 beforeEach(function () {
                     spyOn(service, 'showResolvedReqDialog');       
@@ -145,18 +145,43 @@
                     request.setStatus('rejected');
                     service.showRequestDialog(notification, event, dialogProperties);
                     httpBackend.flush();
-                    expect(service.showResolvedReqDialog).toHaveBeenCalled();
+                    service.showResolvedReqDialog(event);
+                    expect(service.showResolvedReqDialog).toHaveBeenCalledWith(event);
                 });
 
                 it("should show the dialog for accepted request", function () {
                     request.setStatus('accepted');
                     service.showRequestDialog(notification, event, dialogProperties);
                     httpBackend.flush();
-                    expect(service.showResolvedReqDialog).toHaveBeenCalled();
+                    expect(service.showResolvedReqDialog).toHaveBeenCalledWith(event);
+                });
+            });
+
+            describe("Test showInvalidReqDialog", function () {
+
+                beforeEach(function () {
+                    spyOn(service, 'showInvalidReqDialog');       
+                    request.setType(REQUEST_CHILDREN);
+                    setNotificationType(REQUEST_CHILDREN);
+                    httpBackend.when('GET', REQUEST_URI + request.key + "/institution_children").respond(request);
+                });
+                
+                it("should show the dialog when the request institution is inactive", function () {
+                    request.institution.state = 'inactive';
+                    service.showRequestDialog(notification, event, dialogProperties);
+                    httpBackend.flush();
+                    expect(service.showInvalidReqDialog).toHaveBeenCalledWith(event);
+                });
+
+                it("should show the dialog when the request requested_institution is inactive", function () {
+                    request.requested_institution.state = 'inactive';
+                    service.showRequestDialog(notification, event, dialogProperties);
+                    httpBackend.flush();
+                    expect(service.showInvalidReqDialog).toHaveBeenCalledWith(event);
                 });
             });
             
-            describe("Test select showHierarchyDialog", function () {
+            describe("Test showHierarchyDialog", function () {
 
                 beforeEach(function () {
                     spyOn(service, 'showHierarchyDialog');
@@ -183,7 +208,7 @@
                 });
             });
 
-            describe("Test select pending request dialog", function () {
+            describe("Test showPendingReqDialog", function () {
 
                 beforeEach(function () {
                     spyOn(service, 'showPendingReqDialog');

--- a/frontend/utils/messageService.js
+++ b/frontend/utils/messageService.js
@@ -68,5 +68,26 @@
 
             return $mdDialog.show(confirm);
         };
+
+        service.showMessageDialog = function (event, message) {
+
+            function MessageController ($mdDialog) {
+                const controll = this;
+                controll.message = message;
+    
+                controll.hide = function hide() {
+                    $mdDialog.hide();
+                };
+            }
+        
+            $mdDialog.show({
+                templateUrl: "app/utils/message_dialog.html",
+                controller: MessageController,
+                controllerAs: 'ctrl',
+                parent: angular.element(document.body),
+                targetEvent: event,
+                clickOutsideToClose:true
+            });
+        }
     });
 })();

--- a/frontend/utils/message_dialog.html
+++ b/frontend/utils/message_dialog.html
@@ -1,6 +1,6 @@
 <md-dialog>
     <md-dialog-content class="md-dialog-content" style="margin-bottom: -2em;">
-        <h3>Esta solicitação já foi resolvida</h3>
+        <h3>{{ ctrl.message }}</h3>
     </md-dialog-content>
     <md-dialog-actions layout="row" layout-align="end center" layout-wrap>
         <md-button class="md-primary" md-colors="{color: 'default-teal-500'}"


### PR DESCRIPTION
**Feature/Bug description:** When the user clicks on a request notification that is related to an institution no more active, the notification dialog is shown with empty fields.

Exemple: User request
![notificacao antiga](https://user-images.githubusercontent.com/13683704/42031793-eeb41d5a-7aad-11e8-9285-c4bcdc9147bf.png)

**Solution:** On RequestDialogService, in the selectDialog function, I added a verification to check if the request is valid, based on the request's institutions state. If on of the institutions is invalid, a dialog is showed to inform this to the user.

Invalid request dialog
![invalid](https://user-images.githubusercontent.com/13683704/42032826-30174224-7ab1-11e8-9640-c6836fe4e7d0.png)


**TODO/FIXME:** n/a