### PR TITLE
Fix show dialog to accept request institution

### DIFF
--- a/frontend/requests/requestDialogService.js
+++ b/frontend/requests/requestDialogService.js
@@ -78,6 +78,7 @@
                 case REQUEST_CHILDREN:
                     service.showHierarchyDialog(request, event); break;
                 case REQUEST_INSTITUTION:
+                    dialogProperties.locals.request = request;
                     service.showPendingReqDialog(dialogProperties, event); break;
                 default:
                     dialogProperties.locals.request = request;


### PR DESCRIPTION
**Feature/Bug description:** When trying to view the dialog processing a request_institution, it is not displayed because the request is not being passed to the controller.

**Solution:** Place the request on the locals variable in the selectDialogToShow function of the RequestDialogService so that it passes the request to the controller.

**TODO/FIXME:** n/a