### PR TITLE
Create option to run with datastore emulator

### DIFF
--- a/ecis
+++ b/ecis
@@ -213,11 +213,14 @@ case "$1" in
         set_support_url local $SUPPORT_LOCAL
         set_frontend_url local $FRONTEND_LOCAL
 
-        gcloud beta emulators datastore start --host-port=0.0.0.0:8586 &
-        $(gcloud beta emulators datastore env-init)
-
-        dev_appserver.py $APP_YAML $FRONTEND_YAML $BACKEND_YAML $SUPPORT_YAML $WORKER_YAML -A development-cis --support_datastore_emulator=True $2
-        $(gcloud beta emulators datastore env-unset)
+        if [[ -n $2 ]] && [ $2 = "--enable_datastore_emulator" ] ; then
+            gcloud beta emulators datastore start --host-port=0.0.0.0:8586 &
+            $(gcloud beta emulators datastore env-init)
+            dev_appserver.py $APP_YAML $FRONTEND_YAML $BACKEND_YAML $SUPPORT_YAML $WORKER_YAML -A development-cis --support_datastore_emulator=True $3
+            $(gcloud beta emulators datastore env-unset)
+        else
+            dev_appserver.py $APP_YAML $FRONTEND_YAML $BACKEND_YAML $SUPPORT_YAML $WORKER_YAML -A development-cis $2
+        fi
     ;;
 
     test)

--- a/ecis
+++ b/ecis
@@ -215,12 +215,16 @@ case "$1" in
 
         if [[ -n $2 ]] && [ $2 = "--enable_datastore_emulator" ] ; then
             gcloud beta emulators datastore start --host-port=0.0.0.0:8586 &
-            $(gcloud beta emulators datastore env-init)
-            dev_appserver.py $APP_YAML $FRONTEND_YAML $BACKEND_YAML $SUPPORT_YAML $WORKER_YAML -A development-cis --support_datastore_emulator=True $3
-            $(gcloud beta emulators datastore env-unset)
+            emulator=True
+            other_parameter=$3
         else
-            dev_appserver.py $APP_YAML $FRONTEND_YAML $BACKEND_YAML $SUPPORT_YAML $WORKER_YAML -A development-cis $2
+            other_parameter=$2
+            emulator=False
         fi
+
+        $(gcloud beta emulators datastore env-init)
+        dev_appserver.py $APP_YAML $FRONTEND_YAML $BACKEND_YAML $SUPPORT_YAML $WORKER_YAML -A development-cis --support_datastore_emulator=$emulator $other_parameter
+        $(gcloud beta emulators datastore env-unset)
     ;;
 
     test)


### PR DESCRIPTION
**Feature/Bug description:** When starting the system, the emulator of the datastore was being inhabited by default, which prevented that in machines where the emulator does not correctly work, the system does not start.

**Solution:** Leave the emulator application optional.

**TODO/FIXME:** n/a