### PR TITLE
Fix is-empty-card component text align

### DIFF
--- a/frontend/utils/is-empty-card/is-empty-card.css
+++ b/frontend/utils/is-empty-card/is-empty-card.css
@@ -22,4 +22,5 @@
     font-weight: bold;
     color: #009688;
     text-align: center;
+    justify-content: center;
 }


### PR DESCRIPTION
**Feature/Bug description:** Fix is-empty-card component text align.

**Solution:** Add justify-content center on css.
- Before:
![localhost_8081_events_institutionkey ahnkzxz-zgv2zwxvcg1lbnqty2lzchglegtjbnn0axr1dglvbhiagicagidgcaw nexus 5 1](https://user-images.githubusercontent.com/38431219/53424070-43c58400-39c1-11e9-8e2e-3a9399e1c236.png)

- After:
![localhost_8081_events_institutionkey ahnkzxz-zgv2zwxvcg1lbnqty2lzchglegtjbnn0axr1dglvbhiagicagidgcaw nexus 5](https://user-images.githubusercontent.com/38431219/53424068-42945700-39c1-11e9-9d28-992c65f2ed0e.png)

**TODO/FIXME:** n/a