### PR TITLE
Fix concurrence in the transfer admin queue and remove admin permissions queue

### DIFF
--- a/backend/worker.py
+++ b/backend/worker.py
@@ -390,7 +390,7 @@ class RemoveAdminPermissionsInInstitutionHierarchy(BaseHandler):
         child_admin_key = institution.admin
 
         @ndb.transactional(xg=True, retries=10)
-        def apply_remove_operation(parent_admin, institution, should_remove, child_admin_key, notification_id):
+        def apply_remove_operation(parent_admin, institution, should_remove, child_admin_key):
             """This method is responsible for getting the permissions involved
             in the link and go up in the hierarchy removing the permissions from
             the admins that have to lose it, based in a condition that checks if 
@@ -403,10 +403,9 @@ class RemoveAdminPermissionsInInstitutionHierarchy(BaseHandler):
                         get_all=False, admin_key=current_admin.key)
                     self.removeAdminPermissions(
                         current_admin, permissions)
-            
-            NotificationsQueueManager.resolve_notification_task(notification_id)
 
-        apply_remove_operation(parent_admin, institution, is_not_admin, child_admin_key, notification_id)
+        apply_remove_operation(parent_admin, institution, is_not_admin, child_admin_key)
+        NotificationsQueueManager.resolve_notification_task(notification_id)
 
 
 class SendInviteHandler(BaseHandler):
@@ -478,7 +477,7 @@ class TransferAdminPermissionsHandler(BaseHandler):
         notifications_ids = self.request.get_all('notifications_ids')
         
         @ndb.transactional(xg=True, retries=10)
-        def save_changes(admin, new_admin, institution, notifications_ids):
+        def save_changes(admin, new_admin, institution):
             institution.set_admin(new_admin.key)
             self.add_permissions(new_admin, institution)
             
@@ -492,10 +491,9 @@ class TransferAdminPermissionsHandler(BaseHandler):
             new_admin.put()
             admin.put()
             institution.put()
-
-            map(lambda notification_id: NotificationsQueueManager.resolve_notification_task(notification_id), notifications_ids)
         
-        save_changes(admin, new_admin, institution, notifications_ids)
+        save_changes(admin, new_admin, institution)
+        map(lambda notification_id: NotificationsQueueManager.resolve_notification_task(notification_id), notifications_ids)
 
 
 app = webapp2.WSGIApplication([


### PR DESCRIPTION
**Feature/Bug description:** When both the administrative transfer queue and the remove administrative permissions queue attempt to update the same user, the notification is sent to the user but a concurrency error occurs, and when attempting to do the operation again, the notification has already been resolved and not is in the queue, causing another error because there is no longer any way to send the notification.

**Solution:** Move the NotificationsQueueManager call out of the transaction, so if there is competition error and retry the notification queue is not affected.

**TODO/FIXME:** n/a