### PR TITLE
Remove unnecessary method remove_link in institution model

### DIFF
--- a/backend/handlers/institution_children_handler.py
+++ b/backend/handlers/institution_children_handler.py
@@ -71,8 +71,8 @@ class InstitutionChildrenHandler(BaseHandler):
                               "User is not allowed to remove link between institutions",
                               institution_children_urlsafe)
 
-        is_parent = True
-        institution_children.remove_link(institution_parent, is_parent)
+        # Remove Parent
+        institution_children.set_parent(None)
         admin = institution_parent.admin
         
         notification_id = create_notification(

--- a/backend/handlers/institution_parent_handler.py
+++ b/backend/handlers/institution_parent_handler.py
@@ -65,8 +65,8 @@ class InstitutionParentHandler(BaseHandler):
                               "User is not allowed to remove link between institutions",
                               institution_parent_urlsafe)
 
-        is_parent = False
-        institution_parent.remove_link(institution_children, is_parent)
+        # Remove child
+        institution_parent.remove_child(institution_children.key)
         admin = institution_children.admin
 
         notification_type = 'REMOVE_INSTITUTION_LINK'

--- a/backend/models/institution.py
+++ b/backend/models/institution.py
@@ -247,14 +247,6 @@ class Institution(ndb.Model):
             returned_method = self.set_parent_for_none
         return returned_method
 
-    def remove_link(self, institution_link, is_parent):
-        """Remove the connection between self and institution_link."""
-        if is_parent == True:
-            self.parent_institution = None
-        else:
-            self.children_institutions.remove(institution_link.key)
-        self.put()
-
     def remove_institution_hierarchy(self, remove_hierarchy, user):
         """Remove institution's hierarchy."""
         for child in self.children_institutions:

--- a/backend/test/model_test/institution_test.py
+++ b/backend/test/model_test/institution_test.py
@@ -219,48 +219,6 @@ class InstitutionTest(TestBase):
         self.assertEqual(self.institution.state, 'inactive',
             "The state of institution should be inactive")
 
-
-    def test_remove_link(self):
-        # case 1: remove parent
-        parent_inst = mocks.create_institution()
-        invite = mocks.create_invite(self.user, parent_inst.key, 'INSTITUTION')
-
-        self.assertTrue(self.institution.key not in parent_inst.children_institutions,
-            "parent_inst should not be has a children institution")
-
-        self.assertTrue(self.institution.parent_institution is None,
-            "institution should not has parent institution")
-
-        self.institution.create_children_connection(invite)
-
-        self.assertEqual(self.institution.parent_institution, parent_inst.key,
-            "Institution should has a children institution")
-
-        self.institution.remove_link(parent_inst, True)
-
-        self.assertTrue(self.institution.parent_institution is None,
-            "institution should not has parent institution")
-
-        # case 2: remove children
-        child_inst = mocks.create_institution()
-        invite = mocks.create_invite(self.user, child_inst.key, 'INSTITUTION')
-
-        self.assertTrue(child_inst.key not in self.institution.children_institutions,
-            "Institution should not has a children institution")
-
-        self.assertTrue(child_inst.parent_institution is None,
-            "child_inst should not has parent institution")
-
-        self.institution.create_parent_connection(invite)
-
-        self.assertTrue(child_inst.key in self.institution.children_institutions,
-            "Institution should has a children institution")
-
-        self.institution.remove_link(child_inst, "false")
-
-        self.assertTrue(child_inst.key not in self.institution.children_institutions,
-            "Institution should not has a children institution")
-
     def test_get_hierarchy_admin_permissions(self):
         
         def generate_permissions(institution_key_url, permissions={}):


### PR DESCRIPTION
**Feature/Bug description:** The remove_link method of the Institution model is no longer needed because there are other methods that already do what it does.

**Solution:** Use the remove_child and set_parent methods to remove child and parent links.

**TODO/FIXME:** n/a