### PR TITLE
Fixed empty poll option on mobile larger screens

### DIFF
--- a/frontend/survey/survey.component.js
+++ b/frontend/survey/survey.component.js
@@ -49,8 +49,8 @@
         /* This method add ids in each option and remove the options that are empty.*/
         function modifyOptions(){
             surveyCtrl.options = surveyCtrl.options
-                .map((option, index) => {option.id = index; return option;})
-                .filter(option => option.text);
+                .filter(option => option.text)
+                .map((option, index) => {option.id = index; return option;});
         }
 
         function formateDate(){

--- a/frontend/survey/survey.component.js
+++ b/frontend/survey/survey.component.js
@@ -46,12 +46,15 @@
             return screen.width < 600;
         };
 
-        /* This method add ids in each option and remove the options that are empty.*/
-        function modifyOptions(){
+        /**
+         * Remove empty objects in the options array and add 'id' property in all objects.
+         * @private
+         */
+        surveyCtrl._processOptions = () => {
             surveyCtrl.options = surveyCtrl.options
                 .filter(option => option.text)
                 .map((option, index) => {option.id = index; return option;});
-        }
+        };
 
         function formateDate(){
             var date = surveyCtrl.post.deadline.toISOString();
@@ -63,7 +66,7 @@
         }
 
         function createSurvey(){
-            modifyOptions();
+            surveyCtrl._processOptions();
             getTypeSurvey();
             surveyCtrl.post.deadline && formateDate();
             surveyCtrl.post.options = surveyCtrl.options;

--- a/frontend/survey/survey.component.js
+++ b/frontend/survey/survey.component.js
@@ -48,8 +48,9 @@
 
         /* This method add ids in each option and remove the options that are empty.*/
         function modifyOptions(){
-            let id = 0;
-            surveyCtrl.options.map(option => option.text ? option.id = id++ : surveyCtrl.removeOption(option));
+            surveyCtrl.options = surveyCtrl.options
+                .map((option, index) => {option.id = index; return option;})
+                .filter(option => option.text);
         }
 
         function formateDate(){

--- a/frontend/test/specs/survey/surveyComponentSpec.js
+++ b/frontend/test/specs/survey/surveyComponentSpec.js
@@ -3,7 +3,7 @@
 (describe('Test SurveyComponent', function() {
     beforeEach(module('app'));
 
-    var surveyCtrl, post, httpBackend, scope, deffered, mdDialog, rootScope, postService, mdToast, http, imageService, createCtrl;
+    var surveyCtrl, post, httpBackend, scope, deffered, mdDialog, rootScope, postService, mdToast, http, imageService;
     var user = {
         name: 'name',
         current_institution: {key: "institutuion_key"},

--- a/frontend/test/specs/survey/surveyComponentSpec.js
+++ b/frontend/test/specs/survey/surveyComponentSpec.js
@@ -3,7 +3,7 @@
 (describe('Test SurveyComponent', function() {
     beforeEach(module('app'));
 
-    var surveyCtrl, post, httpBackend, scope, deffered, mdDialog, rootScope, postService, mdToast, http, imageService;
+    var surveyCtrl, post, httpBackend, scope, deffered, mdDialog, rootScope, postService, mdToast, http, imageService, createCtrl;
     var user = {
         name: 'name',
         current_institution: {key: "institutuion_key"},
@@ -14,6 +14,17 @@
                         'number_votes': 0,
                         'voters': []
                         };
+
+    const unprocessed_options =
+        [{
+            'text': 'Option number 1',
+            'number_votes': 0,
+            'voters': [] },
+        {
+            'text': 'Option number 2',
+            'number_votes': 0,
+            'voters': []
+        }];
 
     var options = [{'id' : 0,
                     'text': 'Option number 1',
@@ -110,6 +121,15 @@
             surveyCtrl.post = new Post(post, {});
             surveyCtrl.resetSurvey();
             expect(surveyCtrl.post).toEqual({});
+        });
+    });
+
+    describe('_processOptions', function() {
+        it('should remove empty options and add "id" property in other options', () => {
+            unprocessed_options.push(option_empty);
+            surveyCtrl.options = unprocessed_options;
+            surveyCtrl._processOptions();
+            expect(surveyCtrl.options).toEqual(options);
         });
     });
 }));


### PR DESCRIPTION
**Feature/Bug description:** 
Fixes #1471 

On mobile larger screens like iphone 6/7/8 plus, polls with only two options fulfilled were posted with the third option empty.
It occurred because the code was removing an object array while was iterating in the same reference.
So what happened, the array contained 5 objects: [{"text"},{"text"},{""},{""},{""}].
Iterating over the array, every time it finds an empty object it was removed, but there were 3 empty equal objects and was the same referenced array.
On third iteration, the index = 2 , empty object removed. result array: [{"text"},{"text"},{""},{""}].
Next iteration, index = 3, so object 4 removed. result array: [{"text"},{"text"},{""}].
Theres no next iteration because theres no object on 4 index. That said, always would last one empty object.

**Bug screenshot**
![image](https://user-images.githubusercontent.com/7011394/53593866-6a79eb00-3b78-11e9-9be6-9ce15801f154.png)


**Solution:** 
Changed the way objects were removed using array.filter();
