### PR TITLE
Change image crop dialog to match design spec

### DIFF
--- a/frontend/imageUpload/crop_image.css
+++ b/frontend/imageUpload/crop_image.css
@@ -1,0 +1,38 @@
+#crop-dialog {
+  display: grid;
+  padding: 1em;
+  grid-template-rows: 10% 1fr auto;
+}
+
+#crop-dialog-buttons {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: min-content;
+  justify-content: end;
+}
+
+.crop-dialog-button {
+  color: #009688;
+  min-width: 1%;
+  font-weight: 500;
+  font-size: 0.7em;
+}
+
+.crop-dialog-title {
+  font-size: 1em;
+  justify-self: center;
+  align-self: center;
+}
+
+.crop-dialog-area {
+  width: 100%;
+  height: 50vh;
+  background: #E4E4E4;
+  overflow: hidden;
+}
+
+@media screen and (max-width: 767px) {
+  .crop-dialog-area {
+    height: 40vh;
+  }
+}

--- a/frontend/imageUpload/crop_image.html
+++ b/frontend/imageUpload/crop_image.html
@@ -1,26 +1,21 @@
-<md-dialog flex flex-gt-md="50" layout="row">
-  <md-card flex="100">
-    <md-card-header>
-      <md-card-header-text>
-        <span class="md-title">Selecione a área a ser exibida.</span>
-      </md-card-header-text>
-      <md-button class="md-icon-button" ng-click="cropImgCtrl.cancelCrop()">
-        <md-icon>close</md-icon>
-      </md-button>
-    </md-card-header>
-    <md-card-content layout="column">
-      <div class="cropArea">
+<md-dialog flex flex-xs='90' flex-gt-md='50'>
+  <md-dialog-content>
+    <div id='crop-dialog'>
+      <span class="md-title crop-dialog-title">Adicionar ou alterar imagem</span>
+      <div class="crop-dialog-area">
         <img-crop image="cropImgCtrl.image" result-image="cropImgCtrl.croppedImage"
             result-image-size="cropImgCtrl.resultImgSize" result-image-format="cropImgCtrl.resultImgFormat" 
             area-type="{{cropImgCtrl.areaType}}" style="background-color: #FFFFFF;">
         </img-crop>
       </div>
-    </md-card-content>
-    <md-dialog-actions layout="row">
-      <span flex></span>
-      <md-button class="md-icon-button" ng-click="cropImgCtrl.confirmCrop()">
-        <md-icon>send</md-icon>
-      </md-button>
-    </md-dialog-actions>
-  </md-card>
+      <div id='crop-dialog-buttons'>
+        <md-button class='crop-dialog-button' ng-click="cropImgCtrl.cancelCrop()">
+          CANCELAR
+        </md-button>
+        <md-button class='crop-dialog-button' ng-click="cropImgCtrl.confirmCrop()">
+          CONFIRMAR
+        </md-button>
+      </div>
+    </div>
+  </md-dialog-content>
 </md-dialog>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -62,6 +62,7 @@
   <link rel="stylesheet" type="text/css" href="app/institution/institutionalLinks/institutional_links_mobile.css">
   <link rel="stylesheet" type="text/css" href="app/institution/institutionalLinks/instLinks/inst_links.css">
   <link rel="stylesheet" type="text/css" href="app/user/configProfile/config_profile_mobile.css">
+  <link rel="stylesheet" type="text/css" href="app/imageUpload/crop_image.css">
 </head>
 <body ng-app="app" ng-cloak layout="column">
 

--- a/frontend/styles/custom.css
+++ b/frontend/styles/custom.css
@@ -453,14 +453,6 @@ a:active {
     color: black;
 }
 
-.cropArea {
-    background: #E4E4E4;
-    padding auto auto auto auto;
-    overflow: hidden;
-    max-width:100%;
-    height: 50vh;
-}
-
 .break {
     word-break: break-all;
 }


### PR DESCRIPTION
**Feature/Bug description:** Change image crop dialog to match design spec

<img width="185" alt="captura de tela 2019-02-07 as 10 30 55" src="https://user-images.githubusercontent.com/39133539/52414589-ade2bb80-2adc-11e9-9590-253c8d54e889.png">


**Solution:** 
* Use css grid to structure the dialog in crop_image.html
* Remove cropArea from custom.css
* Add a new crop_image.css

![localhost_8081_ iphone 5_se](https://user-images.githubusercontent.com/39133539/52417569-15503980-2ae4-11e9-9754-a61d55333d95.png)

**TODO/FIXME:** n/a