### PR TITLE
Fix scrollbar on firefox to have ecis colors and thin width

### DIFF
--- a/frontend/styles/custom.css
+++ b/frontend/styles/custom.css
@@ -602,6 +602,11 @@ a:active {
     background: #009688
 }
 
+.custom-scrollbar {
+    scrollbar-color: #009688 #ccc;
+    scrollbar-width: thin;
+}
+
 .card-title-light {
     font-family: 'Roboto', sans-serif;
     font-size: 15px;


### PR DESCRIPTION
**Feature/Bug description:** On firefox, the scrollbar is not defined as in other browsers, therefore, the custom ecis scrollbar does not render the way it should be.

**Solution:** Add firefox scrollbar definition.

**TODO/FIXME:** n/a