### PR TITLE
Add last information form for new design invite screen

### DIFF
--- a/frontend/institution/forms/forms.css
+++ b/frontend/institution/forms/forms.css
@@ -47,3 +47,29 @@ address-form #address-form {
   justify-self: center;
   display: grid;
 }
+
+institution-form #institution-form {
+  display: grid;
+  grid-template-rows: auto repeat(7, 1fr);
+  height: 100%;
+  width: 100%;
+}
+
+last-info-form #last-info-form {
+  display: grid;
+  grid-template-rows: 8em 1fr 1fr;
+}
+
+#last-info-form md-input-container#description {
+  max-height: 80%;
+  height: 100%;
+  align-items: center;
+  border: 1px solid;
+  border-color: #ccc;
+  border-radius: 0.4em;
+}
+
+#last-info-form #description textarea {
+  height: 100% !important;
+  border: 0 !important;
+}

--- a/frontend/institution/forms/lastInfoForm.component.js
+++ b/frontend/institution/forms/lastInfoForm.component.js
@@ -1,0 +1,16 @@
+'use strict';
+
+(function () {
+  function LastInfoController() {
+  }
+
+  const app = angular.module('app');
+  app.component('lastInfoForm', {
+    controller: [LastInfoController],
+    controllerAs: 'ctrl',
+    templateUrl: 'app/institution/forms/last_info_form.html',
+    bindings: {
+      institution: '=',
+    }
+  });
+})();

--- a/frontend/institution/forms/last_info_form.html
+++ b/frontend/institution/forms/last_info_form.html
@@ -1,0 +1,25 @@
+<form id="last-info-form" name="lastInfo">
+  <md-input-container id='description'>
+    <!-- Empty label prevents placeholder from becoming a label -->
+    <label></label>
+    <textarea name='description'
+              placeholder='Uma breve descrição sobre sua instituição'
+              md-no-auto-grow
+              md-no-resize
+              ng-model="ctrl.institution.description"
+              maxlength="1100"></textarea>
+  </md-input-container>
+  <md-input-container>
+    <label>Site institucional</label>
+    <input type="text" name="site"
+                       ng-model="ctrl.institution.website_url">
+  </md-input-container>
+  <md-input-container>
+    <label>Nome do atual dirigente máximo</label>
+    <input type="text" name="leader" required
+                       ng-model="ctrl.institution.leader">
+    <div ng-messages='lastInfo.leader.$error'>
+      <div ng-message="required">Este campo é obrigatório!</div>
+    </div>
+  </md-input-container>
+</form>


### PR DESCRIPTION
**Feature/Bug description:** A last info data form component is needed for the new screen on creating an invited institution

**Solution:** Add last information form component for new invite institution screen

![final form](https://user-images.githubusercontent.com/39133539/53243575-3b5b0980-36a0-11e9-9e3b-7d463dfb5e25.gif)

**TODO/FIXME:** n/a