### PR TITLE
Fix edit post dialog

### DIFF
--- a/frontend/home/post_dialog.html
+++ b/frontend/home/post_dialog.html
@@ -1,4 +1,4 @@
-<md-dialog class="dialog-transparent-without-shadow">
+<md-dialog class="dialog-transparent-without-shadow" flex-gt-md="50" flex-md="75">
       <div>
         <save-post is-dialog="true" is-editing="controller.isEditing"
           original-post="controller.originalPost">

--- a/frontend/post/save_post.html
+++ b/frontend/post/save_post.html
@@ -1,7 +1,7 @@
-<md-card class="create-post-container-resp create-post-margin">
+<md-card class="create-post-container-resp">
     <form name="saveForm" prevent-state-change="postCtrl.post"
           ng-submit="postCtrl.save(isEditing, originalPost, saveForm)">
-    <div >
+    <div>
       <md-card-content layout="row" layout-padding>
         <div>
           <img ng-src="{{ postCtrl.getInstPhotoUrl()}}"

--- a/frontend/styles/custom.css
+++ b/frontend/styles/custom.css
@@ -893,8 +893,13 @@ md-radio-button.md-default-theme.md-checked .md-off, md-radio-button.md-checked 
 .dialog-transparent-without-shadow {
     background-color: rgba(0, 0, 0, 0);
     box-shadow: 0 0 0;
-    max-width: 100% !important;
-    max-height: 97% !important;
+}
+
+@media screen and (max-width: 960px) {
+    .dialog-transparent-without-shadow {
+        max-width: 100%;
+        max-height: 97%;
+    }
 }
 
 .share-post{


### PR DESCRIPTION
**Feature/Bug description:**
It was missing some flexs and the dialog-transparent-without-shadow class was applying some properties to all screens but it should only to small screen.
**Solution:**
Add the missing flexs and a media queria to add the properties only to the small screens.

![screenshot from 2018-11-14 14-54-52](https://user-images.githubusercontent.com/23387866/48502042-6b7f4a80-e81d-11e8-8afe-a6a52bbc47a2.png)


**TODO/FIXME:** n/a