### PR TITLE
Fix entityShowcase alligment and margin

### DIFF
--- a/frontend/utils/entityShowcase/entityShowcase.css
+++ b/frontend/utils/entityShowcase/entityShowcase.css
@@ -1,6 +1,6 @@
 .entity-showcase {
     display: grid;
-    grid-template-columns: max-content auto auto;
+    grid-template-columns: max-content auto max-content;
     grid-template-rows: max-content max-content;
     grid-template-areas:
             'avatar title right-icon-buttons'

--- a/frontend/utils/iconButton/iconButton.html
+++ b/frontend/utils/iconButton/iconButton.html
@@ -1,4 +1,4 @@
-<md-button class="no-padding no-margin md-icon-button" ng-click="iconButtonCtrl.action()">
+<md-button class="no-padding" style="margin: 0; padding: 0;" ng-click="iconButtonCtrl.action()">
     <md-icon style="color: {{ iconButtonCtrl.iconColor }}">
         {{ iconButtonCtrl.icon }}
     </md-icon>

--- a/frontend/utils/iconButton/iconButton.html
+++ b/frontend/utils/iconButton/iconButton.html
@@ -1,4 +1,4 @@
-<md-button class="no-padding" style="margin: 0; padding: 0;" ng-click="iconButtonCtrl.action()">
+<md-button class="md-icon-button" style="margin: 0; padding: 0;" ng-click="iconButtonCtrl.action()">
     <md-icon style="color: {{ iconButtonCtrl.iconColor }}">
         {{ iconButtonCtrl.icon }}
     </md-icon>


### PR DESCRIPTION
**Feature/Bug description:** Entity showcase icons were varying according to entity name and no-margin and no-padding classes weren't overwriting material class. Fixes #1492.

**Solution:** Replace auto for max-content on icon grid definition. Also, remove margin and padding in style.

**TODO/FIXME:** n/a