### PR TITLE
Send notification of accept transfer admin invite

### DIFF
--- a/backend/models/invite_user_adm.py
+++ b/backend/models/invite_user_adm.py
@@ -66,7 +66,10 @@ class InviteUserAdm(InviteUser):
         )
     
     def create_system_notification(self):
-        """Create a new system notification to transfer admin permissions."""
+        """
+        Create a new system notification for the new administrator 
+        to inform you that administrative permissions have been transferred.
+        """
         message = create_system_message(self.institution_key)
 
         notification = Notification(
@@ -104,7 +107,7 @@ class InviteUserAdm(InviteUser):
         return notification_id
     
     def send_reject_response_notification(self, current_institution):
-        """Send notification to sender of invite when invite is accepted or rejected."""
+        """Send notification to sender of invite when invite is rejected."""
         notification_type = "REJECT_INVITE_USER_ADM"
         notification_message= self.create_notification_message(
             user_key=self.invitee_key,

--- a/backend/models/invite_user_adm.py
+++ b/backend/models/invite_user_adm.py
@@ -4,7 +4,8 @@ from invite_user import InviteUser
 from utils import Utils
 from custom_exceptions import NotAuthorizedException
 from send_email_hierarchy import TransferAdminEmailSender
-from util.strings_pt_br import get_subject
+from util import get_subject
+from util import Notification, NotificationsQueueManager
 
 __all__ = ['InviteUserAdm']
 
@@ -62,6 +63,24 @@ class InviteUserAdm(InviteUser):
             receiver_key=self.invitee_key,
             notification_type=notification_type
         )
+    
+    def create_accept_notification(self, current_institution):
+        """."""
+        message = self.create_notification_message(
+            user_key=self.invitee_key,
+            current_institution_key=current_institution,
+            receiver_institution_key=self.institution_key
+        )
+
+        notification = Notification(
+            message,
+            self.key.urlsafe(),
+            "ACCEPT_INVITE_USER_ADM",
+            self.invitee_key.urlsafe()
+        )
+
+        notification_id = NotificationsQueueManager.create_notification_task(notification)
+        return notification_id
     
     def send_response_notification(self, current_institution, action):
         """Send notification to sender of invite when invite is accepted or rejected."""

--- a/backend/models/invite_user_adm.py
+++ b/backend/models/invite_user_adm.py
@@ -66,7 +66,7 @@ class InviteUserAdm(InviteUser):
         )
     
     def create_system_notification(self):
-        """."""
+        """Create a new system notification to transfer admin permissions."""
         message = create_system_message(self.institution_key)
 
         notification = Notification(
@@ -80,7 +80,12 @@ class InviteUserAdm(InviteUser):
         return notification_id
     
     def create_accept_response_notification(self, current_institution):
-        """."""
+        """
+        Create a new accept response notification.
+        
+        Keyword arguments:
+        current_institution -- Current institution of user.
+        """
         admin = self.institution_key.get().admin
         message = self.create_notification_message(
             user_key=self.invitee_key,

--- a/backend/test/util_modules_tests/notification_test.py
+++ b/backend/test/util_modules_tests/notification_test.py
@@ -2,7 +2,7 @@
 
 import random
 from ..test_base import TestBase
-from util import notification_id, Notification, NotificationNIL
+from util import notification_id, Notification
 from util.notification import get_notification_id
 from service_messages import create_message
 from mock import patch
@@ -133,31 +133,6 @@ class NotificationTest(TestBase):
             'notification_group must be the same as expected.'
         )
     
-    def test_create_notification_nil(self):
-        """Test create notification nil."""
-        notification = NotificationNIL()
-
-        self.assertEqual(
-            notification.message, 
-            'NIL',
-            'Notification message must be the same as expected.'
-        )
-        self.assertEqual(
-            notification.entity_key, 
-            'NIL',
-            'entity_key must be equal to NIL.'
-        )
-        self.assertEqual(
-            notification.notification_type, 
-            'NOTIFICATION_NIL',
-            'notification_type must be the same as expected.'
-        )
-        self.assertEqual(
-            notification.receiver_key, 
-            'NIL',
-            'receiver_key must be equal to NIL.'
-        )
-    
     @patch('util.notification.send_message_notification')
     def test_send_notification(self, send_message_notification):
         """Test send notification."""
@@ -181,14 +156,6 @@ class NotificationTest(TestBase):
 
         notification.send_notification()
         send_message_notification.assert_called_with(**notification.format_notification())
-    
-    @patch('util.notification.send_message_notification')
-    def test_send_notification_with_notification_nil(self, send_message_notification):
-        """Test send notification with notificatin NIL."""
-        notification = NotificationNIL()
-        notification.send_notification()
-
-        send_message_notification.assert_not_called()
     
     def test_format_notification(self):
         """Test format notification."""

--- a/backend/test/util_modules_tests/notification_test.py
+++ b/backend/test/util_modules_tests/notification_test.py
@@ -123,8 +123,14 @@ class NotificationTest(TestBase):
 
         self.assertEqual(
             notification.notification_type, 
-            'ALL_NOTIFICATIONS',
+            'ANY_NOTIFICATIONS',
             'notification_type must be the same as expected.'
+        )
+
+        self.assertEqual(
+            notification.notification_group, 
+            'ALL_NOTIFICATIONS',
+            'notification_group must be the same as expected.'
         )
     
     def test_create_notification_nil(self):

--- a/backend/test/util_modules_tests/notifications_queue_manager_test.py
+++ b/backend/test/util_modules_tests/notifications_queue_manager_test.py
@@ -3,7 +3,7 @@
 import random
 from google.appengine.api import taskqueue
 from ..test_base import TestBase
-from util import NotificationsQueueManager, Notification, NotificationNIL, notification_id
+from util import NotificationsQueueManager, Notification, notification_id
 from service_messages import create_message
 from custom_exceptions import QueueException
 from .. import mocks
@@ -130,37 +130,6 @@ class NotificationsQueueManagerTest(TestBase):
         NotificationsQueueManager.resolve_notification_task(id_notification)
 
         send_message_notification.assert_called_with(**notification.format_notification())
-        num_tasks = self.queue.fetch_statistics().tasks
-        self.assertEqual(
-            num_tasks, 
-            0,
-            'num_tasks must be equal to 0'
-        )
-    
-    @patch('util.notification.send_message_notification')
-    def test_resolve_notification_task_with_notification_nil(self, send_message_notification):
-        """Test resolve notification task with notification nil."""
-        notification = NotificationNIL()
-
-        num_tasks = self.queue.fetch_statistics().tasks
-        self.assertEqual(
-            num_tasks, 
-            0,
-            'num_tasks must be equal to 0'
-        )
-
-        id_notification = NotificationsQueueManager.create_notification_task(notification)
-
-        num_tasks = self.queue.fetch_statistics().tasks
-        self.assertEqual(
-            num_tasks, 
-            1,
-            'num_tasks must be equal to 1'
-        )
-
-        NotificationsQueueManager.resolve_notification_task(id_notification)
-
-        send_message_notification.assert_not_called()
         num_tasks = self.queue.fetch_statistics().tasks
         self.assertEqual(
             num_tasks, 

--- a/backend/util/notification.py
+++ b/backend/util/notification.py
@@ -11,7 +11,8 @@ notification_id = {
     "02": "ACCEPT_INSTITUTION_LINK",
     "03": "ACCEPT_INVITE_HIERARCHY",
     "04": "ACCEPT_INVITE_USER_ADM",
-    "05": "ADD_ADM_PERMISSIONS"
+    "05": "ADD_ADM_PERMISSIONS",
+    "07": "TRANSFER_ADM_PERMISSIONS"
 }
 
 def get_notification_id(notification_type):

--- a/backend/util/notification.py
+++ b/backend/util/notification.py
@@ -3,7 +3,7 @@
 import time
 from service_messages import send_message_notification
 
-__all__ = ['Notification', 'NotificationNIL', 'notification_id']
+__all__ = ['Notification', 'notification_id']
 
 notification_id = {
     "00": "ALL_NOTIFICATIONS",
@@ -108,26 +108,3 @@ class Notification(object):
         Method to generate string representation of notification object.
         """
         return str(self)
-
-
-class NotificationNIL(Notification):
-    """
-    Class to create empty notification.
-    """
-    def __init__(self, **kwords):
-        """
-        Constructor of class NotificationNIL.
-        """
-        super(NotificationNIL, self).__init__(
-            message='NIL',
-            entity_key='NIL',
-            notification_type='NOTIFICATION_NIL',
-            receiver_key='NIL'
-        )
-    
-    def send_notification(self):
-        """
-        Method to send notifications.
-        In empty notifications, this method should have no action.
-        """
-        pass

--- a/backend/util/notification.py
+++ b/backend/util/notification.py
@@ -48,7 +48,8 @@ class Notification(object):
         """
         self.message = message
         self.entity_key = entity_key
-        self.notification_type = self._get_notification_type(notification_type)
+        self.notification_type = notification_type
+        self.notification_group = self._get_notification_group(notification_type)
         self.receiver_key = receiver_key
         self.key = self._generate_key()
     
@@ -70,7 +71,7 @@ class Notification(object):
         of the entity_key, the hash of the receiver_key, and the current 
         date in seconds.
         """
-        id = get_notification_id(self.notification_type)
+        id = get_notification_id(self.notification_group)
         entity_hash = hash(self.entity_key)
         receiver_hash = hash(self.receiver_key)
         timestamp = time.time()
@@ -79,9 +80,9 @@ class Notification(object):
         key = key.replace(".", "")
         return key
     
-    def _get_notification_type(self, notification_type):
+    def _get_notification_group(self, notification_type):
         """
-        Method to get the notification type according to the notifications_id dictionary. 
+        Method to get the notification group according to the notifications_id dictionary. 
         If the notification type already exists in the dictionary, it is returned, 
         otherwise the default type 'ALL_NOTIFICATIONS' is returned.
         """

--- a/backend/util/notifications_queue_manager.py
+++ b/backend/util/notifications_queue_manager.py
@@ -4,7 +4,7 @@ import json
 import time
 from google.appengine.api import taskqueue
 from service_messages import send_message_notification
-from . import Notification, NotificationNIL, notification_id
+from . import Notification, notification_id
 from utils import Utils
 from custom_exceptions import QueueException
 
@@ -33,21 +33,6 @@ def find_task(notification_type, task_id, num_fetchs=0):
         return task if task else find_task(notification_type, task_id, num_fetchs+fetchs)
 
     return None
-
-def create_notification(notification_id, **kwords):
-    """
-    Method to create notification according to your id.
-
-    Keyword arguments:
-    notification_id -- Notification Id to be created.
-    kwords -- Dictionary of arguments to create the notification.
-    """
-    switch = {
-        "01": NotificationNIL,
-        "OTHERWISE": Notification
-    }
-    
-    return switch.get(notification_id, switch['OTHERWISE'])(**kwords)
 
 class NotificationsQueueManager:
     """
@@ -108,6 +93,6 @@ class NotificationsQueueManager:
             QueueException
         )
 
-        notification = create_notification(task_id, **json.loads(task.payload))
+        notification = Notification(**json.loads(task.payload))
         notification.send_notification()
         queue.delete_tasks([task])

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -442,13 +442,6 @@ class TransferAdminPermissionsHandler(BaseHandler):
                 user.permissions[permission].update(permissions[permission])
             else:
                 user.permissions.update({permission: permissions[permission]})
-
-        #send_message_notification(
-        #    receiver_key=user.key.urlsafe(),
-        #    notification_type='TRANSFER_ADM_PERMISSIONS',
-        #    entity_key=institution.key.urlsafe(),
-        #    message=create_system_message(institution.key),
-        #)
     
     def remove_permissions(self, user, institution):
         """    
@@ -467,13 +460,6 @@ class TransferAdminPermissionsHandler(BaseHandler):
         for permission, institution_keys in permissions_filtered.items():
             for instition_key in institution_keys:
                 user.remove_permission(permission, instition_key)
-
-        #send_message_notification(
-        #    receiver_key=user.key.urlsafe(),
-        #    notification_type='REMOVED_ADM_PERMISSIONS',
-        #    entity_key=institution.key.urlsafe(),
-        #    message=create_system_message(institution.key),
-        #)
 
 
     def post(self):

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -443,12 +443,12 @@ class TransferAdminPermissionsHandler(BaseHandler):
             else:
                 user.permissions.update({permission: permissions[permission]})
 
-        send_message_notification(
-            receiver_key=user.key.urlsafe(),
-            notification_type='TRANSFER_ADM_PERMISSIONS',
-            entity_key=institution.key.urlsafe(),
-            message=create_system_message(institution.key),
-        )
+        #send_message_notification(
+        #    receiver_key=user.key.urlsafe(),
+        #    notification_type='TRANSFER_ADM_PERMISSIONS',
+        #    entity_key=institution.key.urlsafe(),
+        #    message=create_system_message(institution.key),
+        #)
     
     def remove_permissions(self, user, institution):
         """    
@@ -468,12 +468,12 @@ class TransferAdminPermissionsHandler(BaseHandler):
             for instition_key in institution_keys:
                 user.remove_permission(permission, instition_key)
 
-        send_message_notification(
-            receiver_key=user.key.urlsafe(),
-            notification_type='REMOVED_ADM_PERMISSIONS',
-            entity_key=institution.key.urlsafe(),
-            message=create_system_message(institution.key),
-        )
+        #send_message_notification(
+        #    receiver_key=user.key.urlsafe(),
+        #    notification_type='REMOVED_ADM_PERMISSIONS',
+        #    entity_key=institution.key.urlsafe(),
+        #    message=create_system_message(institution.key),
+        #)
 
 
     def post(self):
@@ -489,9 +489,10 @@ class TransferAdminPermissionsHandler(BaseHandler):
         institution = ndb.Key(urlsafe=institution_key).get()
         admin = institution.admin.get()
         new_admin = ndb.Key(urlsafe=user_key).get()
+        notifications_ids = self.request.get_all('notifications_ids')
         
         @ndb.transactional(xg=True, retries=10)
-        def save_changes(admin, new_admin, institution):
+        def save_changes(admin, new_admin, institution, notifications_ids):
             institution.set_admin(new_admin.key)
             self.add_permissions(new_admin, institution)
             
@@ -505,8 +506,10 @@ class TransferAdminPermissionsHandler(BaseHandler):
             new_admin.put()
             admin.put()
             institution.put()
+
+            map(lambda notification_id: NotificationsQueueManager.resolve_notification_task(notification_id), notifications_ids)
         
-        save_changes(admin, new_admin, institution)
+        save_changes(admin, new_admin, institution, notifications_ids)
 
 
 app = webapp2.WSGIApplication([

--- a/frontend/notification/notificationMessageCreatorService.js
+++ b/frontend/notification/notificationMessageCreatorService.js
@@ -45,8 +45,7 @@
             'ACCEPT_INVITE_HIERARCHY': messageCreator('Aceitou seu convite e estabeleceu vínculo entre ', DOUBLE_INST),
             'TRANSFER_ADM_PERMISSIONS': messageCreator('Você agora possui permissões para administrar ', SINGLE_INST),
             'DELETED_USER': messageCreator('Removeu sua conta na Plataforma Virtual CIS', NO_INST),
-            'ADD_ADM_PERMISSIONS': messageCreator('Suas permissões hierárquicas foram atualizadas na instituição ', SINGLE_INST),
-            'REMOVED_ADM_PERMISSIONS': messageCreator('Transferência de administração concluída. Você não possui mais permissões para administrar ', SINGLE_INST),
+            'ADD_ADM_PERMISSIONS': messageCreator('Suas permissões hierárquicas foram atualizadas na instituição ', SINGLE_INST)
         };
 
 

--- a/frontend/test/specs/notification/notificationControllerSpec.js
+++ b/frontend/test/specs/notification/notificationControllerSpec.js
@@ -7,7 +7,7 @@
 
     var EVENTS_TO_UPDATE_USER = ["DELETED_INSTITUTION", "DELETE_MEMBER", "ACCEPTED_LINK",
                                 "ACCEPT_INSTITUTION_LINK", "TRANSFER_ADM_PERMISSIONS",
-                                "ADD_ADM_PERMISSIONS", "REMOVED_ADM_PERMISSIONS"];
+                                "ADD_ADM_PERMISSIONS", "ACCEPT_INVITE_USER_ADM"];
     
     var institution = {
         name: 'institution',

--- a/frontend/user/userService.js
+++ b/frontend/user/userService.js
@@ -11,7 +11,7 @@
 
         service.NOTIFICATIONS_TO_UPDATE_USER = ["DELETED_INSTITUTION", "DELETE_MEMBER", "ACCEPTED_LINK",
                                                 "ACCEPT_INSTITUTION_LINK", "TRANSFER_ADM_PERMISSIONS",
-                                                "ADD_ADM_PERMISSIONS", "REMOVED_ADM_PERMISSIONS"];
+                                                "ADD_ADM_PERMISSIONS", "ACCEPT_INVITE_USER_ADM"];
 
         service.deleteAccount = function deleteAccount() {
             return HttpService.delete(USER_URI);


### PR DESCRIPTION
**Feature/Bug description:** When an administrator sends an administration transfer invitation to another member of the institution and he accepts, a notification must be sent to the current administrator and another to the new administrator as soon as the administration transfer queue finishes so that the permissions can be reloaded.

**Solution:** Use notifications queue manager to create a notification that will be resolved only when the administration transfer queue is finished.

**TODO/FIXME:** n/a