### PR TITLE
changed add button collor on timeline

### DIFF
--- a/frontend/home/home.html
+++ b/frontend/home/home.html
@@ -97,7 +97,7 @@
 <md-fab-speed-dial id="fab-new-post" class="md-fab-bottom-right" hide-gt-sm>
   <md-fab-trigger>
     <md-button aria-label="menu" class="md-fab md-primary" ng-click="homeCtrl.newPost()"
-        md-colors="{background: 'teal-900'}">
+        md-colors="{background: 'light-green-600'}">
       <md-icon>add</md-icon>
     </md-button>
   </md-fab-trigger>


### PR DESCRIPTION
**Feature/Bug description:** 
Fixes #1434 
Add button on mobile timeline page has wrong green color.
**Solution:** 
change the color to 'light-green-600'

**TODO/FIXME:** 
Some others green colors are not the same.