### PR TITLE
Change package manager bower to yarn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -546,3 +546,4 @@ backend/Pipfile
 
 #Frontend tests
 frontend/test/package-lock.json
+frontend/test/yarn.lock

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
   agent {
     docker {
-      image 'eciis/nodejs-python'
+      image 'eciis/nodejs-python:10'
       args '--group-add staff --user root'
     }
     

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
   agent {
     docker {
-      image 'eciis/nodejs-python:10'
+      image 'eciis/nodejs-python'
       args '--group-add staff --user root'
     }
     

--- a/ecis
+++ b/ecis
@@ -233,13 +233,6 @@ case "$1" in
                     log_message "Node modules already installed"
                 fi
 
-                # if [ ! -e bower_components ]; then
-                #     bower install --allow-root
-                #     catch_error $? "Bower modules installed with success"
-                # else
-                #     log_message "Bower modules already installed"
-                # fi
-
                 echo "=========== Starting to run Fronted Tests ==========="
                 karma start --single-run
             ;;

--- a/ecis
+++ b/ecis
@@ -227,18 +227,18 @@ case "$1" in
                 fi
                 
                 if [ ! -e node_modules ]; then
-                    npm install
+                    yarn add package.json
                     catch_error $? "Node modules installed with success"
                 else
                     log_message "Node modules already installed"
                 fi
 
-                if [ ! -e bower_components ]; then
-                    bower install --allow-root
-                    catch_error $? "Bower modules installed with success"
-                else
-                    log_message "Bower modules already installed"
-                fi
+                # if [ ! -e bower_components ]; then
+                #     bower install --allow-root
+                #     catch_error $? "Bower modules installed with success"
+                # else
+                #     log_message "Bower modules already installed"
+                # fi
 
                 echo "=========== Starting to run Fronted Tests ==========="
                 karma start --single-run

--- a/frontend/test/package.json
+++ b/frontend/test/package.json
@@ -4,10 +4,11 @@
     "angular": "1.6.4",
     "angular-animate": "1.6.4",
     "angular-aria": "1.6.4",
+    "angular-material": "1.1.5",
     "angular-messages": "1.6.4",
     "angular-mocks": "1.6.4",
+    "angular-moment": "1.0.1",
     "angular-sanitize": "1.6.4",
-    "angular-material": "1.1.5",
     "angularfire": "^2.3.0",
     "crypto-js": "^3.1.9-1",
     "jasmine": "2.99.0",
@@ -20,10 +21,18 @@
     "karma-spec-reporter": "0.0.31",
     "lodash": "^4.17.4",
     "mockfirebase": "^0.12.0",
-    "moment-js": "^1.1.15",
-    "angular-moment": "1.0.1"
+    "moment-js": "^1.1.15"
   },
   "dependencies": {
-    "moment": "^2.18.1"
+    "@bower_components/moment": "moment/moment#^2.18.1",
+    "@bower_components/ngMask": "candreoliveira/ngMask#^3.1.1",
+    "moment": "^2.18.1",
+    "package.json": "^2.0.1"
+  },
+  "engines": {
+    "yarn": ">= 1.0.0"
+  },
+  "scripts": {
+    "postinstall": "node -e \"try { require('fs').symlinkSync(require('path').resolve('node_modules/@bower_components'), 'bower_components', 'junction') } catch (e) { }\""
   }
 }


### PR DESCRIPTION
**Feature/Bug description:** The bower package manager was decoupled and replaced with yarn

**Solution:** Update how to run the frontend tests so that you use yarn.

**TODO/FIXME:** n/a