### PR TITLE
Fix send request invite

### DIFF
--- a/frontend/auth/signupDirective.js
+++ b/frontend/auth/signupDirective.js
@@ -3,7 +3,7 @@
     
     var app = angular.module('app');
     
-    app.controller('SignupController', function(AuthService, $scope) {
+    app.controller('SignupController', function(AuthService, $scope, MessageService) {
         var controller = this;
 
         controller.newUser = {};


### PR DESCRIPTION
**Feature/Bug description:** When you click request invite and fill in the password fields incorrectly, an error in the console appears, warning that the MessageService is not set.

**Solution:** Injecting the MessageService into the SignupController controller

**TODO/FIXME:** n/a