### PR TITLE
Fix event data visualization

### DIFF
--- a/frontend/test/specs/event/eventDetailsControllerSpec.js
+++ b/frontend/test/specs/event/eventDetailsControllerSpec.js
@@ -166,6 +166,14 @@
             eventCtrl.event = event;
             var result = eventCtrl.endInTheSameDay();
             expect(result).toBeFalsy();
+
+            var startTime = new Date('2018-10-04');
+            var endTime = new Date('2018-10-11');
+            event.start_time = startTime;
+            event.end_time = endTime;
+            eventCtrl.event = event;
+            var result = eventCtrl.endInTheSameDay();
+            expect(result).toBeFalsy();
         });
     });
 


### PR DESCRIPTION
**Feature/Bug description:** When the event start date falls on the same day as the week of the end date, it is not displayed.

**Solution:** Change the way the date is checked.

**TODO/FIXME:** n/a