### PR TITLE
Fix can't open institution request dialog

### DIFF
--- a/frontend/invites/invite.js
+++ b/frontend/invites/invite.js
@@ -28,9 +28,9 @@ Invite.prototype.setType = function (typeOfInvite) {
 };
 
 Invite.prototype.areInstitutionsValid = function () {
-    const isInstitutionActive = this.institution.isStateOn('active');
-    const isRequestedInstActive = this.requested_institution ? this.requested_institution.isStateOn('active') : true;
-    return isInstitutionActive && isRequestedInstActive;
+    const isNotInstitutionInactive = ! this.institution.isStateOn('inactive');
+    const isNotRequestedInstInactive = this.requested_institution ? ! this.requested_institution.isStateOn('inactive') : true;
+    return isNotInstitutionInactive && isNotRequestedInstInactive;
 }
 
 function isValueValid(value) {

--- a/frontend/requests/requestDialogService.js
+++ b/frontend/requests/requestDialogService.js
@@ -77,6 +77,8 @@
                 case REQUEST_PARENT:
                 case REQUEST_CHILDREN:
                     service.showHierarchyDialog(request, event); break;
+                case REQUEST_INSTITUTION:
+                    service.showPendingReqDialog(dialogProperties, event); break;
                 default:
                     dialogProperties.locals.request = request;
                     service.showPendingReqDialog(dialogProperties, event);


### PR DESCRIPTION
**Feature/Bug description:**
It wasn't possible to open dialog when the notification's type was REQUEST_INSTITUTION. It was missing this type in the case inside the function that selects the dialog and the function areInstitutionsValid in invite.js was checking if the institutions were active instead of checking if the institutions weren't inactive.

![screenshot from 2018-07-10 11-32-57](https://user-images.githubusercontent.com/23387866/42517154-71e4925a-8435-11e8-8a75-2a3a76b9e7eb.png)


**Solution:**
I've added this case in the switch case and fixed the function.

![screenshot from 2018-07-10 11-30-00](https://user-images.githubusercontent.com/23387866/42517093-4fe6a9cc-8435-11e8-94c2-1cbf7230bab2.png)


**TODO/FIXME:** n/a