### PR TITLE
Hide success cases' showtoast in mobile devices

### DIFF
--- a/frontend/utils/messageService.js
+++ b/frontend/utils/messageService.js
@@ -3,7 +3,7 @@
 (function() {
     var app = angular.module("app");
 
-    app.service("MessageService", function MessageService($mdToast, $mdDialog) {
+    app.service("MessageService", function MessageService($mdToast, $mdDialog, SCREEN_SIZES) {
         var service = this;
 
         var msg = {

--- a/frontend/utils/messageService.js
+++ b/frontend/utils/messageService.js
@@ -44,16 +44,22 @@
         };
 
         service.showToast = function showToast(message) {
-            message = customMessage(message);
-            $mdToast.show(
-                $mdToast.simple()
-                    .textContent(message)
-                    .action('FECHAR')
-                    .highlightAction(true)
-                    .hideDelay(5000)
-                    .position('bottom right')
-            );
+            if(! hideToast(message)) {
+              message = customMessage(message);
+              $mdToast.show(
+                  $mdToast.simple()
+                      .textContent(message)
+                      .action('FECHAR')
+                      .highlightAction(true)
+                      .hideDelay(5000)
+                      .position('bottom right')
+              );
+            }
         };
+
+        function hideToast (message) {
+          return Utils.isMobileScreen(SCREEN_SIZES.SMARTPHONE) && message.includes('sucesso');
+        }
 
         function customMessage(message) {
             return (message && msg[message.code]) || msg[message] || message;


### PR DESCRIPTION
**Feature/Bug description:**
Its not friendly to show a message in the mobile devices every time something works.

**Solution:** Hide showtoast in some cases.

**TODO/FIXME:** n/a