### PR TITLE
Fixing the event page layout #

### DIFF
--- a/frontend/event/event_details_small_page.html
+++ b/frontend/event/event_details_small_page.html
@@ -1,5 +1,5 @@
 <div class="event-content">
-    <div style="background-color: white;">
+    <div style="background-color: white;" class="box">
         <div class="title-container">
             <span>{{ eventDetailsCtrl.event.title | uppercase}}</span>
             <md-menu id="menu-button" md-offset="-165 45">


### PR DESCRIPTION
**Feature/Bug description:** 
Issue #1347
The event page layout is not correct in mobile screens with width bigger than 320px or event without an image.
![selection_011](https://user-images.githubusercontent.com/20300259/49380129-9f001700-f6ef-11e8-8ffb-0f804a69a465.png)

**Solution:** Adding a class box solve the problem.
![selection_012](https://user-images.githubusercontent.com/20300259/49380133-a2939e00-f6ef-11e8-92ce-20583abdd9d4.png)



**TODO/FIXME:** n/a