### PR TITLE
Fix notification's icon

### DIFF
--- a/frontend/notification/notifications_list.css
+++ b/frontend/notification/notifications_list.css
@@ -1,4 +1,5 @@
 .notification-icon {
+    font-size: 20px;
     color:white;
     line-height: 24px;
     text-align: center;
@@ -6,12 +7,12 @@
 
 .notification-icon-bg {
     background: #009688; 
-    width: 2.3em; 
-    height: 2.3em; 
+    width: 2em; 
+    height: 2em; 
     border-radius: 50%;
     align-self: center;
     text-align: center;
-    line-height: 2.3em;
+    line-height: 2em;
 }
 
 .unread-notification {

--- a/frontend/notification/notifications_list.css
+++ b/frontend/notification/notifications_list.css
@@ -1,15 +1,17 @@
 .notification-icon {
-    font-size: 20px; 
     color:white;
+    line-height: 24px;
+    text-align: center;
 }
 
 .notification-icon-bg {
     background: #009688; 
-    width: 1.3em; 
-    height: 1.3em; 
-    padding: 0.25em; 
+    width: 2.3em; 
+    height: 2.3em; 
     border-radius: 50%;
     align-self: center;
+    text-align: center;
+    line-height: 2.3em;
 }
 
 .unread-notification {


### PR DESCRIPTION
**Feature/Bug description:**
The icon wasn't centralized
**Solution:**
Fix the icon's classes.

![screenshot from 2018-11-14 15-37-17](https://user-images.githubusercontent.com/23387866/48504364-560d1f00-e823-11e8-90d3-dffa11237cbf.png)


**TODO/FIXME:** n/a