### PR TITLE
Fixing the layout of events timeline

### DIFF
--- a/frontend/event/event.html
+++ b/frontend/event/event.html
@@ -1,4 +1,4 @@
-<div flex="100" layout="row" layout-align="center">
+<div class="container-resp">
   <div flex flex-md="95" layout="row" layout-align="space-around"
       md-colors="{background: 'grey-50'}">
     <div flex flex-gt-md="100" layout-align="center top" layout="row">
@@ -31,7 +31,7 @@
               <h4>Nenhum evento a ser exibido.</h4>
             </md-content>
         </md-card>
-        <md-content flex id="content" class="body custom-scrollbar container-resp box">
+        <md-content id="content" class="body custom-scrollbar box">
           <div ng-repeat="event in eventCtrl.events | orderBy:'start_time'" ng-if="eventCtrl.events.length > 0"
               style="margin-left: 65px; border-left: 2px solid #8BC34A;" layut="colum">
             <div layout="row">
@@ -42,9 +42,9 @@
                   <md-icon>share</md-icon>
                 </md-button>
               </div>
-              <div flex class="container-resp" style="margin-left: -22px;">
-                <md-card>
-                    <event-details class="box" event="event" posts="eventCtrl.posts" is-event-page=false></event-details>
+              <div class="box" style="margin-left: -22px;">
+                <md-card >
+                    <event-details event="event" posts="eventCtrl.posts" is-event-page=false></event-details>
                 </md-card>
               </div>
             </div>


### PR DESCRIPTION
**Feature/Bug description:** The width of event card in timeline of events are according by the size of institution name.
![screenshot_2018-10-03_16-18-03](https://user-images.githubusercontent.com/20300259/46433917-77f58b00-c728-11e8-87a5-450834a3ca1e.png)
![screenshot_2018-10-03_16-16-41](https://user-images.githubusercontent.com/20300259/46433924-7c21a880-c728-11e8-92e1-c0654762087d.png)

**Solution:** Applying the correct flexbox in design to show the cards of event correctly.
![screenshot_2018-10-03_16-17-37](https://user-images.githubusercontent.com/20300259/46433975-9fe4ee80-c728-11e8-831e-fff732b21915.png)
![screenshot_2018-10-03_16-17-10](https://user-images.githubusercontent.com/20300259/46433980-a2dfdf00-c728-11e8-988a-14417d783a47.png)

**TODO/FIXME:** n/a