### PR TITLE
Fix show button edit

### DIFF
--- a/frontend/post/postDetailsDirective.js
+++ b/frontend/post/postDetailsDirective.js
@@ -167,7 +167,7 @@
 
         postDetailsCtrl.showButtonEdit = function showButtonEdit() {
             const hasPermission = postDetailsCtrl.user.hasPermission(EDIT_POST_PERMISSION, postDetailsCtrl.post.key);
-            const isActiveInst = postDetailsCtrl.post.institution_state == "active";
+            var isActiveInst = postDetailsCtrl.post.institution_state == "active";
             return hasPermission && !postDetailsCtrl.isDeleted(postDetailsCtrl.post) && isActiveInst &&
                     !postDetailsCtrl.postHasActivity() && !postDetailsCtrl.isShared() && !postDetailsCtrl.showSurvey();
         };

--- a/frontend/post/postDetailsDirective.js
+++ b/frontend/post/postDetailsDirective.js
@@ -167,7 +167,8 @@
 
         postDetailsCtrl.showButtonEdit = function showButtonEdit() {
             const hasPermission = postDetailsCtrl.user.hasPermission(EDIT_POST_PERMISSION, postDetailsCtrl.post.key);
-            return hasPermission && !postDetailsCtrl.isDeleted(postDetailsCtrl.post) &&
+            const isActiveInst = postDetailsCtrl.post.institution_state == "active";
+            return hasPermission && !postDetailsCtrl.isDeleted(postDetailsCtrl.post) && isActiveInst &&
                     !postDetailsCtrl.postHasActivity() && !postDetailsCtrl.isShared() && !postDetailsCtrl.showSurvey();
         };
 

--- a/frontend/test/specs/post/postDetailsControllerSpec.js
+++ b/frontend/test/specs/post/postDetailsControllerSpec.js
@@ -554,7 +554,7 @@
 
     describe('showButtonEdit', function () {
         it('should return true', function () {
-            let post = new Post({key: 'akposdko-OADKAOP', state:'published', number_of_comments: 0, number_of_likes: 0});
+            let post = new Post({key: 'akposdko-OADKAOP', state:'published', institution_state: "active", number_of_comments: 0, number_of_likes: 0});
             postDetailsCtrl.post = post;
             postDetailsCtrl.user.permissions = {};
             postDetailsCtrl.user.permissions['edit_post'] = {};


### PR DESCRIPTION
**Feature/Bug description:** Fix edit post button when the institution is inactive.

**Solution:** Added verification that confirms is institution is active.

**TODO/FIXME:** n/a

![screenshot from 2018-07-04 14-12-01](https://user-images.githubusercontent.com/18709274/42289195-91e5ff80-7f94-11e8-85e6-8b0a854febdb.png)
