### PR TITLE
Fix all-day checkbox to not change when having an end date

### DIFF
--- a/frontend/event/eventDialogController.js
+++ b/frontend/event/eventDialogController.js
@@ -365,7 +365,8 @@
             dialogCtrl.startHour = new Date(dialogCtrl.event.start_time);
             dialogCtrl.startHour.setHours(8, 0, 0);
             dialogCtrl.addStartHour();
-            dialogCtrl.event.end_time = new Date(dialogCtrl.event.start_time);
+            dialogCtrl.event.end_time = _.isNil(dialogCtrl.event.end_time) ?
+                new Date(dialogCtrl.event.start_time) : dialogCtrl.event.end_time;
             dialogCtrl.endHour = new Date(dialogCtrl.event.start_time);
             dialogCtrl.endHour.setHours(18, 0, 0);
             dialogCtrl.addEndHour();


### PR DESCRIPTION
**Feature/Bug description:** Fixes #1503 

**Solution:** Add a ternary operator in the attribution of the endDate

**TODO/FIXME:** n/a