### PR TITLE
Fix answer later thougth notification.

### DIFF
--- a/frontend/invites/newInviteController.js
+++ b/frontend/invites/newInviteController.js
@@ -128,9 +128,9 @@
                 if(invite.key === newInviteCtrl.inviteKey){
                     invite.answerLater = true;
                     AuthService.save();
-                    $state.go("app.user.home");
                 }
             });
+            $state.go("app.user.home");
         };
 
         newInviteCtrl.canAnswerLater = function canAnswerLater() {

--- a/frontend/test/specs/invites/newInviteControllerSpec.js
+++ b/frontend/test/specs/invites/newInviteControllerSpec.js
@@ -107,13 +107,6 @@
                 expect(newInviteCtrl.user.invites[0].answerLater).toEqual(true);
                 expect(state.go).toHaveBeenCalledWith("app.user.home");
             });
-
-            it('should not redirect to home', function () {
-                spyOn(state, 'go');
-                newInviteCtrl.inviteKey = "notExist";
-                newInviteCtrl.answerLater();
-                expect(state.go).not.toHaveBeenCalled();
-            });
         });
 
         describe('canAnswerLater', function () {


### PR DESCRIPTION
**Feature/Bug description:** When the user accesses a new invitation page via notification, the invitation is not on the user's invitations, so as the method is implemented it cannot be redirected home.

**Solution:**  When the user chooses to respond later to the invitation by clicking the button, he is redirected home.

**TODO/FIXME:** n/a