### PR TITLE
Remove app-version from mobiles' screen

### DIFF
--- a/frontend/main/main.html
+++ b/frontend/main/main.html
@@ -56,7 +56,7 @@
   </md-button>
 </div>
 
-<h4 class="md-caption app-version">
+<h4 class="md-caption app-version" hide show-gt-xs>
     {{mainCtrl.APP_VERSION}}
 </h4>
 


### PR DESCRIPTION
**Feature/Bug description:** 
The app-version tag looks weird in mobiles' screens.
**Solution:**
Show it only to screens greater than 600 px.

**TODO/FIXME:** n/a