### PR TITLE
Fix InstitutionControllerSpec

### DIFF
--- a/frontend/test/specs/institution/institutionControllerSpec.js
+++ b/frontend/test/specs/institution/institutionControllerSpec.js
@@ -260,7 +260,7 @@
                 spyOn(utilsService, 'selectNavOption');
                 institutionCtrl.goToEvents(first_institution.key);
                 expect(utilsService.selectNavOption).toHaveBeenCalledWith(
-                    states.EVENTS,
+                    states.INST_EVENTS,
                     {
                         institutionKey: first_institution.key,
                     }

--- a/frontend/test/specs/institution/institutionControllerSpec.js
+++ b/frontend/test/specs/institution/institutionControllerSpec.js
@@ -255,9 +255,11 @@
                 expect(institutionService.update).toHaveBeenCalled();
             });
         });
+
         describe('goToEvents', function() {
-            it('should call state.go with the right params', function(){
+            it('should call state.go with the INST_EVENTS on desktop', function(){
                 spyOn(utilsService, 'selectNavOption');
+                spyOn(Utils, 'isMobileScreen').and.returnValue(false);
                 institutionCtrl.goToEvents(first_institution.key);
                 expect(utilsService.selectNavOption).toHaveBeenCalledWith(
                     states.INST_EVENTS,
@@ -266,7 +268,20 @@
                     }
                 );
             });
+
+            it('should call state.go with the EVENTS on mobile', function(){
+                spyOn(utilsService, 'selectNavOption');
+                spyOn(Utils, 'isMobileScreen').and.returnValue(true);
+                institutionCtrl.goToEvents(first_institution.key);
+                expect(utilsService.selectNavOption).toHaveBeenCalledWith(
+                    states.EVENTS,
+                    {
+                        institutionKey: first_institution.key,
+                    }
+                );
+            });
         });
+
         describe('goToLinks()', function() {
             it('should call state.go', function() {
                 spyOn(state, 'go');


### PR DESCRIPTION
**Feature/Bug description:** Spec is failing on:
```
Expected spy selectNavOption to have been called with [ 'app.user.events', Object({ institutionKey: '987654321' }) ] but actual calls were [ 'app.institution.events', Object({ institutionKey: '987654321' }) ].
            at UserContext.<anonymous> (specs/institution/institutionControllerSpec.js:262:54)
```

**Solution:** Add two specs, one for mobile and another for desktop screen

**TODO/FIXME:** n/a