### PR TITLE
Modified when push notification permission is asked

### DIFF
--- a/frontend/auth/authService.js
+++ b/frontend/auth/authService.js
@@ -130,9 +130,7 @@
                 if (user.emailVerified) {
                     return user.getIdToken(true).then(function(idToken) {
                         return service.setupUser(idToken, user.emailVerified).then(function success(userInfo) {
-                            return PushNotificationService.requestNotificationPermission(service.getCurrentUser()).finally(() => {
-                                return userInfo;
-                            });
+                            return userInfo;
                         });
                     });
                 } else {

--- a/frontend/auth/authService.js
+++ b/frontend/auth/authService.js
@@ -3,8 +3,8 @@
 
     var app = angular.module("app");
 
-    app.service("AuthService", function AuthService($q, $state, $window, UserService, 
-        MessageService, PushNotificationService, STATES) {
+    app.service("AuthService", ['$q', '$state', '$window', 'UserService', 'MessageService', 'STATES',
+        function AuthService($q, $state, $window, UserService, MessageService, STATES) {
         var service = this;
 
         var authObj = firebase.auth();
@@ -257,5 +257,5 @@
         }
 
         init();
-    });
+    }]);
 })();

--- a/frontend/home/homeController.js
+++ b/frontend/home/homeController.js
@@ -4,7 +4,7 @@
     var app = angular.module("app");
 
     app.controller("HomeController", function HomeController(AuthService, $mdDialog, 
-        $state, EventService, ProfileService, $rootScope, POST_EVENTS, STATES) {
+        $state, EventService, ProfileService, $rootScope, POST_EVENTS, STATES, PushNotificationService) {
         var homeCtrl = this;
 
         var LIMITE_EVENTS = 5;
@@ -13,8 +13,6 @@
         homeCtrl.followingInstitutions = [];
         homeCtrl.isLoadingPosts = true;
         homeCtrl.showMessageOfEmptyEvents = true;
-        
-        homeCtrl.user = AuthService.getCurrentUser();
 
         homeCtrl.eventInProgress = function eventInProgress(event) {
             var end_time = event.end_time;
@@ -122,10 +120,12 @@
             $rootScope.$broadcast(eventType, post);
         }
 
-        (function main() {
+        homeCtrl.$onInit = () => {
+            homeCtrl.user = AuthService.getCurrentUser();
             loadEvents();
             getFollowingInstitutions();
             registerPostEvents();
-        })();
+            return PushNotificationService.requestNotificationPermission(homeCtrl.user);
+        };
     });
 })();

--- a/frontend/home/homeController.js
+++ b/frontend/home/homeController.js
@@ -3,8 +3,10 @@
 (function() {
     var app = angular.module("app");
 
-    app.controller("HomeController", function HomeController(AuthService, $mdDialog, 
-        $state, EventService, ProfileService, $rootScope, POST_EVENTS, STATES, PushNotificationService) {
+    app.controller("HomeController", ['AuthService', '$mdDialog', '$state', 'EventService', 'ProfileService', '$rootScope',
+        'PushNotificationService', 'POST_EVENTS', 'STATES',
+        function HomeController(AuthService, $mdDialog, $state, EventService, ProfileService, $rootScope,
+                                PushNotificationService, POST_EVENTS, STATES) {
         var homeCtrl = this;
 
         var LIMITE_EVENTS = 5;
@@ -127,5 +129,5 @@
             registerPostEvents();
             return PushNotificationService.requestNotificationPermission(homeCtrl.user);
         };
-    });
+    }]);
 })();

--- a/frontend/test/specs/home/homeControllerSpec.js
+++ b/frontend/test/specs/home/homeControllerSpec.js
@@ -2,7 +2,7 @@
 
 (describe('Test HomeController', function() {
 
-    let homeCtrl, httpBackend, scope, createCtrl, mdDialog, state, states, http, postService;
+    let homeCtrl, httpBackend, scope, createCtrl, mdDialog, state, states, http, postService, pushNotService;
 
     var institutions = [{
         acronym: 'Certbio',
@@ -35,7 +35,7 @@
     beforeEach(module('app'));
 
     beforeEach(inject(function($controller, $httpBackend, $rootScope,
-            PostService, $mdDialog, $state, AuthService, $http, STATES) {
+            PostService, $mdDialog, $state, AuthService, PushNotificationService, $http, STATES) {
         httpBackend = $httpBackend;
         http = $http;
         scope = $rootScope.$new();
@@ -43,6 +43,7 @@
         state = $state;
         postService = PostService;
         states = STATES;
+        pushNotService = PushNotificationService;
 
         httpBackend.when('GET', "/api/events?page=0&limit=15").respond([event]);
         httpBackend.when('GET', 'main/main.html').respond(200);
@@ -61,11 +62,14 @@
         };
 
         spyOn($rootScope, '$on').and.callThrough();
+        spyOn(pushNotService, 'requestNotificationPermission');
 
         homeCtrl = createCtrl();
+        homeCtrl.$onInit();
         httpBackend.flush();
 
         expect($rootScope.$on).toHaveBeenCalled();
+        expect(pushNotService.requestNotificationPermission).toHaveBeenCalledWith(new User(user));
     }));
 
     afterEach(function() {


### PR DESCRIPTION
**Feature/Bug description:** ...
The Push notification permission was being asked after the user login and blocked the home page to load until the user answer the dialog permission.
But the client chose to allow home page to load. What means that, The push notification permission will be asked on home page after first login.

**Solution:** 
Removed the function that asks the  permission from AuthService to HomeCtrl.