### PR TITLE
Fix bug on management institution options

### DIFF
--- a/frontend/sideMenu/factories/homeItems.factory.js
+++ b/frontend/sideMenu/factories/homeItems.factory.js
@@ -25,7 +25,7 @@
         };
 
         factory.getItems = user => {
-            const institutionKey = user.current_institution.key;
+            const getInstitutionKey = () => user.current_institution.key;
             const isNotMobileScreen = !Utils.isMobileScreen(600);
             return [
                 {
@@ -61,21 +61,21 @@
                     showIf: () => user.isAdminOfCurrentInst(),
                     sectionTitle: 'INSTITUIÇÃO',
                     topDivider: true,
-                    onClick: () => $state.go(STATES.MANAGE_INST_EDIT, {institutionKey}),
+                    onClick: () => $state.go(STATES.MANAGE_INST_EDIT, {institutionKey: getInstitutionKey()}),
                 },
                 {
                     icon: 'account_circle',
                     description: 'Gerenciar Membros',
                     stateName: 'MANAGE_INST_MEMBERS',
                     showIf: () => user.isAdminOfCurrentInst() && isNotMobileScreen,
-                    onClick: () => $state.go(STATES.MANAGE_INST_MEMBERS, {institutionKey}),
+                    onClick: () => $state.go(STATES.MANAGE_INST_MEMBERS, {institutionKey: getInstitutionKey()}),
                 },
                 {
                     icon: 'account_balance',
                     description: 'Vínculos Institucionais',
                     stateName: 'MANAGE_INST_INVITE_INST',
                     showIf: () => user.isAdminOfCurrentInst() && isNotMobileScreen,
-                    onClick: () => $state.go(STATES.MANAGE_INST_INVITE_INST, {institutionKey}),
+                    onClick: () => $state.go(STATES.MANAGE_INST_INVITE_INST, {institutionKey: getInstitutionKey()}),
                 },
                 {
                     icon: 'account_balance',


### PR DESCRIPTION
**Feature/Bug description:** On the home page, when the user changes the current institution and clicks on one of the management institution options, the corresponding management page is loaded with the key of the previous institution. That was occurring because the HomeItemsFactory was using a constant to save the current institution key, so when the user changes its current institution this value is not updated. Hence, the functions that redirect to the institution management page were using the previous institution key.

**Solution:** It was created a function to return the current institution key;

**TODO/FIXME:** n/a