### PR TITLE
Fix delete event redirect to events

### DIFF
--- a/frontend/event/eventDetailsDirective.js
+++ b/frontend/event/eventDetailsDirective.js
@@ -42,6 +42,7 @@
             promise.then(function success() {
                 MessageService.showToast('Evento removido com sucesso!');
                 eventCtrl.event.state = "deleted";
+                $state.go(STATES.EVENTS);
             });
             return promise;
         }

--- a/frontend/institution/edit_registration_data_mobile.css
+++ b/frontend/institution/edit_registration_data_mobile.css
@@ -118,7 +118,7 @@
     font-size: 0.7em;
 }
 
-.edit-registration-select-menu-size, .md-select-menu-container {
+.edit-registration-select-menu-size .md-select-menu-container {
     width: 96%;
 }
 

--- a/frontend/test/specs/event/eventDetailsControllerSpec.js
+++ b/frontend/test/specs/event/eventDetailsControllerSpec.js
@@ -2,7 +2,8 @@
 
 (describe('Test EventDetailsController', function () {
 
-    let eventCtrl, scope, httpBackend, rootScope, deffered, eventService, messageService, mdDialog, state, clipboard, q;
+    let eventCtrl, scope, httpBackend, rootScope, deffered, eventService,
+        messageService, mdDialog, state, clipboard, q, states;
 
     const
         splab = { name: 'Splab', key: '098745' },
@@ -38,7 +39,7 @@
     beforeEach(module('app'));
 
     beforeEach(inject(function ($controller, $httpBackend, $http, $q, AuthService,
-        $rootScope, EventService, MessageService, $mdDialog, $state, ngClipboard) {
+        $rootScope, EventService, MessageService, $mdDialog, $state, ngClipboard, STATES) {
         scope = $rootScope.$new();
         httpBackend = $httpBackend;
         rootScope = $rootScope;
@@ -49,6 +50,7 @@
         state = $state;
         clipboard = ngClipboard;
         q = $q;
+        states = STATES;
         AuthService.login(user);
 
         eventCtrl = $controller('EventDetailsController', {
@@ -74,6 +76,7 @@
     describe('confirmDeleteEvent()', function () {
         beforeEach(function () {
             spyOn(mdDialog, 'confirm').and.callThrough();
+            spyOn(state, 'go').and.callThrough();
             spyOn(mdDialog, 'show').and.callFake(function () {
                 return {
                     then: function (callback) {
@@ -93,6 +96,7 @@
             expect(eventService.deleteEvent).toHaveBeenCalledWith(other_event);
             expect(mdDialog.confirm).toHaveBeenCalled();
             expect(mdDialog.show).toHaveBeenCalled();
+            expect(state.go).toHaveBeenCalledWith(states.EVENTS);
         });
     });
 


### PR DESCRIPTION
**Feature/Bug description:** When cancel the event show toast but not redirect to event pages and class of all md-select was overwritten.
Fixes #1452 
Fixes #1453 
**Solution:** Added state go and fix class of css.

**TODO/FIXME:** n/a

![captura de tela de 2019-02-19 16-39-16](https://user-images.githubusercontent.com/18709274/53043029-4f1b2b80-3466-11e9-8dc0-89292c2d7490.png)
![captura de tela de 2019-02-19 16-37-36](https://user-images.githubusercontent.com/18709274/53043030-4f1b2b80-3466-11e9-8703-4e568898274b.png)
![captura de tela de 2019-02-19 16-37-18](https://user-images.githubusercontent.com/18709274/53043032-4fb3c200-3466-11e9-8c87-56d0a247e8a6.png)
