### PR TITLE
Fix share dialog

### DIFF
--- a/frontend/event/eventDetailsDirective.js
+++ b/frontend/event/eventDetailsDirective.js
@@ -16,7 +16,10 @@
             $mdDialog.show({
                 controller: "SharePostController",
                 controllerAs: "sharePostCtrl",
-                templateUrl: 'app/post/share_post_dialog.html',
+                templateUrl: Utils.selectFieldBasedOnScreenSize(
+                    'app/post/share_post_dialog.html',
+                    'app/post/share_post_dialog_mobile.html'
+                ),
                 parent: angular.element(document.body),
                 targetEvent: ev,
                 clickOutsideToClose: true,

--- a/frontend/post/postDetailsDirective.js
+++ b/frontend/post/postDetailsDirective.js
@@ -230,7 +230,10 @@
             $mdDialog.show({
                 controller: "SharePostController",
                 controllerAs: "sharePostCtrl",
-                templateUrl: 'app/post/share_post_dialog.html',
+                templateUrl: Utils.selectFieldBasedOnScreenSize(
+                    'app/post/share_post_dialog.html',
+                    'app/post/share_post_dialog_mobile.html'
+                ),
                 parent: angular.element(document.body),
                 targetEvent: event,
                 clickOutsideToClose:true,

--- a/frontend/post/sharePostController.js
+++ b/frontend/post/sharePostController.js
@@ -93,5 +93,11 @@
             }
             return text && text.replace(URL_PATTERN, REPLACE_URL);
         };
+
+        shareCtrl.$onInit = () => {
+            const type = shareCtrl.isEvent() ? 'evento' : 'post';
+            shareCtrl.title = `Compartilhar ${type}`;
+            shareCtrl.subtitle = `Você deseja compartilhar esse ${type}?`;
+        };
     });
 })();

--- a/frontend/post/share_post_dialog_mobile.html
+++ b/frontend/post/share_post_dialog_mobile.html
@@ -1,7 +1,7 @@
 <md-dialog>
     <gen-dialog
-            title="Compartilhar post"
-            subtitle="Você deseja compartilhar esse post?"
+            title=sharePostCtrl.title
+            subtitle=sharePostCtrl.subtitle
             confirm-action="sharePostCtrl.share">
     </gen-dialog>
 </md-dialog>

--- a/frontend/post/share_post_dialog_mobile.html
+++ b/frontend/post/share_post_dialog_mobile.html
@@ -1,0 +1,7 @@
+<md-dialog>
+    <gen-dialog
+            title="Compartilhar post"
+            subtitle="Você deseja compartilhar esse post?"
+            confirm-action="sharePostCtrl.share">
+    </gen-dialog>
+</md-dialog>


### PR DESCRIPTION
**Feature/Bug description:** Fix share dialog on event and on post.
Fixes #1502 


**Solution:** Create a new dialog template file that uses gen-dialog component.
- Before:
1. Post:
![localhost_8081_ nexus 5 4](https://user-images.githubusercontent.com/38431219/54030201-96552c00-4189-11e9-9461-1c775dd5e088.png)

2. Event:
![localhost_8081_ nexus 5 5](https://user-images.githubusercontent.com/38431219/54030218-a2d98480-4189-11e9-9a99-bef46449314a.png)


- After:
1. Post:
![localhost_8081_ nexus 5 3](https://user-images.githubusercontent.com/38431219/54030113-555d1780-4189-11e9-8d8b-26ea0b0d053a.png)

2. Event:
![localhost_8081_ nexus 5 2](https://user-images.githubusercontent.com/38431219/54030102-4bd3af80-4189-11e9-9153-93be9af09420.png)


**TODO/FIXME:** n/a