### PR TITLE
Center no-events-feedback

### DIFF
--- a/frontend/event/event.css
+++ b/frontend/event/event.css
@@ -141,6 +141,8 @@
 
 .centralized-event-content, .event-day-properties {
     margin: 0;
+    display: flex;
+    justify-content: center;
 }
 
 #menu-button {

--- a/frontend/event/event.css
+++ b/frontend/event/event.css
@@ -141,6 +141,9 @@
 
 .centralized-event-content, .event-day-properties {
     margin: 0;
+}
+
+.centralized-event-content {
     display: flex;
     justify-content: center;
 }


### PR DESCRIPTION
**Feature/Bug description:** No-events feedback wasn't centralized.
Fixes #1507 

**Solution:** Add `display: flex` and `justify-content: center`. 
- Before:
![screenshot from 2019-03-07 10-46-05](https://user-images.githubusercontent.com/38431219/53961445-604f7380-40c7-11e9-8eb7-daf5c37a3968.png)

- After:
![screenshot from 2019-03-07 10-52-25](https://user-images.githubusercontent.com/38431219/53961451-647b9100-40c7-11e9-8b3a-981edcce407c.png)


**TODO/FIXME:** n/a