### PR TITLE
Hide scrollbar of the timeline in mobile devices

### DIFF
--- a/frontend/event/events_mobile.html
+++ b/frontend/event/events_mobile.html
@@ -1,6 +1,6 @@
 <main-toolbar toolbar-menu-items="eventCtrl.toolbarItems" toolbar-general-options="eventCtrl.toolbarGeneralOptions"></main-toolbar>
 
-<div style="overflow: scroll">
+<div style="overflow: scroll;" class="custom-scrollbar hide-scrollbar-mobile">
   <div flex layout="column">
     <load-circle flex add-layout-fill="true" ng-if="eventCtrl.isLoadingEvents"></load-circle>
     <div ng-if="!eventCtrl.isLoadingEvents" class="centralized-event-content">
@@ -8,7 +8,7 @@
                      text="Nenhum evento a ser exibido">
       </is-empty-card>
     </div>
-    <md-content id="content" class="custom-scrollbar box">
+    <md-content id="content" class="box">
       <div ng-repeat="events in eventCtrl.eventsByDay"
         ng-if="eventCtrl.events.length > 0" class="events-grid events-grid-position">
           <div class="events-day-position event-day-properties">

--- a/frontend/home/home.html
+++ b/frontend/home/home.html
@@ -10,7 +10,8 @@
         <div>
           <save-post is-dialog="false" hide show-gt-sm></save-post>
         </div>
-        <md-content flex id="content" class="body custom-scrollbar" hide-navbar="top">
+        <md-content flex id="content" class="body custom-scrollbar" hide-navbar="top"
+          ng-class="homeCtrl.isMobileScreen() ? 'hide-scrollbar': ''">
             <div flex layout="row">
                 <post-timeline flex layout="column" institution="false"
                   user="homeCtrl.user"></post-timeline>

--- a/frontend/home/home.html
+++ b/frontend/home/home.html
@@ -10,8 +10,7 @@
         <div>
           <save-post is-dialog="false" hide show-gt-sm></save-post>
         </div>
-        <md-content flex id="content" class="body custom-scrollbar" hide-navbar="top"
-          ng-class="homeCtrl.isMobileScreen() ? 'hide-scrollbar': ''">
+        <md-content flex id="content" class="body custom-scrollbar hide-scrollbar-mobile" hide-navbar="top">
             <div flex layout="row">
                 <post-timeline flex layout="column" institution="false"
                   user="homeCtrl.user"></post-timeline>

--- a/frontend/home/homeController.js
+++ b/frontend/home/homeController.js
@@ -79,6 +79,10 @@
             });
         };
 
+        homeCtrl.isMobileScreen = function isMobileScreen() {
+            return Utils.isMobileScreen(600);
+        };
+
         function getFollowingInstitutions() {
             homeCtrl.followingInstitutions = homeCtrl.user.follows;
         }

--- a/frontend/home/homeController.js
+++ b/frontend/home/homeController.js
@@ -79,10 +79,6 @@
             });
         };
 
-        homeCtrl.isMobileScreen = function isMobileScreen() {
-            return Utils.isMobileScreen(600);
-        };
-
         function getFollowingInstitutions() {
             homeCtrl.followingInstitutions = homeCtrl.user.follows;
         }

--- a/frontend/institution/registered_institutions_mobile.html
+++ b/frontend/institution/registered_institutions_mobile.html
@@ -1,6 +1,6 @@
 <main-toolbar title="INSTITUIÇÕES" sort-by-alpha="true" sort-func="allInstitutionsCtrl.changeOrderParam"></main-toolbar>
 
-<div style="overflow: auto;" id="content">
+<div style="overflow: auto;" id="content" class="hide-scrollbar-mobile">
     <div class="registered-institutions-mobile-top-bar">
         <div ng-click="allInstitutionsCtrl.changeTab('all')">
             <b>TODAS</b>

--- a/frontend/notification/notifications_list_mobile.html
+++ b/frontend/notification/notifications_list_mobile.html
@@ -1,4 +1,4 @@
-<md-content>
+<div>
     <is-empty-card ng-if="notificationListCtrl.notifications.length === 0"
                    text="Nenhuma notificação no momento">
     </is-empty-card>
@@ -26,4 +26,4 @@
             </div>
         </div>
     </div>
-</md-content>
+</div>

--- a/frontend/notification/notifications_page.html
+++ b/frontend/notification/notifications_page.html
@@ -28,7 +28,8 @@
     </md-card>
 </div>
 
-<div ng-if="notificationCtrl.isMobileScreen(600)" style="overflow: scroll">
+<div ng-if="notificationCtrl.isMobileScreen(600)" style="overflow-y: scroll" class="hide-scrollbar-mobile">
     <notification-list notifications="notificationCtrl.notificationsToShow" 
         mark-as-read="notificationCtrl.markAsRead" keyword="notificationCtrl.keyword">
+    </notification-list>
 </div>

--- a/frontend/styles/custom.css
+++ b/frontend/styles/custom.css
@@ -890,6 +890,10 @@ md-radio-button.md-default-theme.md-checked .md-off, md-radio-button.md-checked 
     #post-container {
         margin: 8px 0;
     }
+
+    .hide-scrollbar-mobile::-webkit-scrollbar {
+        display: none;
+    }
 }
 
 @media only screen and (max-width: 450px) {


### PR DESCRIPTION
**Feature/Bug description:** Hide scrollbar of the timeline in mobile devices
fixes #1448 
![localhost_8081_ nexus 5](https://user-images.githubusercontent.com/18005317/52959588-4c8cd900-3375-11e9-9f97-27f428665ed1.png)

**Solution:** Add class hide-scrollbar if is a mobile device.

![localhost_8081_ nexus 5 1](https://user-images.githubusercontent.com/18005317/52959594-50206000-3375-11e9-87db-4f46a6d1f71b.png)

**TODO/FIXME:** n/a