### PR TITLE
Fix worker test

### DIFF
--- a/backend/test/worker_handlers_tests/worker_aux_methods_test.py
+++ b/backend/test/worker_handlers_tests/worker_aux_methods_test.py
@@ -68,14 +68,17 @@ class WorkerAuxMethodsTest(TestBase):
             'publish_survey': [],
             'publish_post': []
         }
-        for permission_type in PERMISSIONS:
-            expected_permissions[permission_type] = [second_inst_urlsafe, third_inst_urlsafe]
 
         permissions_to_remove = filter_permissions_to_remove(
             user, user.permissions,
             second_inst_urlsafe, should_remove
         )
 
+        for permission_type in PERMISSIONS:
+            expected_permissions[permission_type] = [second_inst_urlsafe, third_inst_urlsafe]
+            permissions_to_remove[permission_type].sort()
+            expected_permissions[permission_type].sort()
+        
         # assert filtered permissions using should_remove method
         self.assertEquals(
             permissions_to_remove, expected_permissions,


### PR DESCRIPTION
**Feature/Bug description:**
There was a worker_aux_methods' test breaking locally. Filter_permissions_to_remove. The compared objects used to have unsorted lists.
**Solution:**
I've sorted the lists in the objects what made the comparison return true.
**TODO/FIXME:** n/a