### PR TITLE
Fix duplicated institutions on institutions page

### DIFF
--- a/frontend/institution/allInstitutionsController.js
+++ b/frontend/institution/allInstitutionsController.js
@@ -29,7 +29,7 @@
                 possibleTabs.includes(nextTab) ? nextTab : allInstitutionsCtrl.currentTab);
 
                 currentPage = 0;
-                loadInstitutions();
+                return loadInstitutions();
             }
         };
 

--- a/frontend/institution/allInstitutionsController.js
+++ b/frontend/institution/allInstitutionsController.js
@@ -24,11 +24,13 @@
          * {string} nextTab
          */
         allInstitutionsCtrl.changeTab = function changeTab(nextTab) {
-            allInstitutionsCtrl.currentTab = (
-              possibleTabs.includes(nextTab) ? nextTab : allInstitutionsCtrl.currentTab);
-            
-            currentPage = 0;
-            loadInstitutions();
+            if (nextTab !== allInstitutionsCtrl.currentTab) {
+                allInstitutionsCtrl.currentTab = (
+                possibleTabs.includes(nextTab) ? nextTab : allInstitutionsCtrl.currentTab);
+
+                currentPage = 0;
+                loadInstitutions();
+            }
         };
 
         /**


### PR DESCRIPTION
**Feature/Bug description:** Double-clicking one of the tabs on the institution page will double the institutions.
Fixes #1487 

**Solution:** Add a check if the clicked tab is the current tab.

**TODO/FIXME:** n/a