### PR TITLE
Fix event test

### DIFF
--- a/frontend/test/specs/event/eventDialogCtrlSpec.js
+++ b/frontend/test/specs/event/eventDialogCtrlSpec.js
@@ -468,9 +468,10 @@
       it('should set the hours of start time', () => {
         controller.event.start_time = new Date(2018, 12, 12);
         controller.createInitDate();
-        controller.startHour = new Date(2018,12,12, 9, 55);
+        controller.startHour = undefined;
         expect(controller.event.start_time.getHours()).not.toEqual(9);
         expect(controller.event.start_time.getMinutes()).not.toEqual(55);
+        controller.startHour = new Date(2018,12,12, 9, 55);
         controller.addStartHour();
         expect(controller.event.start_time.getHours()).toEqual(9);
         expect(controller.event.start_time.getMinutes()).toEqual(55);


### PR DESCRIPTION
**Feature/Bug description:** ...
Bug maybe caused by test lifecycle.
Probably `startHour` was defined when it shouldn't.
**Solution:** 
Make sure statHour is defined only when it should be.

**TODO/FIXME:** n/a