### PR TITLE
Fix cancel edit post

### DIFF
--- a/frontend/post/postDirective.js
+++ b/frontend/post/postDirective.js
@@ -317,7 +317,7 @@
         postCtrl.cancelDialog = function() {
             postCtrl.clearPost();
             SubmitFormListenerService.unobserve("postCtrl.post");
-            $mdDialog.hide();
+            $mdDialog.cancel();
         };
 
         postCtrl.showButton = function() {

--- a/frontend/test/specs/post/postDirectiveSpec.js
+++ b/frontend/test/specs/post/postDirectiveSpec.js
@@ -112,10 +112,10 @@
     });
 
     describe('cancelDialog()', function() {
-        it('should call mdDialog.hide()', function() {
-            spyOn(mdDialog, 'hide');
+        it('should call mdDialog.cancel()', function() {
+            spyOn(mdDialog, 'cancel');
             postCtrl.cancelDialog();
-            expect(mdDialog.hide).toHaveBeenCalled();
+            expect(mdDialog.cancel).toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
**Feature/Bug description:** When click to edit a post and then click on edit, an error appears in the console with the second message: cannot read property 'title' of undefined.

**Solution:** Modify the $ mdDialog.hide() call to $ mdDialog.cancel(), so that the edit is canceled.

**TODO/FIXME:** n/a