### PR TITLE
Fix page reload when a new link is established

### DIFF
--- a/frontend/main/mainController.js
+++ b/frontend/main/mainController.js
@@ -141,8 +141,6 @@
 
         mainCtrl.refreshUser = function refreshUser() {
             AuthService.reload();
-            $state.reload();
-            $window.location.reload();
         };
 
         /** Return correct class according currently state.

--- a/frontend/test/specs/event/eventDialogCtrlSpec.js
+++ b/frontend/test/specs/event/eventDialogCtrlSpec.js
@@ -467,8 +467,8 @@
     describe('addStartHour()', () => {
       it('should set the hours of start time', () => {
         controller.event.start_time = new Date(2018, 12, 12);
-        controller.createInitDate();
         controller.startHour = undefined;
+        controller.createInitDate();
         expect(controller.event.start_time.getHours()).not.toEqual(9);
         expect(controller.event.start_time.getMinutes()).not.toEqual(55);
         controller.startHour = new Date(2018,12,12, 9, 55);

--- a/frontend/test/specs/main/mainControllerSpec.js
+++ b/frontend/test/specs/main/mainControllerSpec.js
@@ -208,4 +208,12 @@
             expect(authService.reload).not.toHaveBeenCalled();
         });
     });
+
+    describe('refreshUser', () => {
+        it('should call reload()', () => {
+            spyOn(authService, 'reload');
+            mainCtrl.refreshUser();
+            expect(authService.reload).toHaveBeenCalled();
+        });
+    });
 }));


### PR DESCRIPTION
**Feature/Bug description:**
fixes #1401 
The page was being reloaded when a new link was established

**Solution:**
Remove some unnecessary reloads, like $state.reload(), that was at mainCtrl.refreshUser.

**TODO/FIXME:** n/a