### PR TITLE
Fix hide top toolbar when scroll 

### DIFF
--- a/frontend/utils/hideNavbar.js
+++ b/frontend/utils/hideNavbar.js
@@ -72,7 +72,7 @@
 
                     if(Utils.isMobileScreen(SCREEN_SIZES.SMARTPHONE)){
                         const content = element[0];
-                        const limitScrol =  30;
+                        const limitScrol =  50;
     
                         const hideTopDynamically = hideTop && inStateArray(scope.STATES_DINAMICALLY_TOP);
                         const hideBottomDynamically = hideBottom && inStateArray(scope.STATES_DINAMICALLY_BOTTOM);


### PR DESCRIPTION
**Feature/Bug description:** Bug to show and hide top bar caused by wrong calculation.

**Solution:** Changed limit to apply to hide dynamically top toolbar to 50.

**TODO/FIXME:** n/a