### PR TITLE
Send notification to refresh user when accept request

### DIFF
--- a/backend/custom_exceptions/__init__.py
+++ b/backend/custom_exceptions/__init__.py
@@ -4,7 +4,8 @@ from .entityException import *
 from .fieldException import *
 from .notAuthorizedException import *
 from .queryException import *
+from .queueException import *
 
-exceptions = [entityException, fieldException, notAuthorizedException, queryException]
+exceptions = [entityException, fieldException, notAuthorizedException, queryException, queueException]
 
 __all__ = [prop for exception in exceptions for prop in exception.__all__]

--- a/backend/custom_exceptions/queueException.py
+++ b/backend/custom_exceptions/queueException.py
@@ -1,0 +1,10 @@
+"""Queue Exception."""
+
+__all__ = ['QueueException']
+
+class QueueException(Exception):
+    """Entity Exception."""
+
+    def __init__(self, msg=None):
+        """Init method."""
+        super(QueueException, self).__init__(msg or 'Invalid task')

--- a/backend/custom_exceptions/queueException.py
+++ b/backend/custom_exceptions/queueException.py
@@ -3,7 +3,7 @@
 __all__ = ['QueueException']
 
 class QueueException(Exception):
-    """Entity Exception."""
+    """Queue Exception."""
 
     def __init__(self, msg=None):
         """Init method."""

--- a/backend/handlers/institution_children_request_handler.py
+++ b/backend/handlers/institution_children_request_handler.py
@@ -49,10 +49,10 @@ class InstitutionChildrenRequestHandler(BaseHandler):
         institution_children = request.institution_requested_key.get()
         institution_children.set_parent(request.institution_key)
 
-        id_not = request.send_response_notification(user.current_institution, user.key, 'ACCEPT')
+        notification_id = request.send_response_notification(user.current_institution, user.key, 'ACCEPT')
         request.send_response_email('ACCEPT')
 
-        enqueue_task('add-admin-permissions', {'institution_key': institution_children.key.urlsafe(), 'id': id_not})
+        enqueue_task('add-admin-permissions', {'institution_key': institution_children.key.urlsafe(), 'id': notification_id})
 
         self.response.write(json.dumps(request.make()))
 

--- a/backend/handlers/institution_children_request_handler.py
+++ b/backend/handlers/institution_children_request_handler.py
@@ -49,7 +49,7 @@ class InstitutionChildrenRequestHandler(BaseHandler):
         institution_children = request.institution_requested_key.get()
         institution_children.set_parent(request.institution_key)
 
-        notification_id = request.send_response_notification(user.current_institution, user.key, 'ACCEPT')
+        notification_id = request.create_accept_response_notification(user.current_institution, user.key)
         request.send_response_email('ACCEPT')
 
         enqueue_task('add-admin-permissions', {
@@ -74,6 +74,6 @@ class InstitutionChildrenRequestHandler(BaseHandler):
         if institution_children.parent_institution == request.institution_key:
             institution_children.set_parent(None)
 
-        request.send_response_notification(user.current_institution, user.key, 'REJECT')
+        request.send_reject_response_notification(user.current_institution, user.key)
         request.send_response_email('REJECT')
         

--- a/backend/handlers/institution_children_request_handler.py
+++ b/backend/handlers/institution_children_request_handler.py
@@ -49,10 +49,12 @@ class InstitutionChildrenRequestHandler(BaseHandler):
         institution_children = request.institution_requested_key.get()
         institution_children.set_parent(request.institution_key)
 
-        request.send_response_notification(user.current_institution, user.key, 'ACCEPT')
+        id_not = request.send_response_notification(user.current_institution, user.key, 'ACCEPT')
         request.send_response_email('ACCEPT')
 
-        enqueue_task('add-admin-permissions', {'institution_key': institution_children.key.urlsafe()})
+        import pdb
+        pdb.set_trace()
+        enqueue_task('add-admin-permissions', {'institution_key': institution_children.key.urlsafe(), 'id': id_not})
 
         self.response.write(json.dumps(request.make()))
 

--- a/backend/handlers/institution_children_request_handler.py
+++ b/backend/handlers/institution_children_request_handler.py
@@ -52,8 +52,6 @@ class InstitutionChildrenRequestHandler(BaseHandler):
         id_not = request.send_response_notification(user.current_institution, user.key, 'ACCEPT')
         request.send_response_email('ACCEPT')
 
-        import pdb
-        pdb.set_trace()
         enqueue_task('add-admin-permissions', {'institution_key': institution_children.key.urlsafe(), 'id': id_not})
 
         self.response.write(json.dumps(request.make()))

--- a/backend/handlers/institution_children_request_handler.py
+++ b/backend/handlers/institution_children_request_handler.py
@@ -52,7 +52,10 @@ class InstitutionChildrenRequestHandler(BaseHandler):
         notification_id = request.send_response_notification(user.current_institution, user.key, 'ACCEPT')
         request.send_response_email('ACCEPT')
 
-        enqueue_task('add-admin-permissions', {'institution_key': institution_children.key.urlsafe(), 'id': notification_id})
+        enqueue_task('add-admin-permissions', {
+            'institution_key': institution_children.key.urlsafe(), 
+            'id_notification': notification_id
+        })
 
         self.response.write(json.dumps(request.make()))
 

--- a/backend/handlers/institution_parent_request_handler.py
+++ b/backend/handlers/institution_parent_request_handler.py
@@ -57,8 +57,8 @@ class InstitutionParentRequestHandler(BaseHandler):
             message=create_system_message(institution_children.key)
         )
 
-        id_not = NotificationsQueueManager.create_notification_task(notification)
-        enqueue_task('add-admin-permissions', {'institution_key': institution_children.key.urlsafe(), 'id': id_not})
+        notification_id = NotificationsQueueManager.create_notification_task(notification)
+        enqueue_task('add-admin-permissions', {'institution_key': institution_children.key.urlsafe(), 'id': notification_id})
 
         self.response.write(json.dumps(request.make()))
 

--- a/backend/handlers/institution_parent_request_handler.py
+++ b/backend/handlers/institution_parent_request_handler.py
@@ -58,7 +58,10 @@ class InstitutionParentRequestHandler(BaseHandler):
         )
 
         notification_id = NotificationsQueueManager.create_notification_task(notification)
-        enqueue_task('add-admin-permissions', {'institution_key': institution_children.key.urlsafe(), 'id': notification_id})
+        enqueue_task('add-admin-permissions', {
+            'institution_key': institution_children.key.urlsafe(), 
+            'id_notification': notification_id
+        })
 
         self.response.write(json.dumps(request.make()))
 

--- a/backend/models/request_institution_children.py
+++ b/backend/models/request_institution_children.py
@@ -6,6 +6,8 @@ from . import Request
 from google.appengine.ext import ndb
 from send_email_hierarchy import RequestLinkEmailSender
 from util import get_subject
+from util import Notification
+from util import NotificationsQueueManager
 
 __all__ = ['RequestInstitutionChildren']
 
@@ -98,13 +100,16 @@ class RequestInstitutionChildren(Request):
             sender_institution_key=self.institution_requested_key
         )
 
-        super(RequestInstitutionChildren, self).send_notification(
-            current_institution=current_institution, 
-            sender_key=invitee_key, 
-            receiver_key=self.sender_key or self.admin_key,
+        notification = Notification(
+            entity_key=self.key.urlsafe(), 
+            receiver_key=self.admin_key.urlsafe(), 
             notification_type=notification_type,
             message=notification_message
         )
+
+        id_not = NotificationsQueueManager.create_notification_task(notification)
+
+        return id_not
 
     def make(self):
         """Create json of request to institution children."""

--- a/backend/models/request_institution_children.py
+++ b/backend/models/request_institution_children.py
@@ -100,16 +100,24 @@ class RequestInstitutionChildren(Request):
             sender_institution_key=self.institution_requested_key
         )
 
-        notification = Notification(
-            entity_key=self.key.urlsafe(), 
-            receiver_key=self.admin_key.urlsafe(), 
-            notification_type=notification_type,
-            message=notification_message
-        )
+        if action == 'ACCEPT':
+            notification = Notification(
+                entity_key=self.key.urlsafe(), 
+                receiver_key=self.sender_key.urlsafe() if self.sender_key else self.admin_key.urlsafe(), 
+                notification_type=notification_type,
+                message=notification_message
+            )
 
-        id_not = NotificationsQueueManager.create_notification_task(notification)
-
-        return id_not
+            id_not = NotificationsQueueManager.create_notification_task(notification)
+            return id_not
+        else:
+            super(RequestInstitutionChildren, self).send_notification(
+                current_institution=current_institution, 
+                sender_key=invitee_key, 
+                receiver_key=self.sender_key or self.admin_key,
+                notification_type=notification_type,
+                message=notification_message
+            )
 
     def make(self):
         """Create json of request to institution children."""

--- a/backend/models/request_institution_children.py
+++ b/backend/models/request_institution_children.py
@@ -89,10 +89,9 @@ class RequestInstitutionChildren(Request):
             notification_type=notification_type,
             message=notification_message
         )
-
-    def send_response_notification(self, current_institution, invitee_key, action):
-        """Send notification to sender of invite when invite is accepted or rejected."""
-        notification_type = 'ACCEPT_INSTITUTION_LINK' if action == 'ACCEPT' else 'REJECT_INSTITUTION_LINK'
+    
+    def create_accept_response_notification(self, current_institution, invitee_key):
+        """Send accept notification to sender of invite"""
         notification_message = self.create_notification_message(
             user_key=invitee_key, 
             current_institution_key=current_institution,
@@ -100,24 +99,32 @@ class RequestInstitutionChildren(Request):
             sender_institution_key=self.institution_requested_key
         )
 
-        if action == 'ACCEPT':
-            notification = Notification(
-                entity_key=self.key.urlsafe(), 
-                receiver_key=self.sender_key.urlsafe() if self.sender_key else self.admin_key.urlsafe(), 
-                notification_type=notification_type,
-                message=notification_message
-            )
+        notification = Notification(
+            entity_key=self.key.urlsafe(), 
+            receiver_key=self.sender_key.urlsafe() if self.sender_key else self.admin_key.urlsafe(), 
+            notification_type='ACCEPT_INSTITUTION_LINK',
+            message=notification_message
+        )
 
-            id_not = NotificationsQueueManager.create_notification_task(notification)
-            return id_not
-        else:
-            super(RequestInstitutionChildren, self).send_notification(
-                current_institution=current_institution, 
-                sender_key=invitee_key, 
-                receiver_key=self.sender_key or self.admin_key,
-                notification_type=notification_type,
-                message=notification_message
-            )
+        notification_id = NotificationsQueueManager.create_notification_task(notification)
+        return notification_id
+
+    def send_reject_response_notification(self, current_institution, invitee_key):
+        """Send reject notification to sender of invite."""
+        notification_message = self.create_notification_message(
+            user_key=invitee_key, 
+            current_institution_key=current_institution,
+            receiver_institution_key=self.institution_key, 
+            sender_institution_key=self.institution_requested_key
+        )
+
+        super(RequestInstitutionChildren, self).send_notification(
+            current_institution=current_institution, 
+            sender_key=invitee_key, 
+            receiver_key=self.sender_key or self.admin_key,
+            notification_type='REJECT_INSTITUTION_LINK',
+            message=notification_message
+        )
 
     def make(self):
         """Create json of request to institution children."""

--- a/backend/models/request_institution_children.py
+++ b/backend/models/request_institution_children.py
@@ -91,7 +91,7 @@ class RequestInstitutionChildren(Request):
         )
     
     def create_accept_response_notification(self, current_institution, invitee_key):
-        """Send accept notification to sender of invite"""
+        """Create accept notification to sender of invite"""
         notification_message = self.create_notification_message(
             user_key=invitee_key, 
             current_institution_key=current_institution,

--- a/backend/test/model_test/request_institution_children_test.py
+++ b/backend/test/model_test/request_institution_children_test.py
@@ -193,49 +193,64 @@ class RequestInstitutionChildrenTest(TestBase):
     @patch('models.request_institution_children.Notification', return_value='Mocked_notification')
     @patch.object(Invite, 'send_notification')
     @patch.object(Invite, 'create_notification_message', return_value='mocked_message')
-    def test_send_response_notification(self, create_notification_message, send_notification, Notification, NotificationQueueManager):
-        """Test send response notification."""
+    def test_create_accept_response_notification(self, create_notification_message, send_notification, Notification, NotificationQueueManager):
+        """Test create accept response notification."""
         request = generate_request(
             self.admin, self.institution, 
             self.other_institution
         )
 
-        for action in ['ACCEPT', 'REJECT']:
-            request.send_response_notification(
-                current_institution=self.other_institution.key, 
-                invitee_key=self.other_institution.admin,
-                action=action
-            )
-            
-            create_notification_message.assert_called_with(
-                user_key=self.other_institution.admin, 
-                current_institution_key=self.other_institution.key,
-                sender_institution_key=self.other_institution.key,
-                receiver_institution_key=self.institution.key
-            )
+        request.create_accept_response_notification(
+            current_institution=self.other_institution.key, 
+            invitee_key=self.other_institution.admin,
+        )
+        
+        create_notification_message.assert_called_with(
+            user_key=self.other_institution.admin, 
+            current_institution_key=self.other_institution.key,
+            sender_institution_key=self.other_institution.key,
+            receiver_institution_key=self.institution.key
+        )
 
-            notification_type = 'ACCEPT_INSTITUTION_LINK' if action == 'ACCEPT' else 'REJECT_INSTITUTION_LINK'
+        Notification.assert_called_with(
+            entity_key=request.key.urlsafe(), 
+            receiver_key=self.admin.key.urlsafe(), 
+            notification_type='ACCEPT_INSTITUTION_LINK',
+            message='mocked_message'
+        )
 
-            if action == 'ACCEPT':
-                Notification.assert_called_with(
-                    entity_key=request.key.urlsafe(), 
-                    receiver_key=self.admin.key.urlsafe(), 
-                    notification_type=notification_type,
-                    message='mocked_message'
-                )
+        NotificationQueueManager.create_notification_task.assert_called_with(
+            'Mocked_notification'
+        )
+    
+    @patch.object(Invite, 'send_notification')
+    @patch.object(Invite, 'create_notification_message', return_value='mocked_message')
+    def test_send_reject_response_notification(self, create_notification_message, send_notification):
+        """Test send reject response notification."""
+        request = generate_request(
+            self.admin, self.institution, 
+            self.other_institution
+        )
 
-                NotificationQueueManager.create_notification_task.assert_called_with(
-                    'Mocked_notification'
-                )
-            else:
-                send_notification.assert_called_with(
-                    current_institution=self.other_institution.key, 
-                    sender_key=self.other_institution.admin, 
-                    receiver_key=self.admin.key, 
-                    notification_type=notification_type,
-                    message='mocked_message'
-                )
+        request.send_reject_response_notification(
+            current_institution=self.other_institution.key, 
+            invitee_key=self.other_institution.admin,
+        )
+        
+        create_notification_message.assert_called_with(
+            user_key=self.other_institution.admin, 
+            current_institution_key=self.other_institution.key,
+            sender_institution_key=self.other_institution.key,
+            receiver_institution_key=self.institution.key
+        )
 
+        send_notification.assert_called_with(
+            current_institution=self.other_institution.key, 
+            sender_key=self.other_institution.admin, 
+            receiver_key=self.admin.key, 
+            notification_type='REJECT_INSTITUTION_LINK',
+            message='mocked_message'
+        )
 
     @patch.object(EmailSender, 'send_email')
     def test_send_email(self, send_email):

--- a/backend/test/util_modules_tests/notification_test.py
+++ b/backend/test/util_modules_tests/notification_test.py
@@ -103,6 +103,15 @@ class NotificationTest(TestBase):
 
         self.assertEqual(notification.notification_type, 'ALL_NOTIFICATIONS')
     
+    def test_create_notification_nil(self):
+        """Test create notification nil."""
+        notification = NotificationNIL()
+
+        self.assertEqual(notification.message, 'NIL')
+        self.assertEqual(notification.entity_key, 'NIL')
+        self.assertEqual(notification.notification_type, 'NOTIFICATION_NIL')
+        self.assertEqual(notification.receiver_key, 'NIL')
+    
     @patch('util.notification.send_message_notification')
     def test_send_notification(self, send_message_notification):
         """Test send notification."""
@@ -126,6 +135,14 @@ class NotificationTest(TestBase):
 
         notification.send_notification()
         send_message_notification.assert_called_with(**notification.format_notification())
+    
+    @patch('util.notification.send_message_notification')
+    def test_send_notification_with_notification_nil(self, send_message_notification):
+        """Test send notification with notificatin NIL."""
+        notification = NotificationNIL()
+        notification.send_notification()
+
+        send_message_notification.assert_not_called()
     
     def test_format_notification(self):
         """Test format notification."""

--- a/backend/test/util_modules_tests/notification_test.py
+++ b/backend/test/util_modules_tests/notification_test.py
@@ -1,0 +1,157 @@
+"""Notification Model Test."""
+
+import random
+from ..test_base import TestBase
+from util import notification_id, Notification, NotificationNIL
+from util.notification import get_notification_id
+from service_messages import create_message
+from mock import patch
+from .. import mocks
+
+
+class TimeMock(object):
+    def __init__(self):
+        self.rand_time = 0
+
+    def time(self):
+        self.rand_time = random.randint(1000000, 2000000)
+        return self.rand_time
+
+
+class NotificationTest(TestBase):
+    
+    @classmethod
+    def setUp(cls):
+        """Provide the base for the tests."""
+        cls.test = cls.testbed.Testbed()
+        cls.test.activate()
+        cls.policy = cls.datastore.PseudoRandomHRConsistencyPolicy(
+            probability=1)
+        cls.test.init_datastore_v3_stub(consistency_policy=cls.policy)
+        cls.test.init_memcache_stub()
+        cls.notifications_type = notification_id.values()
+    
+    def tearDown(self):
+        """Deactivate the test."""
+        self.test.deactivate()
+    
+    def get_notification_type(self):
+        """Method to get random notification_type."""
+        notification_type = self.notifications_type[random.randint(0, len(self.notifications_type) - 1)]
+
+        while notification_type == 'NOTIFICATION_NIL':
+            notification_type = self.notifications_type[random.randint(0, len(self.notifications_type) - 1)]
+
+        return notification_type
+    
+    @patch('util.notification.time')
+    def test_create_notification(self, time):
+        """Test create new notification."""
+        timeMock = TimeMock()
+        time.time.side_effect = timeMock.time
+
+        user = mocks.create_user()
+        institution = mocks.create_institution()
+        notification_type = self.get_notification_type()
+
+        message = create_message(
+            sender_key=user.key,
+            current_institution_key=institution.key,
+            receiver_institution_key=institution.key,
+            sender_institution_key=institution.key,
+        )
+
+        notification = Notification(
+            message=message,
+            entity_key=institution.key.urlsafe(),
+            notification_type=notification_type,
+            receiver_key=user.key.urlsafe()
+        )
+
+        id = get_notification_id(notification_type)
+        entity_hash = hash(institution.key.urlsafe())
+        receiver_hash = hash(user.key.urlsafe())
+        timestamp = timeMock.rand_time
+
+        expected_key = id + '-' + str(entity_hash) + str(receiver_hash) + str(timestamp)
+        
+        self.assertEqual(notification.key, expected_key)
+        self.assertEqual(notification.message, message)
+        self.assertEqual(notification.entity_key, institution.key.urlsafe())
+        self.assertEqual(notification.notification_type, notification_type)
+        self.assertEqual(notification.receiver_key, user.key.urlsafe())
+    
+    def test_create_notification_with_unregistred_type(self):
+        """Test create notification with unregistred_type."""
+        user = mocks.create_user()
+        institution = mocks.create_institution()
+        notification_type = 'ANY_NOTIFICATIONS'
+
+        message = create_message(
+            sender_key=user.key,
+            current_institution_key=institution.key,
+            receiver_institution_key=institution.key,
+            sender_institution_key=institution.key,
+        )
+
+        notification = Notification(
+            message=message,
+            entity_key=institution.key.urlsafe(),
+            notification_type=notification_type,
+            receiver_key=user.key.urlsafe()
+        )
+
+        self.assertEqual(notification.notification_type, 'ALL_NOTIFICATIONS')
+    
+    @patch('util.notification.send_message_notification')
+    def test_send_notification(self, send_message_notification):
+        """Test send notification."""
+        user = mocks.create_user()
+        institution = mocks.create_institution()
+        notification_type = self.get_notification_type()
+
+        message = create_message(
+            sender_key=user.key,
+            current_institution_key=institution.key,
+            receiver_institution_key=institution.key,
+            sender_institution_key=institution.key,
+        )
+
+        notification = Notification(
+            message=message,
+            entity_key=institution.key.urlsafe(),
+            notification_type=notification_type,
+            receiver_key=user.key.urlsafe()
+        )
+
+        notification.send_notification()
+        send_message_notification.assert_called_with(**notification.format_notification())
+    
+    def test_format_notification(self):
+        """Test format notification."""
+        user = mocks.create_user()
+        institution = mocks.create_institution()
+        notification_type = self.get_notification_type()
+
+        message = create_message(
+            sender_key=user.key,
+            current_institution_key=institution.key,
+            receiver_institution_key=institution.key,
+            sender_institution_key=institution.key,
+        )
+
+        notification = Notification(
+            message=message,
+            entity_key=institution.key.urlsafe(),
+            notification_type=notification_type,
+            receiver_key=user.key.urlsafe()
+        )
+
+        expected_format = {
+            'receiver_key': user.key.urlsafe(),
+            'message': message,
+            'notification_type': notification_type,
+            'entity_key': institution.key.urlsafe()
+        }
+
+        self.assertEqual(notification.format_notification(), expected_format)

--- a/backend/test/util_modules_tests/notification_test.py
+++ b/backend/test/util_modules_tests/notification_test.py
@@ -75,11 +75,31 @@ class NotificationTest(TestBase):
 
         expected_key = id + '-' + str(entity_hash) + str(receiver_hash) + str(timestamp)
         
-        self.assertEqual(notification.key, expected_key)
-        self.assertEqual(notification.message, message)
-        self.assertEqual(notification.entity_key, institution.key.urlsafe())
-        self.assertEqual(notification.notification_type, notification_type)
-        self.assertEqual(notification.receiver_key, user.key.urlsafe())
+        self.assertEqual(
+            notification.key, 
+            expected_key,
+            'Notification key must be the same as expected.'
+        )
+        self.assertEqual(
+            notification.message, 
+            message,
+            'Notification message must be the same as expected.'
+        )
+        self.assertEqual(
+            notification.entity_key, 
+            institution.key.urlsafe(),
+            'entity_key must be equal to institution key.'
+        )
+        self.assertEqual(
+            notification.notification_type, 
+            notification_type,
+            'notification_type must be the same as expected.'
+        )
+        self.assertEqual(
+            notification.receiver_key, 
+            user.key.urlsafe(),
+            'receiver_key must be equal to user key.'
+        )
     
     def test_create_notification_with_unregistred_type(self):
         """Test create notification with unregistred_type."""
@@ -101,16 +121,36 @@ class NotificationTest(TestBase):
             receiver_key=user.key.urlsafe()
         )
 
-        self.assertEqual(notification.notification_type, 'ALL_NOTIFICATIONS')
+        self.assertEqual(
+            notification.notification_type, 
+            'ALL_NOTIFICATIONS',
+            'notification_type must be the same as expected.'
+        )
     
     def test_create_notification_nil(self):
         """Test create notification nil."""
         notification = NotificationNIL()
 
-        self.assertEqual(notification.message, 'NIL')
-        self.assertEqual(notification.entity_key, 'NIL')
-        self.assertEqual(notification.notification_type, 'NOTIFICATION_NIL')
-        self.assertEqual(notification.receiver_key, 'NIL')
+        self.assertEqual(
+            notification.message, 
+            'NIL',
+            'Notification message must be the same as expected.'
+        )
+        self.assertEqual(
+            notification.entity_key, 
+            'NIL',
+            'entity_key must be equal to NIL.'
+        )
+        self.assertEqual(
+            notification.notification_type, 
+            'NOTIFICATION_NIL',
+            'notification_type must be the same as expected.'
+        )
+        self.assertEqual(
+            notification.receiver_key, 
+            'NIL',
+            'receiver_key must be equal to NIL.'
+        )
     
     @patch('util.notification.send_message_notification')
     def test_send_notification(self, send_message_notification):
@@ -171,4 +211,8 @@ class NotificationTest(TestBase):
             'entity_key': institution.key.urlsafe()
         }
 
-        self.assertEqual(notification.format_notification(), expected_format)
+        self.assertEqual(
+            notification.format_notification(), 
+            expected_format,
+            'Formated notification must be the same as expected.'
+        )

--- a/backend/test/util_modules_tests/notifications_queue_manager_test.py
+++ b/backend/test/util_modules_tests/notifications_queue_manager_test.py
@@ -1,0 +1,223 @@
+"""Notifications Queue Manager Test."""
+
+import random
+from google.appengine.api import taskqueue
+from ..test_base import TestBase
+from util import NotificationsQueueManager, Notification, NotificationNIL
+from util.notifications_queue_manager import notification_id, get_notification_id
+from service_messages import create_message
+from .. import mocks
+from mock import patch
+
+
+class TimeMock(object):
+    def __init__(self):
+        self.rand_time = 0
+
+    def time(self):
+        self.rand_time = random.randint(1000000, 2000000)
+        return self.rand_time
+
+class NotificationsQueueManagerTest(TestBase):
+    
+    @classmethod
+    def setUp(cls):
+        """Provide the base for the tests."""
+        cls.test = cls.testbed.Testbed()
+        cls.test.activate()
+        cls.policy = cls.datastore.PseudoRandomHRConsistencyPolicy(
+            probability=1)
+        cls.test.init_datastore_v3_stub(consistency_policy=cls.policy)
+        cls.test.init_memcache_stub()
+        cls.notifications_type = notification_id.values()
+        cls.queue = taskqueue.Queue('notifications-manage-pull')
+    
+    def tearDown(self):
+        """Deactivate the test."""
+        self.test.deactivate()
+        self.queue.purge()
+    
+    def get_notification_type(self):
+        """Method to get random notification_type."""
+        notification_type = self.notifications_type[random.randint(0, len(self.notifications_type) - 1)]
+
+        while notification_type == 'NOTIFICATION_NIL':
+            notification_type = self.notifications_type[random.randint(0, len(self.notifications_type) - 1)]
+
+        return notification_type
+    
+    @patch('util.notifications_queue_manager.time')
+    def test_create_notification(self, time):
+        """Test create new notification."""
+        timeMock = TimeMock()
+        time.time.side_effect = timeMock.time
+
+        user = mocks.create_user()
+        institution = mocks.create_institution()
+        notification_type = self.get_notification_type()
+
+        message = create_message(
+            sender_key=user.key,
+            current_institution_key=institution.key,
+            receiver_institution_key=institution.key,
+            sender_institution_key=institution.key,
+        )
+
+        notification = Notification(
+            message=message,
+            entity_key=institution.key.urlsafe(),
+            notification_type=notification_type,
+            receiver_key=user.key.urlsafe()
+        )
+
+        id = get_notification_id(notification_type)
+        entity_hash = hash(institution.key.urlsafe())
+        receiver_hash = hash(user.key.urlsafe())
+        timestamp = timeMock.rand_time
+
+        expected_key = id + '-' + str(entity_hash) + str(receiver_hash) + str(timestamp)
+        
+        self.assertEqual(notification.key, expected_key)
+        self.assertEqual(notification.message, message)
+        self.assertEqual(notification.entity_key, institution.key.urlsafe())
+        self.assertEqual(notification.notification_type, notification_type)
+        self.assertEqual(notification.receiver_key, user.key.urlsafe())
+    
+    def test_create_notification_with_unregistred_type(self):
+        """Test create notification with unregistred_type."""
+        user = mocks.create_user()
+        institution = mocks.create_institution()
+        notification_type = 'ANY_NOTIFICATIONS'
+
+        message = create_message(
+            sender_key=user.key,
+            current_institution_key=institution.key,
+            receiver_institution_key=institution.key,
+            sender_institution_key=institution.key,
+        )
+
+        notification = Notification(
+            message=message,
+            entity_key=institution.key.urlsafe(),
+            notification_type=notification_type,
+            receiver_key=user.key.urlsafe()
+        )
+
+        self.assertEqual(notification.notification_type, 'ALL_NOTIFICATIONS')
+    
+    @patch('util.notifications_queue_manager.send_message_notification')
+    def test_send_notification(self, send_message_notification):
+        """Test send notification."""
+        user = mocks.create_user()
+        institution = mocks.create_institution()
+        notification_type = self.get_notification_type()
+
+        message = create_message(
+            sender_key=user.key,
+            current_institution_key=institution.key,
+            receiver_institution_key=institution.key,
+            sender_institution_key=institution.key,
+        )
+
+        notification = Notification(
+            message=message,
+            entity_key=institution.key.urlsafe(),
+            notification_type=notification_type,
+            receiver_key=user.key.urlsafe()
+        )
+
+        notification.send_notification()
+        send_message_notification.assert_called_with(**notification.format_notification())
+    
+    def test_format_notification(self):
+        """Test format notification."""
+        user = mocks.create_user()
+        institution = mocks.create_institution()
+        notification_type = self.get_notification_type()
+
+        message = create_message(
+            sender_key=user.key,
+            current_institution_key=institution.key,
+            receiver_institution_key=institution.key,
+            sender_institution_key=institution.key,
+        )
+
+        notification = Notification(
+            message=message,
+            entity_key=institution.key.urlsafe(),
+            notification_type=notification_type,
+            receiver_key=user.key.urlsafe()
+        )
+
+        expected_format = {
+            'receiver_key': user.key.urlsafe(),
+            'message': message,
+            'notification_type': notification_type,
+            'entity_key': institution.key.urlsafe()
+        }
+
+        self.assertEqual(notification.format_notification(), expected_format)
+        
+    def test_create_notification_task(self):
+        """Test create notification task."""
+        user = mocks.create_user()
+        institution = mocks.create_institution()
+        notification_type = self.get_notification_type()
+
+        message = create_message(
+            sender_key=user.key,
+            current_institution_key=institution.key,
+            receiver_institution_key=institution.key,
+            sender_institution_key=institution.key,
+        )
+
+        notification = Notification(
+            message=message,
+            entity_key=institution.key.urlsafe(),
+            notification_type=notification_type,
+            receiver_key=user.key.urlsafe()
+        )
+
+        num_tasks = self.queue.fetch_statistics().tasks
+        self.assertEqual(num_tasks, 0)
+
+        id_notification = NotificationsQueueManager.create_notification_task(notification)
+
+        num_tasks = self.queue.fetch_statistics().tasks
+        self.assertEqual(num_tasks, 1)
+        self.assertEqual(id_notification, notification.key)
+    
+    @patch('util.notifications_queue_manager.send_message_notification')
+    def test_resolve_notification_task(self, send_message_notification):
+        """Test resolve notification task."""
+        user = mocks.create_user()
+        institution = mocks.create_institution()
+        notification_type = self.get_notification_type()
+
+        message = create_message(
+            sender_key=user.key,
+            current_institution_key=institution.key,
+            receiver_institution_key=institution.key,
+            sender_institution_key=institution.key,
+        )
+
+        notification = Notification(
+            message=message,
+            entity_key=institution.key.urlsafe(),
+            notification_type=notification_type,
+            receiver_key=user.key.urlsafe()
+        )
+
+        num_tasks = self.queue.fetch_statistics().tasks
+        self.assertEqual(num_tasks, 0)
+
+        id_notification = NotificationsQueueManager.create_notification_task(notification)
+
+        num_tasks = self.queue.fetch_statistics().tasks
+        self.assertEqual(num_tasks, 1)
+
+        NotificationsQueueManager.resolve_notification_task(id_notification)
+
+        send_message_notification.assert_called_with(**notification.format_notification())
+        num_tasks = self.queue.fetch_statistics().tasks
+        self.assertEqual(num_tasks, 0)

--- a/backend/test/util_modules_tests/notifications_queue_manager_test.py
+++ b/backend/test/util_modules_tests/notifications_queue_manager_test.py
@@ -3,8 +3,8 @@
 import random
 from google.appengine.api import taskqueue
 from ..test_base import TestBase
-from util import NotificationsQueueManager, Notification, NotificationNIL
-from util.notifications_queue_manager import notification_id, get_notification_id
+from util import NotificationsQueueManager, Notification, NotificationNIL, notification_id
+from util.notification import get_notification_id
 from service_messages import create_message
 from .. import mocks
 from mock import patch
@@ -46,7 +46,7 @@ class NotificationsQueueManagerTest(TestBase):
 
         return notification_type
     
-    @patch('util.notifications_queue_manager.time')
+    @patch('util.notification.time')
     def test_create_notification(self, time):
         """Test create new notification."""
         timeMock = TimeMock()
@@ -105,7 +105,7 @@ class NotificationsQueueManagerTest(TestBase):
 
         self.assertEqual(notification.notification_type, 'ALL_NOTIFICATIONS')
     
-    @patch('util.notifications_queue_manager.send_message_notification')
+    @patch('util.notification.send_message_notification')
     def test_send_notification(self, send_message_notification):
         """Test send notification."""
         user = mocks.create_user()
@@ -187,7 +187,7 @@ class NotificationsQueueManagerTest(TestBase):
         self.assertEqual(num_tasks, 1)
         self.assertEqual(id_notification, notification.key)
     
-    @patch('util.notifications_queue_manager.send_message_notification')
+    @patch('util.notification.send_message_notification')
     def test_resolve_notification_task(self, send_message_notification):
         """Test resolve notification task."""
         user = mocks.create_user()

--- a/backend/test/util_modules_tests/notifications_queue_manager_test.py
+++ b/backend/test/util_modules_tests/notifications_queue_manager_test.py
@@ -3,8 +3,7 @@
 import random
 from google.appengine.api import taskqueue
 from ..test_base import TestBase
-from util import NotificationsQueueManager, Notification, NotificationNIL, notification_id
-from util.notification import get_notification_id
+from util import NotificationsQueueManager, Notification, notification_id
 from service_messages import create_message
 from .. import mocks
 from mock import patch

--- a/backend/test/util_modules_tests/notifications_queue_manager_test.py
+++ b/backend/test/util_modules_tests/notifications_queue_manager_test.py
@@ -59,20 +59,36 @@ class NotificationsQueueManagerTest(TestBase):
         )
 
         num_tasks = self.queue.fetch_statistics().tasks
-        self.assertEqual(num_tasks, 0)
+        self.assertEqual(
+            num_tasks, 
+            0,
+            'num_tasks must be equal to 0'
+        )
 
         id_notification = NotificationsQueueManager.create_notification_task(notification)
 
         num_tasks = self.queue.fetch_statistics().tasks
-        self.assertEqual(num_tasks, 1)
-        self.assertEqual(id_notification, notification.key)
+        self.assertEqual(
+            num_tasks, 
+            1,
+            'num_tasks must be equal to 0'
+        )
+        self.assertEqual(
+            id_notification, 
+            notification.key,
+            'id_notification must equal the notification key.'
+        )
     
     def test_create_notification_task_with_invalid_notification(self):
         """Test create notification task wiht invalid notification."""
         with self.assertRaises(TypeError) as raises_context:
             NotificationsQueueManager.create_notification_task("Notification")
 
-        self.assertEqual(str(raises_context.exception), 'Expected type Notification but got str.')
+        self.assertEqual(
+            str(raises_context.exception), 
+            'Expected type Notification but got str.',
+            'Exception message must be equal to Expected type Notification but got str.'
+        )
     
     @patch('util.notification.send_message_notification')
     def test_resolve_notification_task(self, send_message_notification):
@@ -96,18 +112,30 @@ class NotificationsQueueManagerTest(TestBase):
         )
 
         num_tasks = self.queue.fetch_statistics().tasks
-        self.assertEqual(num_tasks, 0)
+        self.assertEqual(
+            num_tasks, 
+            0,
+            'num_tasks must be equal to 0'
+        )
 
         id_notification = NotificationsQueueManager.create_notification_task(notification)
 
         num_tasks = self.queue.fetch_statistics().tasks
-        self.assertEqual(num_tasks, 1)
+        self.assertEqual(
+            num_tasks, 
+            1,
+            'num_tasks must be equal to 1'
+        )
 
         NotificationsQueueManager.resolve_notification_task(id_notification)
 
         send_message_notification.assert_called_with(**notification.format_notification())
         num_tasks = self.queue.fetch_statistics().tasks
-        self.assertEqual(num_tasks, 0)
+        self.assertEqual(
+            num_tasks, 
+            0,
+            'num_tasks must be equal to 0'
+        )
     
     @patch('util.notification.send_message_notification')
     def test_resolve_notification_task_with_notification_nil(self, send_message_notification):
@@ -115,27 +143,47 @@ class NotificationsQueueManagerTest(TestBase):
         notification = NotificationNIL()
 
         num_tasks = self.queue.fetch_statistics().tasks
-        self.assertEqual(num_tasks, 0)
+        self.assertEqual(
+            num_tasks, 
+            0,
+            'num_tasks must be equal to 0'
+        )
 
         id_notification = NotificationsQueueManager.create_notification_task(notification)
 
         num_tasks = self.queue.fetch_statistics().tasks
-        self.assertEqual(num_tasks, 1)
+        self.assertEqual(
+            num_tasks, 
+            1,
+            'num_tasks must be equal to 1'
+        )
 
         NotificationsQueueManager.resolve_notification_task(id_notification)
 
         send_message_notification.assert_not_called()
         num_tasks = self.queue.fetch_statistics().tasks
-        self.assertEqual(num_tasks, 0)
+        self.assertEqual(
+            num_tasks, 
+            0,
+            'num_tasks must be equal to 0'
+        )
     
     def test_resolve_notification_task_with_invalid_id(self):
         """Test resolve notification task with invalid id."""
         with self.assertRaises(QueueException) as raises_context:
             NotificationsQueueManager.resolve_notification_task('03-jksahdjkasjksahdshadkjsdhjksakjdhsajhkdhsajkdhas')
         
-        self.assertEqual(str(raises_context.exception), 'Task not found.')
+        self.assertEqual(
+            str(raises_context.exception), 
+            'Task not found.',
+            'Exception message must be equal to Task not found.'
+        )
 
         with self.assertRaises(QueueException) as raises_context:
             NotificationsQueueManager.resolve_notification_task('ab-jksahdjkasjksahdshadkjsdhjksakjdhsajhkdhsajkdhas')
         
-        self.assertEqual(str(raises_context.exception), 'Invalid task key.')          
+        self.assertEqual(
+            str(raises_context.exception), 
+            'Invalid task key.',
+            'Exception message must be equal to Invalid task key.'
+        )          

--- a/backend/test/util_modules_tests/notifications_queue_manager_test.py
+++ b/backend/test/util_modules_tests/notifications_queue_manager_test.py
@@ -10,14 +10,6 @@ from .. import mocks
 from mock import patch
 
 
-class TimeMock(object):
-    def __init__(self):
-        self.rand_time = 0
-
-    def time(self):
-        self.rand_time = random.randint(1000000, 2000000)
-        return self.rand_time
-
 class NotificationsQueueManagerTest(TestBase):
     
     @classmethod
@@ -45,118 +37,6 @@ class NotificationsQueueManagerTest(TestBase):
             notification_type = self.notifications_type[random.randint(0, len(self.notifications_type) - 1)]
 
         return notification_type
-    
-    @patch('util.notification.time')
-    def test_create_notification(self, time):
-        """Test create new notification."""
-        timeMock = TimeMock()
-        time.time.side_effect = timeMock.time
-
-        user = mocks.create_user()
-        institution = mocks.create_institution()
-        notification_type = self.get_notification_type()
-
-        message = create_message(
-            sender_key=user.key,
-            current_institution_key=institution.key,
-            receiver_institution_key=institution.key,
-            sender_institution_key=institution.key,
-        )
-
-        notification = Notification(
-            message=message,
-            entity_key=institution.key.urlsafe(),
-            notification_type=notification_type,
-            receiver_key=user.key.urlsafe()
-        )
-
-        id = get_notification_id(notification_type)
-        entity_hash = hash(institution.key.urlsafe())
-        receiver_hash = hash(user.key.urlsafe())
-        timestamp = timeMock.rand_time
-
-        expected_key = id + '-' + str(entity_hash) + str(receiver_hash) + str(timestamp)
-        
-        self.assertEqual(notification.key, expected_key)
-        self.assertEqual(notification.message, message)
-        self.assertEqual(notification.entity_key, institution.key.urlsafe())
-        self.assertEqual(notification.notification_type, notification_type)
-        self.assertEqual(notification.receiver_key, user.key.urlsafe())
-    
-    def test_create_notification_with_unregistred_type(self):
-        """Test create notification with unregistred_type."""
-        user = mocks.create_user()
-        institution = mocks.create_institution()
-        notification_type = 'ANY_NOTIFICATIONS'
-
-        message = create_message(
-            sender_key=user.key,
-            current_institution_key=institution.key,
-            receiver_institution_key=institution.key,
-            sender_institution_key=institution.key,
-        )
-
-        notification = Notification(
-            message=message,
-            entity_key=institution.key.urlsafe(),
-            notification_type=notification_type,
-            receiver_key=user.key.urlsafe()
-        )
-
-        self.assertEqual(notification.notification_type, 'ALL_NOTIFICATIONS')
-    
-    @patch('util.notification.send_message_notification')
-    def test_send_notification(self, send_message_notification):
-        """Test send notification."""
-        user = mocks.create_user()
-        institution = mocks.create_institution()
-        notification_type = self.get_notification_type()
-
-        message = create_message(
-            sender_key=user.key,
-            current_institution_key=institution.key,
-            receiver_institution_key=institution.key,
-            sender_institution_key=institution.key,
-        )
-
-        notification = Notification(
-            message=message,
-            entity_key=institution.key.urlsafe(),
-            notification_type=notification_type,
-            receiver_key=user.key.urlsafe()
-        )
-
-        notification.send_notification()
-        send_message_notification.assert_called_with(**notification.format_notification())
-    
-    def test_format_notification(self):
-        """Test format notification."""
-        user = mocks.create_user()
-        institution = mocks.create_institution()
-        notification_type = self.get_notification_type()
-
-        message = create_message(
-            sender_key=user.key,
-            current_institution_key=institution.key,
-            receiver_institution_key=institution.key,
-            sender_institution_key=institution.key,
-        )
-
-        notification = Notification(
-            message=message,
-            entity_key=institution.key.urlsafe(),
-            notification_type=notification_type,
-            receiver_key=user.key.urlsafe()
-        )
-
-        expected_format = {
-            'receiver_key': user.key.urlsafe(),
-            'message': message,
-            'notification_type': notification_type,
-            'entity_key': institution.key.urlsafe()
-        }
-
-        self.assertEqual(notification.format_notification(), expected_format)
         
     def test_create_notification_task(self):
         """Test create notification task."""

--- a/backend/util/__init__.py
+++ b/backend/util/__init__.py
@@ -2,8 +2,8 @@
 
 from .json_patch import *
 from .strings_pt_br import *
-from .login_service import *
 from .notifications_queue_manager import *
+from .login_service import *
 
 
 util_modules = [json_patch, strings_pt_br, login_service, notifications_queue_manager]

--- a/backend/util/__init__.py
+++ b/backend/util/__init__.py
@@ -3,8 +3,9 @@
 from .json_patch import *
 from .strings_pt_br import *
 from .login_service import *
+from .notifications_queue_manager import *
 
 
-util_modules = [json_patch, strings_pt_br, login_service]
+util_modules = [json_patch, strings_pt_br, login_service, notifications_queue_manager]
 
 __all__ = [prop for util_module in util_modules for prop in util_module.__all__]

--- a/backend/util/__init__.py
+++ b/backend/util/__init__.py
@@ -2,10 +2,11 @@
 
 from .json_patch import *
 from .strings_pt_br import *
+from .notification import *
 from .notifications_queue_manager import *
 from .login_service import *
 
 
-util_modules = [json_patch, strings_pt_br, login_service, notifications_queue_manager]
+util_modules = [json_patch, strings_pt_br, login_service, notification, notifications_queue_manager]
 
 __all__ = [prop for util_module in util_modules for prop in util_module.__all__]

--- a/backend/util/notification.py
+++ b/backend/util/notification.py
@@ -1,0 +1,131 @@
+"""Notification model."""
+
+import time
+from service_messages import send_message_notification
+
+__all__ = ['Notification', 'NotificationNIL', 'notification_id']
+
+notification_id = {
+    "00": "ALL_NOTIFICATIONS",
+    "01": "NOTIFICATION_NIL",
+    "02": "ACCEPT_INSTITUTION_LINK",
+    "03": "ACCEPT_INVITE_HIERARCHY",
+    "04": "ACCEPT_INVITE_USER_ADM",
+    "05": "ADD_ADM_PERMISSIONS"
+}
+
+def get_notification_id(notification_type):
+    """
+    Method that takes the id of a given notification in 
+    the notification_id dictionary, if the notification 
+    does not exist in the dictionary, returns the id '00'.
+
+    Keyword arguments:
+    notification_type -- Type of notification to get id.
+    """
+    for key, value in notification_id.items():
+        if value == notification_type:
+            return key
+    
+    return "00"
+
+
+class Notification(object):
+    """
+    Class to create notification.
+    """
+
+    def __init__(self, message, entity_key, notification_type, receiver_key):
+        """
+        Constructor of class Notification.
+
+        Keyword arguments:
+        message -- Message dictionary of notification.
+        entity_key -- entity key of type invite.
+        notification_type -- type of notification. 
+        receiver_key -- Urlsafe of the user who will receive the notification.
+        """
+        self.message = message
+        self.entity_key = entity_key
+        self.notification_type = self._get_notification_type(notification_type)
+        self.receiver_key = receiver_key
+        self.key = self._generate_key()
+    
+    def format_notification(self):
+        """
+        Method that returns a dictionary with the attributes needed to send the notification.
+        """
+        return {
+            'receiver_key': self.receiver_key,
+            'message': self.message,
+            'notification_type': self.notification_type,
+            'entity_key': self.entity_key
+        }
+    
+    def _generate_key(self):
+        """
+        Method that generates a unique key for the created notification. 
+        Using to generate the key the notification type id, the hash 
+        of the entity_key, the hash of the receiver_key, and the current 
+        date in seconds.
+        """
+        id = get_notification_id(self.notification_type)
+        entity_hash = hash(self.entity_key)
+        receiver_hash = hash(self.receiver_key)
+        timestamp = time.time()
+
+        key = id + '-' + str(entity_hash) + str(receiver_hash) + str(timestamp)
+        key = key.replace(".", "")
+        return key
+    
+    def _get_notification_type(self, notification_type):
+        """
+        Method to get the notification type according to the notifications_id dictionary. 
+        If the notification type already exists in the dictionary, it is returned, 
+        otherwise the default type 'ALL_NOTIFICATIONS' is returned.
+        """
+        return notification_type if notification_type in notification_id.values() else "ALL_NOTIFICATIONS"
+    
+    def send_notification(self):
+        """
+        Method to send notification.
+        """
+        send_message_notification(**self.format_notification())
+    
+    def __str__(self):
+        """
+        Method to generate string representation of notification object.
+        """
+        formated_notification = self.format_notification()
+        formated_notification['key'] = self.key
+
+        return self.__class__.__name__ + " " + str(formated_notification)
+    
+    def __repr__(self):
+        """
+        Method to generate string representation of notification object.
+        """
+        return str(self)
+
+
+class NotificationNIL(Notification):
+    """
+    Class to create empty notification.
+    """
+    def __init__(self, **kwords):
+        """
+        Constructor of class NotificationNIL.
+        """
+        super(NotificationNIL, self).__init__(
+            message='NIL',
+            entity_key='NIL',
+            notification_type='NOTIFICATION_NIL',
+            receiver_key='NIL'
+        )
+    
+    def send_notification(self):
+        """
+        Method to send notifications.
+        In empty notifications, this method should have no action.
+        """
+        pass

--- a/backend/util/notifications_queue_manager.py
+++ b/backend/util/notifications_queue_manager.py
@@ -65,7 +65,7 @@ def create_notification(notification_id, **kwords):
         "01": NotificationNIL,
         "OTHERWISE": Notification
     }
-
+    
     return switch.get(notification_id, switch['OTHERWISE'])(**kwords)
 
 class NotificationsQueueManager:
@@ -196,7 +196,7 @@ class NotificationNIL(Notification):
     """
     Class to create empty notification.
     """
-    def __init__(self):
+    def __init__(self, **kwords):
         """
         Constructor of class NotificationNIL.
         """

--- a/backend/util/notifications_queue_manager.py
+++ b/backend/util/notifications_queue_manager.py
@@ -55,7 +55,7 @@ class NotificationsQueueManager:
     def create_notification_task(notification):
         """
         Method for creating a task from the notification and 
-        trigger it in the queue. Returns the task key.
+        add it to the queue. Returns the task key.
 
         Keyword arguments:
         notification -- Notification that will be used to create the task.

--- a/backend/util/notifications_queue_manager.py
+++ b/backend/util/notifications_queue_manager.py
@@ -18,6 +18,14 @@ notification_id = {
 }
 
 def get_notification_id(notification_type):
+    """
+    Method that takes the id of a given notification in 
+    the notification_id dictionary, if the notification 
+    does not exist in the dictionary, returns the id '00'.
+
+    Keyword arguments:
+    notification_type - Type of notification to get id.
+    """
     for key, value in notification_id.items():
         if value == notification_type:
             return key
@@ -25,6 +33,16 @@ def get_notification_id(notification_type):
     return "00"
 
 def find_task(notification_type, task_id, num_fetchs=0):
+    """
+    Method to find tasks in the queue, based on the task 
+    id and the grouping (notification_type), both passed by parameter.
+    If it does not find it, returns None.
+    
+    Keyword arguments:
+    notification_type - Notification type to catch of just task of specified type.
+    task_id - Id of the task to be found.
+    num_fetchs - (Optional) Current number of tasks that have already been taken from the queue.
+    """
     num_tasks = queue.fetch_statistics().tasks
     
     if num_fetchs <= num_tasks:
@@ -36,6 +54,13 @@ def find_task(notification_type, task_id, num_fetchs=0):
     return None
 
 def create_notification(notification_id, **kwords):
+    """
+    Method to create notification according to your id.
+
+    Keyword arguments:
+    notification_id - Notification Id to be created.
+    kwords - Dictionary of arguments to create the notification.
+    """
     switch = {
         "01": NotificationNIL,
         "OTHERWISE": Notification
@@ -44,15 +69,25 @@ def create_notification(notification_id, **kwords):
     return switch.get(notification_id, switch['OTHERWISE'])(**kwords)
 
 class NotificationsQueueManager:
+    """
+    Class to manage the notification queue.
+    """
     
     @staticmethod
-    def create_notification_task(notification_message):
-        notification_type = notification_message.notification_type
-        notification_key = notification_message.key
+    def create_notification_task(notification):
+        """
+        Method for creating a task from the notification and 
+        trigger it in the queue. Returns the task key.
+
+        Keyword arguments:
+        notification - Notification that will be used to create the task.
+        """
+        notification_type = notification.notification_type
+        notification_key = notification.key
 
         task = taskqueue.Task(
             name=notification_key,
-            payload=json.dumps(notification_message.format_notification()),
+            payload=json.dumps(notification.format_notification()),
             tag=notification_type,
             method='PULL'
         )
@@ -63,6 +98,13 @@ class NotificationsQueueManager:
     
     @staticmethod
     def resolve_notification_task(task_id):
+        """
+        Method to get a queue task, if any, re-create the 
+        notification, resolve it and delete the queue task.
+
+        Keyword arguments:
+        task_id - Task id to be resolved.
+        """
         notification_type = notification_id[task_id[:2]]
         task = find_task(notification_type,task_id)
 

--- a/backend/util/notifications_queue_manager.py
+++ b/backend/util/notifications_queue_manager.py
@@ -90,7 +90,7 @@ class NotificationsQueueManager:
         notification, resolve it and delete the queue task.
 
         Keyword arguments:
-        task_key -- Task id to be resolved.
+        task_key -- Task key to be resolved.
         """
         task_id = task_key[:2]
         Utils._assert(

--- a/backend/util/notifications_queue_manager.py
+++ b/backend/util/notifications_queue_manager.py
@@ -3,9 +3,9 @@
 import json
 import time
 from google.appengine.api import taskqueue
-from protorpc import messages
+from service_messages import send_message_notification
 
-__all__ = ['NotiticationsQueueManager', 'NotificationMessage']
+__all__ = ['NotificationsQueueManager', 'Notification']
 
 queue = taskqueue.Queue('notifications-manage-pull')
 notification_id = {
@@ -22,17 +22,21 @@ def get_notification_id(notification_type):
     
     return "00"
 
-class NotiticationsQueueManager:
+notifications_tasks = []
+
+def get_notification_tasks(notification_type, notifications_tasks):
+    notifications_tasks += queue.lease_tasks_by_tag(10, 100, notification_type)
+
+class NotificationsQueueManager:
     
     @staticmethod
     def create_notification_task(notification_message):
-        message = notification_message.message
         notification_type = notification_message.notification_type
         notification_key = notification_message.key
 
         task = taskqueue.Task(
             name=notification_key,
-            payload=json.dumps(message),
+            payload=json.dumps(notification_message.format_notification()),
             tag=notification_type,
             method='PULL'
         )
@@ -42,32 +46,42 @@ class NotiticationsQueueManager:
 
     
     @staticmethod
-    def resolve_notification_task(notification_id):
-        pass
+    def resolve_notification_task(task_id):
+        notification_type = notification_id[task_id[:2]]
+        task = reduce(lambda found, task: task if task.name == task_id else found, notifications_tasks, None)
+
+        if task:
+            notification = Notification(**json.loads(task.payload))
+            send_message_notification(**notification.format_notification())
+            queue.delete_tasks([task])
+        else:
+            get_notification_tasks(notification_type, notifications_tasks)
+            NotificationsQueueManager.resolve_notification_task(task_id)
 
 
-class NotificationMessage(object):
-    def __init__(self, message, entity_urlsafe, notification_type, receiver_urlsafe):
+class Notification(object):
+    def __init__(self, message, entity_key, notification_type, receiver_key):
         self.message = message
-        self.entity_urlsafe = entity_urlsafe
+        self.entity_key = entity_key
         self.notification_type = notification_type
-        self.receiver_urlsafe = receiver_urlsafe
+        self.receiver_key = receiver_key
         self.key = self._gererate_key()
     
     def format_notification(self):
         return {
-            'receiver_key': self.receiver_urlsafe,
+            'receiver_key': self.receiver_key,
             'message': self.message,
             'notification_type': self.notification_type,
-            'entity_key': self.entity_urlsafe
+            'entity_key': self.entity_key
         }
     
     def _gererate_key(self):
         id = get_notification_id(self.notification_type)
-        entity_hash = hash(self.entity_urlsafe)
-        receiver_hash = hash(self.receiver_urlsafe)
+        entity_hash = hash(self.entity_key)
+        receiver_hash = hash(self.receiver_key)
         timestamp = time.time()
 
         key = id + '-' + str(entity_hash) + str(receiver_hash) + str(timestamp)
         key = key.replace(".", "")
         return key
+    

--- a/backend/util/notifications_queue_manager.py
+++ b/backend/util/notifications_queue_manager.py
@@ -103,6 +103,15 @@ class Notification(object):
     
     def send_notification(self):
         send_message_notification(**self.format_notification())
+    
+    def __str__(self):
+        formated_notification = self.format_notification()
+        formated_notification['key'] = self.key
+
+        return self.__class__.__name__ + " " + str(formated_notification)
+    
+    def __repr__(self):
+        return str(self)
 
 
 class NotificationNIL(Notification):

--- a/backend/util/notifications_queue_manager.py
+++ b/backend/util/notifications_queue_manager.py
@@ -90,7 +90,7 @@ class NotificationsQueueManager:
         notification, resolve it and delete the queue task.
 
         Keyword arguments:
-        task_id -- Task id to be resolved.
+        task_key -- Task id to be resolved.
         """
         task_id = task_key[:2]
         Utils._assert(
@@ -102,9 +102,12 @@ class NotificationsQueueManager:
         notification_type = notification_id[task_id]
         task = find_task(notification_type,task_key)
 
-        if task:
-            notification = create_notification(task_id, **json.loads(task.payload))
-            notification.send_notification()
-            queue.delete_tasks([task])
-        else:
-            raise QueueException('Task not found.')
+        Utils._assert(
+            not task,
+            'Task not found.',
+            QueueException
+        )
+
+        notification = create_notification(task_id, **json.loads(task.payload))
+        notification.send_notification()
+        queue.delete_tasks([task])

--- a/backend/util/notifications_queue_manager.py
+++ b/backend/util/notifications_queue_manager.py
@@ -24,7 +24,7 @@ def get_notification_id(notification_type):
     does not exist in the dictionary, returns the id '00'.
 
     Keyword arguments:
-    notification_type - Type of notification to get id.
+    notification_type -- Type of notification to get id.
     """
     for key, value in notification_id.items():
         if value == notification_type:
@@ -40,8 +40,8 @@ def find_task(notification_type, task_id, num_fetchs=0):
     
     Keyword arguments:
     notification_type - Notification type to catch of just task of specified type.
-    task_id - Id of the task to be found.
-    num_fetchs - (Optional) Current number of tasks that have already been taken from the queue.
+    task_id -- Id of the task to be found.
+    num_fetchs -- (Optional) Current number of tasks that have already been taken from the queue.
     """
     num_tasks = queue.fetch_statistics().tasks
     
@@ -58,8 +58,8 @@ def create_notification(notification_id, **kwords):
     Method to create notification according to your id.
 
     Keyword arguments:
-    notification_id - Notification Id to be created.
-    kwords - Dictionary of arguments to create the notification.
+    notification_id -- Notification Id to be created.
+    kwords -- Dictionary of arguments to create the notification.
     """
     switch = {
         "01": NotificationNIL,
@@ -80,7 +80,7 @@ class NotificationsQueueManager:
         trigger it in the queue. Returns the task key.
 
         Keyword arguments:
-        notification - Notification that will be used to create the task.
+        notification -- Notification that will be used to create the task.
         """
         notification_type = notification.notification_type
         notification_key = notification.key
@@ -103,7 +103,7 @@ class NotificationsQueueManager:
         notification, resolve it and delete the queue task.
 
         Keyword arguments:
-        task_id - Task id to be resolved.
+        task_id -- Task id to be resolved.
         """
         notification_type = notification_id[task_id[:2]]
         task = find_task(notification_type,task_id)
@@ -115,7 +115,20 @@ class NotificationsQueueManager:
 
 
 class Notification(object):
+    """
+    Class to create notification.
+    """
+
     def __init__(self, message, entity_key, notification_type, receiver_key):
+        """
+        Constructor of class Notification.
+
+        Keyword arguments:
+        message -- Message dictionary of notification.
+        entity_key -- entity key of type invite.
+        notification_type -- type of notification. 
+        receiver_key -- Urlsafe of the user who will receive the notification.
+        """
         self.message = message
         self.entity_key = entity_key
         self.notification_type = self._get_notification_type(notification_type)
@@ -123,6 +136,9 @@ class Notification(object):
         self.key = self._generate_key()
     
     def format_notification(self):
+        """
+        Method that returns a dictionary with the attributes needed to send the notification.
+        """
         return {
             'receiver_key': self.receiver_key,
             'message': self.message,
@@ -131,6 +147,12 @@ class Notification(object):
         }
     
     def _generate_key(self):
+        """
+        Method that generates a unique key for the created notification. 
+        Using to generate the key the notification type id, the hash 
+        of the entity_key, the hash of the receiver_key, and the current 
+        date in seconds.
+        """
         id = get_notification_id(self.notification_type)
         entity_hash = hash(self.entity_key)
         receiver_hash = hash(self.receiver_key)
@@ -141,23 +163,43 @@ class Notification(object):
         return key
     
     def _get_notification_type(self, notification_type):
+        """
+        Method to get the notification type according to the notifications_id dictionary. 
+        If the notification type already exists in the dictionary, it is returned, 
+        otherwise the default type 'ALL_NOTIFICATIONS' is returned.
+        """
         return notification_type if notification_type in notification_id.values() else "ALL_NOTIFICATIONS"
     
     def send_notification(self):
+        """
+        Method to send notification.
+        """
         send_message_notification(**self.format_notification())
     
     def __str__(self):
+        """
+        Method to generate string representation of notification object.
+        """
         formated_notification = self.format_notification()
         formated_notification['key'] = self.key
 
         return self.__class__.__name__ + " " + str(formated_notification)
     
     def __repr__(self):
+        """
+        Method to generate string representation of notification object.
+        """
         return str(self)
 
 
 class NotificationNIL(Notification):
+    """
+    Class to create empty notification.
+    """
     def __init__(self):
+        """
+        Constructor of class NotificationNIL.
+        """
         super(NotificationNIL, self).__init__(
             message='NIL',
             entity_key='NIL',
@@ -166,4 +208,8 @@ class NotificationNIL(Notification):
         )
     
     def send_notification(self):
+        """
+        Method to send notifications.
+        In empty notifications, this method should have no action.
+        """
         pass

--- a/backend/util/notifications_queue_manager.py
+++ b/backend/util/notifications_queue_manager.py
@@ -5,6 +5,7 @@ import time
 from google.appengine.api import taskqueue
 from service_messages import send_message_notification
 from . import Notification, NotificationNIL, notification_id
+from utils import Utils
 
 __all__ = ['NotificationsQueueManager']
 
@@ -60,6 +61,12 @@ class NotificationsQueueManager:
         Keyword arguments:
         notification -- Notification that will be used to create the task.
         """
+        Utils._assert(
+            not isinstance(notification, Notification),
+            "Expected type Notification but got %s." %(type(notification).__name__),
+            TypeError
+        )
+
         notification_type = notification.notification_type
         notification_key = notification.key
 

--- a/backend/util/notifications_queue_manager.py
+++ b/backend/util/notifications_queue_manager.py
@@ -4,33 +4,11 @@ import json
 import time
 from google.appengine.api import taskqueue
 from service_messages import send_message_notification
+from . import Notification, NotificationNIL, notification_id
 
-__all__ = ['NotificationsQueueManager', 'Notification', 'NotificationNIL']
+__all__ = ['NotificationsQueueManager']
 
 queue = taskqueue.Queue('notifications-manage-pull')
-notification_id = {
-    "00": "ALL_NOTIFICATIONS",
-    "01": "NOTIFICATION_NIL",
-    "02": "ACCEPT_INSTITUTION_LINK",
-    "03": "ACCEPT_INVITE_HIERARCHY",
-    "04": "ACCEPT_INVITE_USER_ADM",
-    "05": "ADD_ADM_PERMISSIONS"
-}
-
-def get_notification_id(notification_type):
-    """
-    Method that takes the id of a given notification in 
-    the notification_id dictionary, if the notification 
-    does not exist in the dictionary, returns the id '00'.
-
-    Keyword arguments:
-    notification_type -- Type of notification to get id.
-    """
-    for key, value in notification_id.items():
-        if value == notification_type:
-            return key
-    
-    return "00"
 
 def find_task(notification_type, task_id, num_fetchs=0):
     """
@@ -112,104 +90,3 @@ class NotificationsQueueManager:
             notification = create_notification(task_id[:2], **json.loads(task.payload))
             notification.send_notification()
             queue.delete_tasks([task])
-
-
-class Notification(object):
-    """
-    Class to create notification.
-    """
-
-    def __init__(self, message, entity_key, notification_type, receiver_key):
-        """
-        Constructor of class Notification.
-
-        Keyword arguments:
-        message -- Message dictionary of notification.
-        entity_key -- entity key of type invite.
-        notification_type -- type of notification. 
-        receiver_key -- Urlsafe of the user who will receive the notification.
-        """
-        self.message = message
-        self.entity_key = entity_key
-        self.notification_type = self._get_notification_type(notification_type)
-        self.receiver_key = receiver_key
-        self.key = self._generate_key()
-    
-    def format_notification(self):
-        """
-        Method that returns a dictionary with the attributes needed to send the notification.
-        """
-        return {
-            'receiver_key': self.receiver_key,
-            'message': self.message,
-            'notification_type': self.notification_type,
-            'entity_key': self.entity_key
-        }
-    
-    def _generate_key(self):
-        """
-        Method that generates a unique key for the created notification. 
-        Using to generate the key the notification type id, the hash 
-        of the entity_key, the hash of the receiver_key, and the current 
-        date in seconds.
-        """
-        id = get_notification_id(self.notification_type)
-        entity_hash = hash(self.entity_key)
-        receiver_hash = hash(self.receiver_key)
-        timestamp = time.time()
-
-        key = id + '-' + str(entity_hash) + str(receiver_hash) + str(timestamp)
-        key = key.replace(".", "")
-        return key
-    
-    def _get_notification_type(self, notification_type):
-        """
-        Method to get the notification type according to the notifications_id dictionary. 
-        If the notification type already exists in the dictionary, it is returned, 
-        otherwise the default type 'ALL_NOTIFICATIONS' is returned.
-        """
-        return notification_type if notification_type in notification_id.values() else "ALL_NOTIFICATIONS"
-    
-    def send_notification(self):
-        """
-        Method to send notification.
-        """
-        send_message_notification(**self.format_notification())
-    
-    def __str__(self):
-        """
-        Method to generate string representation of notification object.
-        """
-        formated_notification = self.format_notification()
-        formated_notification['key'] = self.key
-
-        return self.__class__.__name__ + " " + str(formated_notification)
-    
-    def __repr__(self):
-        """
-        Method to generate string representation of notification object.
-        """
-        return str(self)
-
-
-class NotificationNIL(Notification):
-    """
-    Class to create empty notification.
-    """
-    def __init__(self, **kwords):
-        """
-        Constructor of class NotificationNIL.
-        """
-        super(NotificationNIL, self).__init__(
-            message='NIL',
-            entity_key='NIL',
-            notification_type='NOTIFICATION_NIL',
-            receiver_key='NIL'
-        )
-    
-    def send_notification(self):
-        """
-        Method to send notifications.
-        In empty notifications, this method should have no action.
-        """
-        pass

--- a/backend/util/notifications_queue_manager.py
+++ b/backend/util/notifications_queue_manager.py
@@ -1,0 +1,1 @@
+"""Notifications Queue Manager."""

--- a/backend/util/notifications_queue_manager.py
+++ b/backend/util/notifications_queue_manager.py
@@ -1,1 +1,73 @@
 """Notifications Queue Manager."""
+
+import json
+from google.appengine.api import taskqueue
+from protorpc import messages
+
+__all__ = ['NotiticationsQueueManager']
+
+queue = taskqueue.Queue('notifications-manage-pull')
+notification_id = {
+    "01": "ACCEPT_INSTITUTION_LINK",
+    "02": "ACCEPT_INVITE_HIERARCHY",
+    "03": "ACCEPT_INVITE_USER_ADM"
+}
+
+class NotiticationsQueueManager:
+    
+    @staticmethod
+    def create_notification_task(message):
+        pass
+    
+    @staticmethod
+    def resolve_notification_task(notification_id):
+        pass
+
+
+class Message(messages.Message):
+    from_name = messages.StringFiled(1, required=True)
+    from_institution_name = messages.StringFiled(2)
+    from_photo_url = messages.StringFiled(3, required=True)
+    to_institution_name = messages.StringFiled(4)
+    current_instituion_name = messages.StringFiled(5)
+
+    @staticmethod
+    def create_message(message_dict):
+        message_from = message_dict.get('from')
+        message_to = message_dict.get('to')
+        message_current_inst = message_dict('current_instiution')
+
+        return Message(
+            from_name=message_from.get('name'),
+            from_institution_name=message_from.get('institution_name'),
+            from_photo_url=message_from.get('photo_url'),
+            to_institution_name=message_to.get('institution_name'),
+            current_instituion_name=message_current_inst('name')
+        )
+    
+    @staticmethod
+    def format_message(message):
+        return {
+            'from': {
+                'name': message.field_by_number(1),
+                'photo_url': message.field_by_number(3),
+                'institution_name': message.field_by_number(2)
+            },
+            'to': {
+                'institution_name': message.field_by_number(4)
+            },
+            'current_institution': {
+                'name': message.field_by_number(5)
+            }
+        }
+
+
+class NotificationMessage(messages.Message):
+    message = messages.MessageFiled(1, required=True)
+    entity_urlsafe = messages.StringFiled(2)
+    notification_type = messages.StringFiled(3, required=True),
+    receiver_urlsafe = messages.StringFiled(4, required=True)
+
+    def __init__(self, *args, **kwargs):
+        kwargs['message'] = Message.create_message(kwargs['message'])
+        super(NotificationMessage, self).__init__(*args, **kwargs)

--- a/backend/util/notifications_queue_manager.py
+++ b/backend/util/notifications_queue_manager.py
@@ -1,73 +1,73 @@
 """Notifications Queue Manager."""
 
 import json
+import time
 from google.appengine.api import taskqueue
 from protorpc import messages
 
-__all__ = ['NotiticationsQueueManager']
+__all__ = ['NotiticationsQueueManager', 'NotificationMessage']
 
 queue = taskqueue.Queue('notifications-manage-pull')
 notification_id = {
+    "00": "ALL_NOTIFICATIONS",
     "01": "ACCEPT_INSTITUTION_LINK",
     "02": "ACCEPT_INVITE_HIERARCHY",
     "03": "ACCEPT_INVITE_USER_ADM"
 }
 
+def get_notification_id(notification_type):
+    for key, value in notification_id.items():
+        if value == notification_type:
+            return key
+    
+    return "00"
+
 class NotiticationsQueueManager:
     
     @staticmethod
-    def create_notification_task(message):
-        pass
+    def create_notification_task(notification_message):
+        message = notification_message.message
+        notification_type = notification_message.notification_type
+        notification_key = notification_message.key
+
+        task = taskqueue.Task(
+            name=notification_key,
+            payload=json.dumps(message),
+            tag=notification_type,
+            method='PULL'
+        )
+        queue.add(task)
+
+        return notification_key
+
     
     @staticmethod
     def resolve_notification_task(notification_id):
         pass
 
 
-class Message(messages.Message):
-    from_name = messages.StringFiled(1, required=True)
-    from_institution_name = messages.StringFiled(2)
-    from_photo_url = messages.StringFiled(3, required=True)
-    to_institution_name = messages.StringFiled(4)
-    current_instituion_name = messages.StringFiled(5)
-
-    @staticmethod
-    def create_message(message_dict):
-        message_from = message_dict.get('from')
-        message_to = message_dict.get('to')
-        message_current_inst = message_dict('current_instiution')
-
-        return Message(
-            from_name=message_from.get('name'),
-            from_institution_name=message_from.get('institution_name'),
-            from_photo_url=message_from.get('photo_url'),
-            to_institution_name=message_to.get('institution_name'),
-            current_instituion_name=message_current_inst('name')
-        )
+class NotificationMessage(object):
+    def __init__(self, message, entity_urlsafe, notification_type, receiver_urlsafe):
+        self.message = message
+        self.entity_urlsafe = entity_urlsafe
+        self.notification_type = notification_type
+        self.receiver_urlsafe = receiver_urlsafe
+        self.key = self._gererate_key()
     
-    @staticmethod
-    def format_message(message):
+    def format_notification(self):
         return {
-            'from': {
-                'name': message.field_by_number(1),
-                'photo_url': message.field_by_number(3),
-                'institution_name': message.field_by_number(2)
-            },
-            'to': {
-                'institution_name': message.field_by_number(4)
-            },
-            'current_institution': {
-                'name': message.field_by_number(5)
-            }
+            'receiver_key': self.receiver_urlsafe,
+            'message': self.message,
+            'notification_type': self.notification_type,
+            'entity_key': self.entity_urlsafe
         }
+    
+    def _gererate_key(self):
+        id = get_notification_id(self.notification_type)
+        entity_hash = hash(self.entity_urlsafe)
+        receiver_hash = hash(self.receiver_urlsafe)
+        timestamp = time.time()
 
-
-class NotificationMessage(messages.Message):
-    message = messages.MessageFiled(1, required=True)
-    entity_urlsafe = messages.StringFiled(2)
-    notification_type = messages.StringFiled(3, required=True),
-    receiver_urlsafe = messages.StringFiled(4, required=True)
-
-    def __init__(self, *args, **kwargs):
-        kwargs['message'] = Message.create_message(kwargs['message'])
-        super(NotificationMessage, self).__init__(*args, **kwargs)
+        key = id + '-' + str(entity_hash) + str(receiver_hash) + str(timestamp)
+        key = key.replace(".", "")
+        return key

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -363,10 +363,13 @@ class AddAdminPermissionsInInstitutionHierarchy(BaseHandler):
 
     def post(self):
         institution_key = self.request.get('institution_key')
-        id_not = self.request.get('id')
+        id_nototification = self.request.get('id_notification')
         
         self.addAdminPermissions(institution_key)
-        NotificationsQueueManager.resolve_notification_task(id_not)
+        
+        # TODO Remove this 'if' when all handler notifications passed through this queue have been resolved.
+        if id_nototification:
+            NotificationsQueueManager.resolve_notification_task(id_nototification)
 
 
 class RemoveAdminPermissionsInInstitutionHierarchy(BaseHandler):

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -18,6 +18,7 @@ from jinja2 import Environment, FileSystemLoader
 from permissions import DEFAULT_SUPER_USER_PERMISSIONS
 from permissions import DEFAULT_ADMIN_PERMISSIONS
 from send_email_hierarchy import RemoveInstitutionEmailSender
+from util import NotificationsQueueManager
 
 
 def should_remove(user, institution_key, current_inst_key):
@@ -360,16 +361,11 @@ class AddAdminPermissionsInInstitutionHierarchy(BaseHandler):
                 admin.add_permission(permission, institution_key)
             add_permission_to_children(institution, admins, permission)
 
-        send_message_notification(
-            receiver_key=institution.parent_institution.get().admin.urlsafe(),
-            notification_type='ADD_ADM_PERMISSIONS',
-            entity_key=institution.key.urlsafe(),
-            message=create_system_message(institution.key),
-        )
-
     def post(self):
         institution_key = self.request.get('institution_key')
+        id_not = self.request.get('id')
         self.addAdminPermissions(institution_key)
+        NotificationsQueueManager.resolve_notification_task(id_not)
 
 
 class RemoveAdminPermissionsInInstitutionHierarchy(BaseHandler):

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -364,6 +364,7 @@ class AddAdminPermissionsInInstitutionHierarchy(BaseHandler):
     def post(self):
         institution_key = self.request.get('institution_key')
         id_not = self.request.get('id')
+        
         self.addAdminPermissions(institution_key)
         NotificationsQueueManager.resolve_notification_task(id_not)
 

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -360,6 +360,13 @@ class AddAdminPermissionsInInstitutionHierarchy(BaseHandler):
                 admin.add_permission(permission, institution_key)
             add_permission_to_children(institution, admins, permission)
 
+        send_message_notification(
+            receiver_key=institution.parent_institution.get().admin.urlsafe(),
+            notification_type='ADD_ADM_PERMISSIONS',
+            entity_key=institution.key.urlsafe(),
+            message=create_system_message(institution.key),
+        )
+
     def post(self):
         institution_key = self.request.get('institution_key')
         self.addAdminPermissions(institution_key)

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -363,13 +363,14 @@ class AddAdminPermissionsInInstitutionHierarchy(BaseHandler):
 
     def post(self):
         institution_key = self.request.get('institution_key')
-        id_nototification = self.request.get('id_notification')
+        notification_id = self.request.get('id_notification')
         
         self.addAdminPermissions(institution_key)
         
         # TODO Remove this 'if' when all handler notifications passed through this queue have been resolved.
-        if id_nototification:
-            NotificationsQueueManager.resolve_notification_task(id_nototification)
+        # Author: Luiz Silva - 29/06/18
+        if notification_id:
+            NotificationsQueueManager.resolve_notification_task(notification_id)
 
 
 class RemoveAdminPermissionsInInstitutionHierarchy(BaseHandler):

--- a/frontend/notification/notificationDirective.js
+++ b/frontend/notification/notificationDirective.js
@@ -168,6 +168,9 @@
             },
             "DELETED_USER": {
                 icon: "clear"
+            },
+            "ADD_ADM_PERMISSIONS": {
+                icon: "check_circle_outline"
             }
         };
 

--- a/frontend/notification/notificationMessageCreatorService.js
+++ b/frontend/notification/notificationMessageCreatorService.js
@@ -45,7 +45,7 @@
             'ACCEPT_INVITE_HIERARCHY': messageCreator('Aceitou seu convite e estabeleceu vínculo entre ', DOUBLE_INST),
             'TRANSFER_ADM_PERMISSIONS': messageCreator('Você agora possui permissões para administrar ', SINGLE_INST),
             'DELETED_USER': messageCreator('Removeu sua conta na Plataforma Virtual CIS', NO_INST),
-            'ADD_ADM_PERMISSIONS': messageCreator('Suas permissões hierarquicas foram atualizadas na instituição ', SINGLE_INST),
+            'ADD_ADM_PERMISSIONS': messageCreator('Suas permissões hierárquicas foram atualizadas na instituição ', SINGLE_INST),
             'REMOVED_ADM_PERMISSIONS': messageCreator('Transferência de administração concluída. Você não possui mais permissões para administrar ', SINGLE_INST),
         };
 

--- a/frontend/notification/notificationMessageCreatorService.js
+++ b/frontend/notification/notificationMessageCreatorService.js
@@ -44,7 +44,8 @@
             'REJECT_INVITE_USER_ADM': messageCreator('Rejeitou seu convite para ser administrador de ', SINGLE_INST),
             'ACCEPT_INVITE_HIERARCHY': messageCreator('Aceitou seu convite e estabeleceu vínculo entre ', DOUBLE_INST),
             'TRANSFER_ADM_PERMISSIONS': messageCreator('Você agora possui permissões para administrar ', SINGLE_INST),
-            'DELETED_USER': messageCreator('Removeu sua conta na Plataforma Virtual CIS', NO_INST)
+            'DELETED_USER': messageCreator('Removeu sua conta na Plataforma Virtual CIS', NO_INST),
+            'ADD_ADM_PERMISSIONS': messageCreator('Você tem permissão pra tudo', SINGLE_INST)
         };
 
 

--- a/frontend/notification/notificationMessageCreatorService.js
+++ b/frontend/notification/notificationMessageCreatorService.js
@@ -45,7 +45,7 @@
             'ACCEPT_INVITE_HIERARCHY': messageCreator('Aceitou seu convite e estabeleceu vínculo entre ', DOUBLE_INST),
             'TRANSFER_ADM_PERMISSIONS': messageCreator('Você agora possui permissões para administrar ', SINGLE_INST),
             'DELETED_USER': messageCreator('Removeu sua conta na Plataforma Virtual CIS', NO_INST),
-            'ADD_ADM_PERMISSIONS': messageCreator('Você tem permissão pra tudo', SINGLE_INST)
+            'ADD_ADM_PERMISSIONS': messageCreator('Suas permissões hierarquicas foram atualizadas na instituição ', SINGLE_INST)
         };
 
 

--- a/frontend/test/specs/notification/notificationControllerSpec.js
+++ b/frontend/test/specs/notification/notificationControllerSpec.js
@@ -7,7 +7,7 @@
 
     var EVENTS_TO_UPDATE_USER = ["DELETED_INSTITUTION", "DELETE_MEMBER", "ACCEPTED_LINK",
                                 "ACCEPT_INSTITUTION_LINK", "TRANSFER_ADM_PERMISSIONS",
-                                "REMOVED_ADM_PERMISSIONS"];
+                                "ADD_ADM_PERMISSIONS", "REMOVED_ADM_PERMISSIONS"];
     
     var institution = {
         name: 'institution',

--- a/frontend/user/userService.js
+++ b/frontend/user/userService.js
@@ -9,7 +9,8 @@
         var USER_URI = "/api/user";
 
         service.NOTIFICATIONS_TO_UPDATE_USER = ["DELETED_INSTITUTION", "DELETE_MEMBER",
-                                                "ACCEPT_INSTITUTION_LINK", "TRANSFER_ADM_PERMISSIONS"];
+                                                "ACCEPT_INSTITUTION_LINK", "TRANSFER_ADM_PERMISSIONS",
+                                                "ADD_ADM_PERMISSIONS"];
 
         service.deleteAccount = function deleteAccount() {
             return HttpService.delete(USER_URI);

--- a/queue.yaml
+++ b/queue.yaml
@@ -5,3 +5,5 @@ queue:
   rate: 1/s
 - name: emails
   rate: 1/s
+- name: notifications-manage-pull
+  mode: pull


### PR DESCRIPTION
**Feature/Bug description:** In certain system actions, such as administration transfer and request to create a link with other institutions, the permissions of the users involved need to be reloaded. Many problems are happening while reloading due to the fact that as soon as notification that a given request has been accepted, the user is reloaded and sometimes there is no time for the queue to add and remove permissions to finish, ie the user is reloaded but does not yet have the permissions. This is because the queue for adding permissions works asynchronously, just like the queue of notifications, so there is currently no way to control the synchronization between the various existing services.

**Solution:** Create a different queue type from the ones that already exist on the system and can be better managed to ensure synchronization of services.
I created a PULL queue where the activities are stored in it and then need to be removed and resolved, I also created a queue manager, it is responsible for creating a notification task, it returns a key that identifies the task newly created, and when it is necessary to solve the task simply pass your key to the manager that it will solve it. In this way, whenever it is necessary to create a notification that needs to be sent soon after some other queues task is resolved, this manager will be able to guarantee the synchronicity between the services.

**Resolved handlers:**
* Institution_parent_request_handler
* Institution_children_request_handler

**TODO/FIXME:** Remove 'if' in the addAdminPermissions queue when all handler notifications that pass through it are resolved.