### PR TITLE
Fix send email to institution members

### DIFF
--- a/backend/worker.py
+++ b/backend/worker.py
@@ -312,8 +312,9 @@ class EmailMembersHandler(BaseHandler):
                 '%s'
                 """ % justification
             
+            FIRST_EMAIL = 0
             mail.send_mail(sender="Plataforma Virtual CIS <plataformavirtualcis@gmail.com>",
-                        to="<%s>" % member.email,
+                        to="<%s>" % member.email[FIRST_EMAIL],
                         subject=subject,
                         body="",
                         html=template.render(json.loads(message)))


### PR DESCRIPTION
**Feature/Bug description:** In EmailMembersHandler, the send_mail method was being called with the property 'to' receiving a list of emails instead of a single email. 

**Solution:** It was set to send email to the first one on the list

**TODO/FIXME:** n/a