### PR TITLE
Fix sidemenu shadow on events and event pages

### DIFF
--- a/frontend/styles/custom.css
+++ b/frontend/styles/custom.css
@@ -1195,3 +1195,7 @@ md-input-container:not(.md-input-invalid).md-input-focused .green-input,
     max-height: 100%;
     overflow-y: auto;
 }
+
+side-menu {
+  z-index: 10;
+}


### PR DESCRIPTION
**Feature/Bug description:** #1435 

Event page:
<img width="800" alt="Captura de Tela 2019-03-15 às 10 03 14" src="https://user-images.githubusercontent.com/39133539/54433127-dd9f6780-4709-11e9-94b2-e74b77cc557a.png">

Events:
<img width="800" alt="Captura de Tela 2019-03-15 às 10 03 02" src="https://user-images.githubusercontent.com/39133539/54433129-e09a5800-4709-11e9-82a5-2678d2b9a920.png">


**Solution:** Fix #1435: Add z-index to sidemenu

<img width="800" alt="Captura de Tela 2019-03-15 às 10 03 22" src="https://user-images.githubusercontent.com/39133539/54433193-045d9e00-470a-11e9-8663-6d3f4287d4a0.png">

<img width="800" alt="Captura de Tela 2019-03-15 às 10 02 48" src="https://user-images.githubusercontent.com/39133539/54433190-01fb4400-470a-11e9-9581-b7b40918dcce.png">


**TODO/FIXME:** n/a