### PR TITLE
Fix send invite user adm

### DIFF
--- a/backend/handlers/invite_user_collection_handler.py
+++ b/backend/handlers/invite_user_collection_handler.py
@@ -74,7 +74,7 @@ class InviteUserCollectionHandler(BaseHandler):
                     'invites_keys': json.dumps(invites_keys),
                     'host': host,
                     'current_institution': current_institution_key.urlsafe(),
-                    'notification_id': notification_id
+                    'notifications_ids': [notification_id]
                 }
             )
 

--- a/backend/test/invite_handlers_tests/invite_user_collection_handler_test.py
+++ b/backend/test/invite_handlers_tests/invite_user_collection_handler_test.py
@@ -92,7 +92,7 @@ class InviteUserCollectionHandlerTest(TestBaseHandler):
                 'invites_keys': json.dumps([invite.key.urlsafe()]), 
                 'host': response.request.host,
                 'current_institution': institution.key.urlsafe(),
-                'notification_id': 'some_notification_id'
+                'notifications_ids': ['some_notification_id']
             }
         )
 

--- a/backend/test/worker_handlers_tests/send_invite_handler_test.py
+++ b/backend/test/worker_handlers_tests/send_invite_handler_test.py
@@ -49,7 +49,7 @@ class SendInviteHandlerTest(TestBaseHandler):
             second_invite.key.urlsafe()
         ]
 
-        request_url = '/api/queue/send-invite?invites_keys=%s&host=%s&current_institution=%s&notification_id=%s' % (
+        request_url = '/api/queue/send-invite?invites_keys=%s&host=%s&current_institution=%s&notifications_ids=%s' % (
             json.dumps(invites_keys), host, institution.key.urlsafe(), notification_id)
 
         self.testapp.post(request_url)

--- a/backend/worker.py
+++ b/backend/worker.py
@@ -421,8 +421,8 @@ class SendInviteHandler(BaseHandler):
             invite = ndb.Key(urlsafe=key).get()
             invite.send_invite(host, current_institution)
 
-        notification_id = self.request.get('notification_id')
-        NotificationsQueueManager.resolve_notification_task(notification_id)
+        notifications_ids = self.request.get_all('notifications_ids', [])
+        map(lambda notification_id: NotificationsQueueManager.resolve_notification_task(notification_id), notifications_ids)
 
 class TransferAdminPermissionsHandler(BaseHandler):
     """Handler of transfer admin permissions."""


### PR DESCRIPTION
**Feature/Bug description:** When attempting to create an invitation of type invite_user_adm, there is an error in the send-invites queue causing multiple notifications to be sent unnecessarily, this is because this queue expects that the id of a notification that is not sent, will be sent to it.

**Solution:** Make it optional to send the notification id to the send-invites queue.

**TODO/FIXME:** n/a