### PR TITLE
Fix right side panel on high res screens

### DIFF
--- a/frontend/home/home.html
+++ b/frontend/home/home.html
@@ -3,7 +3,7 @@
       md-colors="{background: 'grey-50'}">
 
     <!-- CONTENT -->
-    <div flex flex-gt-md="70" layout-align="center top" layout="row">
+    <div flex flex-gt-md="65" layout-align="center top" layout="row">
       <div flex layout="column">
         <div>
           <save-post is-dialog="false" hide show-gt-sm></save-post>
@@ -19,7 +19,7 @@
     </div>
 
     <!-- RIGHT SIDE PANEL -->
-    <md-content class="hide-scrollbar" flex-gt-md="25" hide show-gt-md>
+    <md-content class="hide-scrollbar" flex-gt-md="30" hide show-gt-md>
         <div layout="column">
           <md-card style="margin-bottom: 50px;">
             <md-toolbar md-colors="{background: 'teal-600'}" layout="row">

--- a/frontend/home/home.html
+++ b/frontend/home/home.html
@@ -70,7 +70,7 @@
               </div>
             </md-toolbar>
             <md-card-content layout-padding>
-              <md-grid-list md-cols="4" md-row-height="1:1" md-gutter="4px">
+              <md-grid-list md-cols="4" md-row-height="1:1">
                 <md-grid-tile
                   ng-repeat="inst in homeCtrl.followingInstitutions | limitTo: 8"
                   md-colspan="1" md-rowspan="1" class="clickable-no-hover">

--- a/frontend/main/main.css
+++ b/frontend/main/main.css
@@ -81,3 +81,9 @@
         display: none;
     }
 }
+
+@media screen and (min-width: 1280px) {
+  .feedback-btn {
+    right: 0;
+  }
+}

--- a/frontend/styles/custom.css
+++ b/frontend/styles/custom.css
@@ -9,7 +9,7 @@
     .fill-screen {
         min-height: 0;
     }
-} 
+}
 
 .card {
     padding-top: 20px;
@@ -96,10 +96,10 @@
 }
 
 .inst-desc p {
-    text-overflow: ellipsis; 
+    text-overflow: ellipsis;
     white-space: nowrap;
-    width: 100%; 
-    margin: 0; 
+    width: 100%;
+    margin: 0;
     overflow: hidden;
 }
 
@@ -195,7 +195,7 @@
 }
 
 .text {
-    word-wrap: break-word; 
+    word-wrap: break-word;
     text-align: left;
     white-space: pre-line;
   }
@@ -345,7 +345,7 @@ a:active {
     0% {
       opacity: 0;
     }
-  
+
     60% {
       opacity: 1;
     }
@@ -614,13 +614,16 @@ a:active {
 }
 
 .rounded-circle {
-    margin-right: 10px;
     width: 45px;
     height: 45px;
     -webkit-border-radius: 50%;
     -moz-border-radius: 50%;
     border-radius: 50%;
     box-shadow: 0 0 1px 0px grey;
+}
+
+.rounded-circle.event-date {
+  margin-right: 10px;
 }
 
 .grey-circle {
@@ -920,10 +923,10 @@ md-radio-button.md-default-theme.md-checked .md-off, md-radio-button.md-checked 
 }
 
 .notifications-menu {
-    overflow-y: hidden; 
-    padding: 1rem 1rem 0 1rem; 
-    max-height: 30rem; 
-    max-width: 25rem; 
+    overflow-y: hidden;
+    padding: 1rem 1rem 0 1rem;
+    max-height: 30rem;
+    max-width: 25rem;
 }
 
 .grey-background {
@@ -961,11 +964,11 @@ md-input-container:not(.md-input-invalid).md-input-has-value .inputEmail {
 }
 
 .status-invite-adm {
-    border: solid; 
-    height: 35px; 
+    border: solid;
+    height: 35px;
     width: 148px;
-    text-align: center; 
-    border-color: rgb(0, 150, 136); 
+    text-align: center;
+    border-color: rgb(0, 150, 136);
     border-radius: 3px;
     font-weight: bold;
 }
@@ -1021,17 +1024,17 @@ md-input-container:not(.md-input-invalid).md-input-has-value .inputEmail {
 
 .inst-card-cover {
     height: 145px;
-    width: 100%; 
-    background-position: 50% 0%; 
-    background-size:cover; 
+    width: 100%;
+    background-position: 50% 0%;
+    background-size:cover;
     margin-bottom: 20px;
     box-shadow: 0px 0px 20px grey;
 }
 
 .small-text-share-post {
-    text-overflow: ellipsis; 
-    overflow: hidden; 
-    white-space: nowrap; 
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
     width: 100%;
 }
 
@@ -1048,14 +1051,14 @@ md-input-container:not(.md-input-invalid).md-input-has-value .inputEmail {
 }
 
 .hollow-button {
-    border: solid; 
-    height: 35px; 
+    border: solid;
+    height: 35px;
     width: 148px;
-    text-align: center; 
-    border-color: rgb(0, 150, 136); 
+    text-align: center;
+    border-color: rgb(0, 150, 136);
     border-radius: 3px;
     font-weight: bold;
-    line-height: 21px; 
+    line-height: 21px;
     padding: 5px;
 }
 


### PR DESCRIPTION
**Feature/Bug description:** Right side panel looked squeezed on high res desktops:
<img width="1266" alt="captura de tela 2019-01-31 as 16 31 53" src="https://user-images.githubusercontent.com/39133539/52081954-6e274b80-2593-11e9-8587-162d6f532ce4.png">

Round buttons would be also squeezed on first load, increasing in size after being hovered on:
![ecis](https://user-images.githubusercontent.com/39133539/52082676-5a7ce480-2595-11e9-8830-102379453d0a.gif)

Feedback button got on top of clickable elements:
<img width="369" alt="captura de tela 2019-01-31 as 17 54 03" src="https://user-images.githubusercontent.com/39133539/52085331-26f18880-259c-11e9-8d53-7f54b4997a32.png">


**Solution:** 
* Increase right side panel width and decrease content width
* Remove margin on institutions round buttons
* Move feedback button


**TODO/FIXME:** n/a