### PR TITLE
Fix institution cover stretching on mobile

### DIFF
--- a/frontend/institution/registered_institution.css
+++ b/frontend/institution/registered_institution.css
@@ -20,7 +20,7 @@
 
 .registered-institution-cover div img {
     height: 5.5em;
-    width: 100%;
+    justify-self: center;
 }
 
 #registered-institution-img {

--- a/frontend/institution/registered_institution.css
+++ b/frontend/institution/registered_institution.css
@@ -36,6 +36,7 @@
     height: 3em;
     width: 3em;
     border-radius: 50%;
+    background: white;
 }
 
 .registered-institution-content {


### PR DESCRIPTION
**Feature/Bug description:** #1462
<img width="153" alt="Captura de Tela 2019-03-15 às 11 20 00" src="https://user-images.githubusercontent.com/39133539/54437850-4d1a5480-4714-11e9-9db3-3f9087449dc8.png">

**Solution:** 
* Remove hard set width on img. Fixes #1462
* Add white background to institutions profile image. Fixes institutions who had pictures with transparent background blending with cover picture

<img width="149" alt="Captura de Tela 2019-03-15 às 11 19 32" src="https://user-images.githubusercontent.com/39133539/54437864-53103580-4714-11e9-9540-fc2628a2f565.png">


**TODO/FIXME:** n/a