### PR TITLE
Fix institutional edit dialog

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
   <base href="/" />
 
   <title>Plataforma CIS</title>
-  
+
   <!--Favicon-->
   <link rel="shortcut icon" type="image/icon" href="app/favicon.ico" />
 
@@ -29,7 +29,7 @@
   <meta name="msapplication-TileImage" content="app/images/icons/cis-64x64.png">
   <meta name="msapplication-TileColor" content="#2F3BA2">
   <meta name="theme-color" content="#009688"/>
-  
+
   <!-- ngScrollbar style sheet -->
   <link rel="stylesheet" href="app/libs/jquery.mCustomScrollbar.css"/>
 
@@ -38,6 +38,7 @@
   <link rel="stylesheet" type="text/css" href="app/notification/notifications_list.css">
   <link rel="stylesheet" type="text/css" href="app/notification/notification_button.css">
   <link rel="stylesheet" type="text/css" href="app/user/config-profile.css">
+  <link rel="stylesheet" type="text/css" href="app/user/edit_profile.css">
   <link rel="stylesheet" type="text/css" href="app/user/userInactive/user_inactive.css">
   <link rel="stylesheet" type="text/css" href="app/user/searchInstitution/search_institution.css">
   <link rel="stylesheet" type="text/css" href="app/event/event.css">
@@ -58,17 +59,17 @@
   <link rel="stylesheet" type="text/css" href="app/sideMenu/side_menu.css">
   <link rel="stylesheet" type="text/css" href="app/institution/institutionalLinks/institutional_links_mobile.css">
   <link rel="stylesheet" type="text/css" href="app/institution/institutionalLinks/instLinks/inst_links.css">
-  
+
 </head>
 <body ng-app="app" ng-cloak layout="column">
 
   <div flex class="content-main" layout="column" ui-view="main"></div>
 
-  <script> 
+  <script>
     var $buoop = {notify:{i:14,f:-4,o:-4,s:-2,c:-4},insecure:true,api:5,noclose:true,l:"pt-br"};
-    function $buo_f(){ 
-     var e = document.createElement("script"); 
-     e.src = "//browser-update.org/update.min.js"; 
+    function $buo_f(){
+     var e = document.createElement("script");
+     e.src = "//browser-update.org/update.min.js";
      document.body.appendChild(e);
     };
     try {document.addEventListener("DOMContentLoaded", $buo_f,false)}
@@ -144,7 +145,7 @@
   <script src="app/sideMenu/factories/homeItems.factory.js"></script>
   <script src="app/sideMenu/factories/manageInstItems.factory.js"></script>
   <script src="app/sideMenu/sideMenuItem/sideMenuItem.component.js"></script>
-  
+
   <!--Utils-->
   <script src="app/utils/utils.js"></script>
   <script src="app/utils/messageService.js"></script>

--- a/frontend/user/edit_profile.html
+++ b/frontend/user/edit_profile.html
@@ -1,4 +1,4 @@
-<md-dialog flex-gt-md="25" flex-md="40" flex-gt-sm="50" flex-sm="50" flex-xs="100" id="dialog-response">
+<md-dialog flex-gt-md="35" flex-md="40" flex-gt-sm="50" flex-sm="50" flex-xs="100" id="dialog-response">
     <md-dialog-content layout="column" class="custom-scrollbar" style="padding:0;">
         <div class="card hovercard" id="cardhover-edit-profile" md-colors="{background: 'default-teal-600'}">
             <div layout="row" layout-align="end">


### PR DESCRIPTION
**Feature/Bug description:** Dialog of edit Institutional link is not looking good. Some css style crashed.

**Solution:** Add edit_profile.css back to index.html, fixes #1394.

Also the dialog looked to thin on high res desktops:
<img width="1246" alt="captura de tela 2019-01-31 as 15 40 09" src="https://user-images.githubusercontent.com/39133539/52077609-521eac80-2589-11e9-9dd1-3250ab0eb438.png">

This is also fixed:
<img width="837" alt="captura de tela 2019-01-31 as 15 40 01" src="https://user-images.githubusercontent.com/39133539/52077627-5ea30500-2589-11e9-896b-e326991d6149.png">

**TODO/FIXME:** n/a